### PR TITLE
Board workflows + new team member template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -1,0 +1,37 @@
+---
+name: New Team Member
+about: Kick off the onboarding process.
+title: New Team Member - [Name]
+labels: 'new team member'
+assignees: charlie-costanzo
+
+---
+Name:
+Role:
+Reports to:
+
+Google Workspace Email Address:  
+GitHub Username:  
+Slack Username:
+
+**Set-up:**
+- [ ] Technical Onboarding call scheduled
+
+- [ ] Added to tools:
+  - [ ] Github
+    - [ ] Organization: Cal-ITP
+    - [ ] Team: jarvus
+    - [ ] Team: warehouse-users
+  - [ ] JupyterLab
+  - [ ] Google Cloud Console
+  - [ ] Metabase
+  - [ ] Slack
+
+- [ ] Added to meetings:
+  - [ ] Daily Stand-ups
+  - [ ] Lunch n' Learn
+
+- [ ] Added to Slack channels:
+  - [ ] #data-analyses
+  - [ ] #data-office-hours
+  - [ ] #lunch-n-learn

--- a/.github/workflows/board-move-issues.yml
+++ b/.github/workflows/board-move-issues.yml
@@ -1,0 +1,27 @@
+name: Board wrangling
+
+on:
+  issues:
+    types: [labeled, opened]
+  pull_request:
+
+jobs:
+  github-actions-automate-projects:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: add-new-issues-to-repository-based-project-column
+      uses: takanabe/github-actions-automate-projects@v0.0.2
+      if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'analytics research'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PROJECT_URL: https://github.com/cal-itp/data-analyses/projects/1
+        GITHUB_PROJECT_COLUMN_NAME: Backlog
+
+    - name: add-new-issues-to-repository-based-project-column
+      uses: takanabe/github-actions-automate-projects@v0.0.2
+      if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'new team member'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PROJECT_URL: https://github.com/cal-itp/data-analyses/projects/1
+        GITHUB_PROJECT_COLUMN_NAME: Backlog


### PR DESCRIPTION
This PR migrates over the features that were being used in the `data-infra` repo to track analysts work, so that it will now live in the `data-analyses` repo which makes more logical sense and convenience.

Files added:
`.github/ISSUE_TEMPLATE/new-team-member.md`
* Creates template issue for use in tracking the onboarding of new team members

`.github/workflows/board-move-issues.yml`
* Added the github workflows in the data-infra repo related to automating the project board