### PR TITLE
make portfolio index deployable in prod

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -2,7 +2,7 @@ name: Update and deploy portfolio index site
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - '.github/workflows/update-portfolio-index.yml'
       - 'portfolio/**'

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          const suffix = "--cal-itp-previews.netlify.app"
+          const suffix = "--cal-itp-data-analyses.netlify.app"
           github.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -1,6 +1,11 @@
 name: Update and deploy portfolio index site
 
 on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/update-portfolio-index.yml'
+      - 'portfolio/**'
   pull_request:
     paths:
       - '.github/workflows/update-portfolio-index.yml'
@@ -31,9 +36,16 @@ jobs:
         npm install -g netlify-cli
         python portfolio/portfolio.py index --deploy --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER}
       env:
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PREVIEW_APP_SITE_ID }}
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_APP_AUTH_TOKEN }}
         PR_NUMBER: ${{ github.event.number }}
+
+    - name: Netlify docs production
+      if: ${{ github.ref == 'refs/heads/main' }}
+      run: |
+        npm install -g netlify-cli
+        python portfolio/portfolio.py index --deploy
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_APP_AUTH_TOKEN }}
 
     - name: Add netlify link PR comment
       uses: actions/github-script@v3

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -43,7 +43,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
         npm install -g netlify-cli
-        python portfolio/portfolio.py index --deploy
+        python portfolio/portfolio.py index --deploy --prod
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_APP_AUTH_TOKEN }}
 

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -152,6 +152,7 @@ def index(
     config=CONFIG_OPTION,
     deploy: bool = DEPLOY_OPTION,
     alias: str = None,
+    prod: bool = False,
 ) -> None:
     with open(config) as f:
         portfolio_config = PortfolioConfig(**yaml.safe_load(f))
@@ -172,6 +173,9 @@ def index(
 
     if alias:
         args.append(f"--alias={alias}")
+
+    if prod:
+        args.append("--prod")
 
     if deploy:
         typer.secho(f"deploying with args {args}", fg=typer.colors.GREEN)


### PR DESCRIPTION
Currently, the portfolio index is only built on PRs to a preview URL, for example https://data-analyses-189--cal-itp-data-analyses.netlify.app. This PR adds a workflow case to run on `main` and deploy to the actual production index site, cal-itp-data-analyses.netlify.app.