### PR TITLE
High level stat: GTFS sched and RT operators year to year

### DIFF
--- a/gtfs_orgs/operators-gtfs-sched-rt.ipynb
+++ b/gtfs_orgs/operators-gtfs-sched-rt.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "54d7c5a7-d698-4bee-8fde-a5c62e4b5ded",
+   "metadata": {},
+   "source": [
+    "# GTFS Schedule and RT compliant operators\n",
+    "\n",
+    "High-level metric to see how many ITP IDs we track year to year with GTFS schedule and RT data\n",
+    "\n",
+    "* [Slack request](https://cal-itp.slack.com/archives/C014Q6G3VCJ/p1657141675073339)\n",
+    "* GTFS Schedule fact daily feeds: https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily\n",
+    "    * this is pre-aggregated, let's just grab distinct ITP IDs from here\n",
+    "* GTFS RT fact files: https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_fact_daily_feeds\n",
+    "    * model this after how GTFS schedule does it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "60c34ea5-0e77-4f63-8c2a-a0ef1b30f418",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.10/site-packages/geopandas/_compat.py:111: UserWarning: The Shapely GEOS version (3.10.2-CAPI-1.16.0) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "\n",
+    "from calitp.tables import tbl\n",
+    "from siuba import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "70c563bd-5993-441d-b74b-b63754a4eace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gtfs_sched_operators = (\n",
+    "    tbl.views.gtfs_schedule_fact_daily()\n",
+    "    >> select(_.date, _.n_distinct_itp_ids)\n",
+    "    >> collect()\n",
+    ")\n",
+    "\n",
+    "gtfs_rt_operators = (\n",
+    "    tbl.views.gtfs_rt_fact_daily_feeds()\n",
+    "    >> select(_.calitp_itp_id, _.date)\n",
+    "    >> distinct()\n",
+    "    >> group_by(_.date)\n",
+    "    >> summarize(n_distinct_itp_ids = _.calitp_itp_id.nunique())\n",
+    "    >> collect()  \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "89bc4015-881b-4c7d-8c4e-b5d1dc64a6fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def parse_date(df):\n",
+    "    df = df.assign(\n",
+    "        date = pd.to_datetime(df.date)\n",
+    "    ).sort_values(\"date\").reset_index(drop=True)\n",
+    "    \n",
+    "    return df\n",
+    "\n",
+    "def select_start_end(df, start, end):\n",
+    "    df2 = parse_date(df)\n",
+    "    \n",
+    "    df3 = df2[(df2.date==start) | \n",
+    "              (df2.date==end)].reset_index(drop=True)\n",
+    "    \n",
+    "    return df3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "945e61c8-2181-44ff-9905-8b43756be43a",
+   "metadata": {},
+   "source": [
+    "## GTFS Schedule - unique ITP IDs year to year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8833bace-1229-4aec-8cb3-69a13cd4e650",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>n_distinct_itp_ids</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2021-07-01</td>\n",
+       "      <td>181</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-06-30</td>\n",
+       "      <td>195</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date  n_distinct_itp_ids\n",
+       "0 2021-07-01                 181\n",
+       "1 2022-06-30                 195"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "start_date = \"2021-07-01\"\n",
+    "end_date = \"2022-06-30\"\n",
+    "\n",
+    "gtfs_sched = select_start_end(gtfs_sched_operators, start_date, end_date)\n",
+    "gtfs_sched"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1769281-5dd9-4ce8-b772-a8a5f47e5527",
+   "metadata": {},
+   "source": [
+    "## GTFS RT - unique ITP IDs year to year\n",
+    "\n",
+    "* Earliest RT is 7/7/21 (pretty close to 7/1/21!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "912ad337-fbe1-4b44-99ab-09aa7acf946e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>n_distinct_itp_ids</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2021-07-07</td>\n",
+       "      <td>29</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-06-30</td>\n",
+       "      <td>79</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date  n_distinct_itp_ids\n",
+       "0 2021-07-07                  29\n",
+       "1 2022-06-30                  79"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "earliest_rt = pd.to_datetime(gtfs_rt_operators.date.min())\n",
+    "\n",
+    "gtfs_rt = select_start_end(gtfs_rt_operators, earliest_rt, end_date)\n",
+    "gtfs_rt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3977ef63-fe57-4d24-a05c-c792c5e6d065",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Unique operators (ITP IDs) we are tracking year to year for high level stat Gillian inputs. [Slack request](https://cal-itp.slack.com/archives/C014Q6G3VCJ/p1657141675073339)

How many unique ITP IDs have GTFS schedule data, how many have GTFS RT.