### PR TITLE
Fix nbviewer workflow

### DIFF
--- a/.github/workflows/nbviewer.yml
+++ b/.github/workflows/nbviewer.yml
@@ -20,6 +20,7 @@ jobs:
       - name: get files
         id: files
         uses: jitterbit/get-changed-files@v1
+        continue-on-error: true
 
       - name: add comments
         uses: actions/github-script@v3


### PR DESCRIPTION
See jitterbit/get-changed-files#11 for context. 

Here's a failed run for a PR: https://github.com/cal-itp/data-analyses/runs/4371698104?check_suite_focus=true

When commits are pushed, then later squashed and re-pushed, the action can fail. Workaround is to continue on error, since the list of files changed is still correct.