### PR TITLE
Where is Metrolink (323)?

### DIFF
--- a/traffic_ops/missing-metrolink.ipynb
+++ b/traffic_ops/missing-metrolink.ipynb
@@ -1,0 +1,877 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fdcdf3f1-2c34-4749-9496-5e1a1f6e0692",
+   "metadata": {},
+   "source": [
+    "# Check why Metrolink (ITP ID: 323) is missing from routes shapefile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "305dcabe-9ce3-4ac9-b23b-d7b0766bfcd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.10/site-packages/geopandas/_compat.py:111: UserWarning: The Shapely GEOS version (3.10.2-CAPI-1.16.0) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "\n",
+    "from calitp.tables import tbl\n",
+    "from calitp import query_sql\n",
+    "from siuba import *\n",
+    "\n",
+    "from shared_utils import utils\n",
+    "import prep_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7b6fe3f-c452-4124-8779-1deafd6491f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#utils.download_geoparquet(prep_data.GCS_FILE_PATH, \n",
+    "#                          \"ca_transit_routes\", save_locally=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdec91c4-6916-4caf-9d8f-66576b9cb6ca",
+   "metadata": {},
+   "source": [
+    "ITP ID 323 is missing in the `ca_transit_routes.parquet`.\n",
+    "\n",
+    "## Initial queries\n",
+    "* Check that 323 shows up there -- it does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "255eb6b9-7c98-463e-9cef-1adefd2f054e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SELECTED_DATE = \"2022-06-21\"\n",
+    "#prep_data.create_local_parquets(prep_data.SELECTED_DATE) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "678b992f-7404-42a3-9ed2-0262e63639af",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'File: agencies'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>agency_id</th>\n",
+       "      <th>agency_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>156</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Metrolink</td>\n",
+       "      <td>Metrolink Trains</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  agency_id       agency_name\n",
+       "156            323  Metrolink  Metrolink Trains"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'File: latest_itp_id'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>77</th>\n",
+       "      <td>323</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    calitp_itp_id\n",
+       "77            323"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'File: route_info'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>route_short_name</th>\n",
+       "      <th>route_long_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>540</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Antelope Valley Line</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Metrolink Antelope Valley Line</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>595</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Orange County Line</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Metrolink Orange County Line</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>685</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Ventura County Line</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Metrolink Ventura County Line</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1509</th>\n",
+       "      <td>323</td>\n",
+       "      <td>LAX FlyAway Bus</td>\n",
+       "      <td>None</td>\n",
+       "      <td>LAX FlyAway Bus</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1867</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Inland Emp.-Orange Co. Line</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Metrolink Inland Empire-Orange County Line</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      calitp_itp_id                     route_id route_short_name  \\\n",
+       "540             323         Antelope Valley Line             None   \n",
+       "595             323           Orange County Line             None   \n",
+       "685             323          Ventura County Line             None   \n",
+       "1509            323              LAX FlyAway Bus             None   \n",
+       "1867            323  Inland Emp.-Orange Co. Line             None   \n",
+       "\n",
+       "                                 route_long_name  \n",
+       "540               Metrolink Antelope Valley Line  \n",
+       "595                 Metrolink Orange County Line  \n",
+       "685                Metrolink Ventura County Line  \n",
+       "1509                             LAX FlyAway Bus  \n",
+       "1867  Metrolink Inland Empire-Orange County Line  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'File: stops'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>stop_id</th>\n",
+       "      <th>stop_lat</th>\n",
+       "      <th>stop_lon</th>\n",
+       "      <th>stop_name</th>\n",
+       "      <th>stop_code</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>51051</th>\n",
+       "      <td>323</td>\n",
+       "      <td>109</td>\n",
+       "      <td>34.093639</td>\n",
+       "      <td>-117.753052</td>\n",
+       "      <td>Pomona (North) Metrolink Station</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51052</th>\n",
+       "      <td>323</td>\n",
+       "      <td>113</td>\n",
+       "      <td>34.211559</td>\n",
+       "      <td>-118.448219</td>\n",
+       "      <td>Van Nuys Metrolink Station</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51053</th>\n",
+       "      <td>323</td>\n",
+       "      <td>165</td>\n",
+       "      <td>34.497860</td>\n",
+       "      <td>-118.118301</td>\n",
+       "      <td>Vincent Grade/Acton Metrolink Station</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51054</th>\n",
+       "      <td>323</td>\n",
+       "      <td>103</td>\n",
+       "      <td>34.253197</td>\n",
+       "      <td>-118.599411</td>\n",
+       "      <td>Chatsworth Metrolink Station</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51055</th>\n",
+       "      <td>323</td>\n",
+       "      <td>101</td>\n",
+       "      <td>34.086426</td>\n",
+       "      <td>-117.957397</td>\n",
+       "      <td>Baldwin Park Metrolink Station</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       calitp_itp_id stop_id   stop_lat    stop_lon  \\\n",
+       "51051            323     109  34.093639 -117.753052   \n",
+       "51052            323     113  34.211559 -118.448219   \n",
+       "51053            323     165  34.497860 -118.118301   \n",
+       "51054            323     103  34.253197 -118.599411   \n",
+       "51055            323     101  34.086426 -117.957397   \n",
+       "\n",
+       "                                   stop_name stop_code  \n",
+       "51051       Pomona (North) Metrolink Station      None  \n",
+       "51052             Van Nuys Metrolink Station      None  \n",
+       "51053  Vincent Grade/Acton Metrolink Station      None  \n",
+       "51054           Chatsworth Metrolink Station      None  \n",
+       "51055         Baldwin Park Metrolink Station      None  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'File: trips'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>shape_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>323</td>\n",
+       "      <td>San Bernardino Line</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>618</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Inland Emp.-Orange Co. Line</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1585</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Riverside Line</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1755</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Antelope Valley Line</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3149</th>\n",
+       "      <td>323</td>\n",
+       "      <td>Ventura County Line</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      calitp_itp_id                     route_id shape_id\n",
+       "21              323          San Bernardino Line     None\n",
+       "618             323  Inland Emp.-Orange Co. Line     None\n",
+       "1585            323               Riverside Line     None\n",
+       "1755            323         Antelope Valley Line     None\n",
+       "3149            323          Ventura County Line     None"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'File: routes'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>shape_id</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>11065</th>\n",
+       "      <td>323</td>\n",
+       "      <td>91in</td>\n",
+       "      <td>LINESTRING (-117.20562 33.76391, -117.20830 33...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11066</th>\n",
+       "      <td>323</td>\n",
+       "      <td>91out</td>\n",
+       "      <td>LINESTRING (-118.23377 34.05600, -118.23343 34...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11067</th>\n",
+       "      <td>323</td>\n",
+       "      <td>AVin</td>\n",
+       "      <td>LINESTRING (-118.13613 34.69658, -118.11499 34...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11068</th>\n",
+       "      <td>323</td>\n",
+       "      <td>AVout</td>\n",
+       "      <td>LINESTRING (-118.23482 34.05420, -118.23229 34...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11069</th>\n",
+       "      <td>323</td>\n",
+       "      <td>IEOCin</td>\n",
+       "      <td>LINESTRING (-117.37573 33.18759, -117.38783 33...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       calitp_itp_id shape_id  \\\n",
+       "11065            323     91in   \n",
+       "11066            323    91out   \n",
+       "11067            323     AVin   \n",
+       "11068            323    AVout   \n",
+       "11069            323   IEOCin   \n",
+       "\n",
+       "                                                geometry  \n",
+       "11065  LINESTRING (-117.20562 33.76391, -117.20830 33...  \n",
+       "11066  LINESTRING (-118.23377 34.05600, -118.23343 34...  \n",
+       "11067  LINESTRING (-118.13613 34.69658, -118.11499 34...  \n",
+       "11068  LINESTRING (-118.23482 34.05420, -118.23229 34...  \n",
+       "11069  LINESTRING (-117.37573 33.18759, -117.38783 33...  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "files = [\"agencies\", \"latest_itp_id\", \"route_info\", \n",
+    "         \"stops\", \"trips\", \"routes\"\n",
+    "        ]\n",
+    "\n",
+    "check_itp_id = 323\n",
+    "\n",
+    "def check_file_for_itp_id(file, itp_id):\n",
+    "    filename = f\"./data/{file}.parquet\"\n",
+    "    \n",
+    "    if file==\"routes\":\n",
+    "        df = gpd.read_parquet(filename)\n",
+    "    else:\n",
+    "        df = pd.read_parquet(filename)\n",
+    "    \n",
+    "    subset = df[df.calitp_itp_id==itp_id]\n",
+    "    display(f\"File: {file}\")\n",
+    "    display(subset.head())\n",
+    "    \n",
+    "for f in files:\n",
+    "    check_file_for_itp_id(f, check_itp_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9a9c5be-7777-44ec-a401-47d17a5c9fe3",
+   "metadata": {},
+   "source": [
+    "## Trips query\n",
+    "\n",
+    "Go look at original query for `trips` without getting rid of any columns. Just in case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "49c986b0-a0c5-4ff9-9db7-812b49d56a2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><pre># Source: lazy query\n",
+       "# DB Conn: Engine(bigquery://cal-itp-data-infra/?maximum_bytes_billed=5000000000)\n",
+       "# Preview:\n",
+       "</pre><div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>service_id</th>\n",
+       "      <th>trip_id</th>\n",
+       "      <th>shape_id</th>\n",
+       "      <th>trip_headsign</th>\n",
+       "      <th>trip_short_name</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>block_id</th>\n",
+       "      <th>wheelchair_accessible</th>\n",
+       "      <th>bikes_allowed</th>\n",
+       "      <th>calitp_extracted_at</th>\n",
+       "      <th>calitp_hash</th>\n",
+       "      <th>trip_key</th>\n",
+       "      <th>calitp_deleted_at</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>323</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Orange County Line</td>\n",
+       "      <td>1152</td>\n",
+       "      <td>296800433</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Oceanside</td>\n",
+       "      <td>668</td>\n",
+       "      <td>0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>2021-10-28</td>\n",
+       "      <td>KJ11lcHqmnqB3TJNnE4YPw==</td>\n",
+       "      <td>4426110514318030117</td>\n",
+       "      <td>2099-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>323</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Antelope Valley Line</td>\n",
+       "      <td>1142</td>\n",
+       "      <td>200090225</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Lancaster</td>\n",
+       "      <td>225</td>\n",
+       "      <td>0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>2022-04-05</td>\n",
+       "      <td>l3cqZlOUX9SjGAI/zer8QQ==</td>\n",
+       "      <td>-1412446666788434424</td>\n",
+       "      <td>2099-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>323</td>\n",
+       "      <td>0</td>\n",
+       "      <td>91 Line</td>\n",
+       "      <td>1150</td>\n",
+       "      <td>200090709</td>\n",
+       "      <td>None</td>\n",
+       "      <td>L.A. Union Station</td>\n",
+       "      <td>709</td>\n",
+       "      <td>1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>2022-04-05</td>\n",
+       "      <td>DJArUXzOYpRArfGDLozZSg==</td>\n",
+       "      <td>-154331551297351104</td>\n",
+       "      <td>2099-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>323</td>\n",
+       "      <td>0</td>\n",
+       "      <td>San Bernardino Line</td>\n",
+       "      <td>1146</td>\n",
+       "      <td>200090308</td>\n",
+       "      <td>None</td>\n",
+       "      <td>San Bernardino - Downtown</td>\n",
+       "      <td>308</td>\n",
+       "      <td>0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>2022-04-05</td>\n",
+       "      <td>xxLjiiA5uuNrNTSVvo1eYg==</td>\n",
+       "      <td>-5084664679889279126</td>\n",
+       "      <td>2099-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>323</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Ventura County Line</td>\n",
+       "      <td>1141</td>\n",
+       "      <td>294200148</td>\n",
+       "      <td>None</td>\n",
+       "      <td>L.A. Union Station</td>\n",
+       "      <td>148</td>\n",
+       "      <td>1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>2022-04-05</td>\n",
+       "      <td>yt5KJTODnuJDQs9ZOdu+0g==</td>\n",
+       "      <td>4873550634793634261</td>\n",
+       "      <td>2099-01-01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div><p># .. may have more rows</p></div>"
+      ],
+      "text/plain": [
+       "# Source: lazy query\n",
+       "# DB Conn: Engine(bigquery://cal-itp-data-infra/?maximum_bytes_billed=5000000000)\n",
+       "# Preview:\n",
+       "   calitp_itp_id  calitp_url_number              route_id service_id  \\\n",
+       "0            323                  0    Orange County Line       1152   \n",
+       "1            323                  0  Antelope Valley Line       1142   \n",
+       "2            323                  0               91 Line       1150   \n",
+       "3            323                  0   San Bernardino Line       1146   \n",
+       "4            323                  0   Ventura County Line       1141   \n",
+       "\n",
+       "     trip_id shape_id              trip_headsign trip_short_name direction_id  \\\n",
+       "0  296800433     None                  Oceanside             668            0   \n",
+       "1  200090225     None                  Lancaster             225            0   \n",
+       "2  200090709     None         L.A. Union Station             709            1   \n",
+       "3  200090308     None  San Bernardino - Downtown             308            0   \n",
+       "4  294200148     None         L.A. Union Station             148            1   \n",
+       "\n",
+       "  block_id wheelchair_accessible bikes_allowed calitp_extracted_at  \\\n",
+       "0     None                  None          None          2021-10-28   \n",
+       "1     None                  None          None          2022-04-05   \n",
+       "2     None                  None          None          2022-04-05   \n",
+       "3     None                  None          None          2022-04-05   \n",
+       "4     None                  None          None          2022-04-05   \n",
+       "\n",
+       "                calitp_hash             trip_key calitp_deleted_at  \n",
+       "0  KJ11lcHqmnqB3TJNnE4YPw==  4426110514318030117        2099-01-01  \n",
+       "1  l3cqZlOUX9SjGAI/zer8QQ== -1412446666788434424        2099-01-01  \n",
+       "2  DJArUXzOYpRArfGDLozZSg==  -154331551297351104        2099-01-01  \n",
+       "3  xxLjiiA5uuNrNTSVvo1eYg== -5084664679889279126        2099-01-01  \n",
+       "4  yt5KJTODnuJDQs9ZOdu+0g==  4873550634793634261        2099-01-01  \n",
+       "# .. may have more rows"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Trips query\n",
+    "dim_trips = (tbl.views.gtfs_schedule_dim_trips()\n",
+    "            #>> filter(_.calitp_itp_id != 200, _.calitp_itp_id != 0)\n",
+    "             #>> select(*trip_cols, _.trip_key)\n",
+    "             >> filter(_.calitp_itp_id==check_itp_id)\n",
+    "             >> distinct()\n",
+    "            )\n",
+    "\n",
+    "dim_trips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e7e30fda-4576-439a-9ce1-8b6ae8e91534",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Series([], Name: shape_id, dtype: int64)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(dim_trips >> collect()).shape_id.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "05aa256d-5bf8-4f2c-9b18-36d89a13ac82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trips = (tbl.views.gtfs_schedule_fact_daily_trips()\n",
+    "         >> filter(_.service_date == SELECTED_DATE, \n",
+    "                   _.is_in_service==True)\n",
+    "         >> select(_.trip_key, _.service_date)\n",
+    "         >> inner_join(_, dim_trips, on = \"trip_key\")\n",
+    "         #>> select(*trip_cols)\n",
+    "         >> distinct()\n",
+    "         >> collect()\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "77f3018b-f8c6-412c-a6c5-1d253168eebf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Series([], Name: shape_id, dtype: int64)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trips.shape_id.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e78397b-dfcc-43b0-9471-753020d69565",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Debug why Metrolink (ITP ID: 323) is missing from `ca_transit_routes`. Merges are working as expected, but maybe this is not what we intend?

Dig into [warehouse queries](https://github.com/cal-itp/data-analyses/blob/main/traffic_ops/prep_data.py#L55-L69) for trips to see what's happening with `shape_id`