### PR TITLE
(utils): more flexible geoparquet to gcs, add rt_utils

### DIFF
--- a/_shared_utils/shared_utils/__init__.py
+++ b/_shared_utils/shared_utils/__init__.py
@@ -4,11 +4,13 @@ from . import (
     geography_utils,
     map_utils,
     portfolio_utils,
+    rt_filter_map_plot,
+    rt_utils,
     styleguide,
     utils,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "utils",
@@ -18,4 +20,6 @@ __all__ = [
     "calitp_color_palette",
     "styleguide",
     "portfolio_utils",
+    "rt_utils",
+    "rt_filter_map_plot",
 ]

--- a/_shared_utils/shared_utils/rt_filter_map_plot.py
+++ b/_shared_utils/shared_utils/rt_filter_map_plot.py
@@ -463,7 +463,7 @@ class RtFilterMapper:
         assert (
             self.filter["shape_ids"] and len(self.filter["shape_ids"]) == 1
         ), "must filter to a single shape_id"
-        _map = self.segment_speed_map()
+        # _map = self.segment_speed_map()
         to_chart = self.stop_segment_speed_view.copy()
         if num_segments:
             unique_stops = list(self.stop_segment_speed_view.stop_sequence.unique())[

--- a/_shared_utils/shared_utils/rt_filter_map_plot.py
+++ b/_shared_utils/shared_utils/rt_filter_map_plot.py
@@ -548,7 +548,7 @@ class RtFilterMapper:
             period_formatted = self.filter_period.replace("_", " ")
             # display(slowest)
             display(Markdown(f"{period_formatted} slowest routes: {with_newlines}"))
-        except:
+        except Exception:
             # print('describe slow routes failed!')
             pass
         return

--- a/_shared_utils/shared_utils/rt_filter_map_plot.py
+++ b/_shared_utils/shared_utils/rt_filter_map_plot.py
@@ -1,0 +1,574 @@
+import datetime as dt
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import pandas as pd
+
+# import rt_utils
+import seaborn as sns
+import shapely
+
+# import shared_utils
+from IPython.display import Markdown, display
+from shared_utils import calitp_color_palette as cp
+from shared_utils import geography_utils, map_utils, rt_utils, utils
+from siuba import *
+
+# from tqdm import tqdm
+
+GCS_FILE_PATH = rt_utils.GCS_FILE_PATH
+
+
+class RtFilterMapper:
+    """
+    Collects filtering and mapping functions, init with stop segment speed view and rt_trips
+    """
+
+    def __init__(self, rt_trips, stop_delay_view, routelines, pbar=None):
+        self.pbar = pbar
+        self.rt_trips = rt_trips
+        self.calitp_itp_id = self.rt_trips.calitp_itp_id.iloc[0]
+        self.stop_delay_view = stop_delay_view
+        self.routelines = routelines
+        self.calitp_agency_name = rt_trips.calitp_agency_name.iloc[0]
+        self.analysis_date = rt_trips.service_date.iloc[0]
+        self.display_date = self.analysis_date.strftime(rt_utils.DATE_WEEKDAY_FMT)
+
+        self.endpoint_delay_view = (
+            self.stop_delay_view
+            >> group_by(_.trip_id)
+            >> filter(_.stop_sequence == _.stop_sequence.max())
+            >> ungroup()
+            >> mutate(arrival_hour=_.arrival_time.apply(lambda x: x.hour))
+            >> inner_join(
+                _, self.rt_trips >> select(_.trip_id, _.mean_speed_mph), on="trip_id"
+            )
+        )
+        self.endpoint_delay_summary = (
+            self.endpoint_delay_view
+            >> group_by(_.direction_id, _.route_id, _.arrival_hour)
+            >> summarize(
+                n_trips=_.route_id.size, mean_end_delay_seconds=_.delay_seconds.mean()
+            )
+        )
+        self.reset_filter()
+
+    def set_filter(
+        self,
+        start_time=None,
+        end_time=None,
+        route_names=None,
+        shape_ids=None,
+        direction_id=None,
+        direction=None,
+    ):
+        """
+        start_time, end_time: string %H:%M, for example '11:00' and '14:00'
+        route_names: list or pd.Series of route_names (GTFS route_short_name)
+        direction_id: '0' or '1'
+        direction: string 'Northbound', 'Eastbound', 'Southbound', 'Westbound' (experimental)
+        """
+        assert (
+            start_time
+            or end_time
+            or route_names
+            or direction_id
+            or direction
+            or shape_ids
+        ), "must supply at least 1 argument to filter"
+        assert not start_time or isinstance(
+            dt.datetime.strptime(start_time, rt_utils.HOUR_MIN_FMT), dt.datetime
+        ), "invalid time string"
+        assert not end_time or isinstance(
+            dt.datetime.strptime(end_time, rt_utils.HOUR_MIN_FMT), dt.datetime
+        ), "invalid time string"
+        assert not route_names or isinstance(route_names, (list, tuple, pd.Series))
+        if route_names:
+            # print(route_names)
+            # print(type(route_names))
+            assert (
+                pd.Series(route_names).isin(self.rt_trips.route_short_name).all()
+            ), "at least 1 route not found in self.rt_trips"
+        assert (
+            not direction_id or isinstance(direction_id, str) and len(direction_id) == 1
+        )
+        self.filter = {}
+        if start_time:
+            self.filter["start_time"] = dt.datetime.strptime(
+                start_time, rt_utils.HOUR_MIN_FMT
+            ).time()
+        else:
+            self.filter["start_time"] = None
+        if end_time:
+            self.filter["end_time"] = dt.datetime.strptime(
+                end_time, rt_utils.HOUR_MIN_FMT
+            ).time()
+        else:
+            self.filter["end_time"] = None
+        self.filter["route_names"] = route_names
+        self.filter["shape_ids"] = shape_ids
+        if shape_ids:
+            shape_trips = (
+                self.rt_trips
+                >> filter(_.shape_id.isin(shape_ids))
+                >> distinct(_.route_short_name, _keep_all=True)
+                >> collect()
+            )
+            self.filter["route_names"] = list(shape_trips.route_short_name)
+            if len(shape_ids) == 1:
+                direction = (
+                    self.rt_trips >> filter(_.shape_id == shape_ids[0])
+                ).direction.iloc[0]
+        self.filter["direction_id"] = direction_id
+        self.filter["direction"] = direction
+        if start_time and end_time:
+            self.hr_duration_in_filter = (
+                dt.datetime.combine(self.analysis_date, self.filter["end_time"])
+                - dt.datetime.combine(self.analysis_date, self.filter["start_time"])
+            ).seconds / 60**2
+        else:
+            self.hr_duration_in_filter = (
+                self.stop_delay_view.actual_time.max()
+                - self.stop_delay_view.actual_time.min()
+            ).seconds / 60**2
+        if self.filter["route_names"] and len(self.filter["route_names"]) < 5:
+            rts = "Route(s) " + ", ".join(self.filter["route_names"])
+        elif self.filter["route_names"] and len(self.filter["route_names"]) > 5:
+            rts = "Multiple Routes"
+        elif not self.filter["route_names"]:
+            rts = "All Routes"
+
+        # print(self.filter)
+        # properly format for pm peak, TODO add other periods
+        if start_time and end_time and start_time == "15:00" and end_time == "19:00":
+            self.filter_period = "PM_Peak"
+        elif start_time and end_time and start_time == "06:00" and end_time == "09:00":
+            self.filter_period = "AM_Peak"
+        elif start_time and end_time and start_time == "10:00" and end_time == "14:00":
+            self.filter_period = "Midday"
+        elif not start_time and not end_time:
+            self.filter_period = "All_Day"
+        else:
+            self.filter_period = f"{start_time}–{end_time}"
+        elements_ordered = [rts, direction, self.filter_period, self.display_date]
+        self.filter_formatted = ", " + ", ".join(
+            [str(x).replace("_", " ") for x in elements_ordered if x]
+        )
+
+        self._time_only_filter = (
+            not route_names and not shape_ids and not direction_id and not direction
+        )
+
+    def reset_filter(self):
+        self.filter = None
+        self.filter_period = "All_Day"
+        rts = "All Routes"
+        elements_ordered = [rts, self.filter_period, self.display_date]
+        self.filter_formatted = ", " + ", ".join(
+            [str(x).replace("_", " ") for x in elements_ordered if x]
+        )
+
+    def _filter(self, df):
+        """Filters a df (containing trip_id) on trip_id based on any set filter."""
+        if self.filter is None:
+            return df
+        else:
+            trips = self.rt_trips.copy()
+            # print(f'view filter: {self.filter}')
+        if self.filter["start_time"]:
+            trips = trips >> filter(_.median_time > self.filter["start_time"])
+        if self.filter["end_time"]:
+            trips = trips >> filter(_.median_time < self.filter["end_time"])
+        if self.filter["route_names"]:
+            trips = trips >> filter(_.route_short_name.isin(self.filter["route_names"]))
+        if self.filter["shape_ids"]:
+            trips = trips >> filter(_.shape_id.isin(self.filter["shape_ids"]))
+        if self.filter["direction_id"]:
+            trips = trips >> filter(_.direction_id == self.filter["direction_id"])
+        if self.filter["direction"]:
+            trips = trips >> filter(_.direction == self.filter["direction"])
+        return df.copy() >> inner_join(_, trips >> select(_.trip_id), on="trip_id")
+
+    # TODO, optionally port over segment speed map from rt_analysis, would require stop delay view
+    # alternatively, simply export full day segment speed view
+
+    def segment_speed_map(
+        self,
+        segments="stops",
+        how="average",
+        colorscale=rt_utils.ZERO_THIRTY_COLORSCALE,
+        size=[900, 550],
+        no_title=False,
+    ):
+        """Generate a map of segment speeds aggregated across all trips for each shape,
+        either as averages
+        or 20th percentile speeds.
+
+        segments: 'stops' or 'detailed' (detailed not yet implemented)
+        how: 'average' or 'low_speeds'
+        colorscale: branca.colormap
+        size: [x, y]
+
+        """
+        assert segments in ["stops", "detailed"]
+        assert how in ["average", "low_speeds"]
+
+        gcs_filename = (
+            f"{self.calitp_itp_id}_{self.analysis_date.strftime(rt_utils.MONTH_DAY_FMT)}"
+            f"_{self.filter_period}"
+        )
+        subfolder = "segment_speed_views/"
+        cached_periods = ["PM_Peak", "AM_Peak", "Midday", "All_Day"]
+        if (
+            rt_utils.check_cached(f"{gcs_filename}.parquet", subfolder)
+            and self.filter_period in cached_periods
+            and self._time_only_filter
+        ):
+            self.stop_segment_speed_view = gpd.read_parquet(
+                f"{GCS_FILE_PATH}{subfolder}{gcs_filename}.parquet"
+            )
+        else:
+            gdf = self._filter(self.stop_delay_view)
+            all_stop_speeds = gpd.GeoDataFrame()
+            # for shape_id in tqdm(gdf.shape_id.unique()): trying self.pbar.update...
+            if not isinstance(self.pbar, type(None)):
+                self.pbar.reset(total=len(gdf.shape_id.unique()))
+                self.pbar.desc = "Generating segment speeds"
+            for shape_id in gdf.shape_id.unique():
+                this_shape = (gdf >> filter((_.shape_id == shape_id))).copy()
+                if this_shape.empty:
+                    # print(f'{shape_id} empty!')
+                    continue
+                # self.debug_dict[f'{shape_id}_{direction_id}_tsd'] = this_shape_direction
+                stop_speeds = (
+                    this_shape
+                    >> group_by(_.trip_key)
+                    >> arrange(_.stop_sequence)
+                    >> mutate(
+                        seconds_from_last=(
+                            _.actual_time - _.actual_time.shift(1)
+                        ).apply(lambda x: x.seconds)
+                    )
+                    >> mutate(last_loc=_.shape_meters.shift(1))
+                    >> mutate(meters_from_last=(_.shape_meters - _.last_loc))
+                    >> mutate(speed_from_last=_.meters_from_last / _.seconds_from_last)
+                    # >> mutate(last_delay = _.delay.shift(1))
+                    >> mutate(
+                        delay_chg_sec=(_.delay_seconds - _.delay_seconds.shift(1))
+                    )
+                    # >> mutate(delay_sec = _.delay.map(lambda x: x.seconds if x.days == 0 else x.seconds - 24*60**2))
+                    >> ungroup()
+                )
+                if stop_speeds.empty:
+                    # print(f'{shape_id}_{direction_id}_st_spd empty!')
+                    continue
+                # self.debug_dict[f'{shape_id}_{direction_id}_st_spd'] = stop_speeds
+                stop_speeds.geometry = stop_speeds.apply(
+                    lambda x: shapely.ops.substring(
+                        (
+                            self.routelines >> filter(_.shape_id == x.shape_id)
+                        ).geometry.iloc[0],
+                        x.last_loc,
+                        x.shape_meters,
+                    ),
+                    axis=1,
+                )
+                stop_speeds = stop_speeds.dropna(subset=["last_loc"]).set_crs(
+                    geography_utils.CA_NAD83Albers
+                )
+
+                try:
+                    stop_speeds = (
+                        stop_speeds
+                        >> mutate(speed_mph=_.speed_from_last * rt_utils.MPH_PER_MPS)
+                        >> group_by(_.stop_sequence)
+                        >> mutate(
+                            n_trips=_.stop_sequence.size,
+                            avg_mph=_.speed_mph.mean(),
+                            _20p_mph=_.speed_mph.quantile(0.2),
+                            trips_per_hour=_.n_trips / self.hr_duration_in_filter,
+                        )
+                        # >> distinct(_.stop_sequence, _keep_all=True) ## comment out to enable speed distribution analysis
+                        >> ungroup()
+                        >> select(
+                            -_.arrival_time, -_.actual_time, -_.delay, -_.last_delay
+                        )
+                    )
+                    # self.debug_dict[f'{shape_id}_{direction_id}_st_spd2'] = stop_speeds
+                    assert not stop_speeds.empty, "stop speeds gdf is empty!"
+                except Exception:  # as e:
+                    # print(f'stop_speeds shape: {stop_speeds.shape}, shape_id: {shape_id}')
+                    # print(e)
+                    continue
+                # Drop impossibly high speeds
+                stop_speeds = stop_speeds >> filter(_.speed_mph < 80)
+                if stop_speeds.avg_mph.max() > 80:
+                    # print(f'speed above 80 for shape {stop_speeds.shape_id.iloc[0]}, dropping')
+                    stop_speeds = stop_speeds >> filter(_.avg_mph < 80)
+                if stop_speeds._20p_mph.min() < 0:
+                    # print(f'negative speed for shape {stop_speeds.shape_id.iloc[0]}, dropping')
+                    stop_speeds = stop_speeds >> filter(_._20p_mph > 0)
+                all_stop_speeds = pd.concat((all_stop_speeds, stop_speeds))
+
+                if not isinstance(self.pbar, type(None)):
+                    self.pbar.update()
+                if not isinstance(self.pbar, type(None)):
+                    self.pbar.refresh
+            if self._time_only_filter:
+                all_stop_speeds = all_stop_speeds >> select(
+                    -_.speed_mph, -_.speed_from_last, -_.trip_id, -_.trip_key
+                )
+            self.stop_segment_speed_view = all_stop_speeds
+            export_path = f"{GCS_FILE_PATH}segment_speed_views/"
+            if self._time_only_filter:
+                utils.geoparquet_gcs_export(all_stop_speeds, export_path, gcs_filename)
+        return self._show_speed_map(
+            how=how, colorscale=colorscale, size=size, no_title=no_title
+        )
+
+    def _show_speed_map(
+        self,
+        how="average",
+        colorscale=rt_utils.ZERO_THIRTY_COLORSCALE,
+        size=[900, 550],
+        no_title=False,
+    ):
+
+        gdf = self.stop_segment_speed_view.copy()
+        # gdf = self._filter(gdf)
+        # print(gdf.dtypes)
+        # singletrip = gdf.trip_id.nunique() == 1 ## incompatible with current caching approach
+        gdf = gdf >> distinct(
+            _.shape_id, _.stop_sequence, _keep_all=True
+        )  # essential here for reasonable map size!
+        orig_rows = gdf.shape[0]
+        gdf["shape_miles"] = gdf.shape_meters / 1609
+        gdf = gdf.round(
+            {"avg_mph": 1, "_20p_mph": 1, "shape_miles": 1, "trips_per_hour": 1}
+        )  # round for display
+
+        how_speed_col = {"average": "avg_mph", "low_speeds": "_20p_mph"}
+        how_formatted = {"average": "Average", "low_speeds": "20th Percentile"}
+
+        gdf = (
+            gdf
+            >> select(
+                -_.service_date,
+                -_.last_loc,
+                -_.shape_meters,
+                -_.meters_from_last,
+                -_.n_trips,
+            )  # drop unused cols for smaller map size
+            >> arrange(_.trips_per_hour)
+        ).set_crs(geography_utils.CA_NAD83Albers)
+
+        # shift to right side of road to display direction
+        gdf.geometry = gdf.geometry.apply(rt_utils.try_parallel)
+        self.detailed_map_view = gdf.copy()
+        # create clips, integrate buffer+simplify?
+        gdf.geometry = gdf.geometry.apply(rt_utils.arrowize_segment).simplify(
+            tolerance=5
+        )
+        gdf = gdf >> filter(gdf.geometry.is_valid) >> filter(-gdf.geometry.is_empty)
+
+        assert (
+            gdf.shape[0] >= orig_rows * 0.99
+        ), "over 1% of geometries invalid after buffer+simplify"
+        gdf = gdf.to_crs(geography_utils.WGS84)
+        centroid = (gdf.geometry.centroid.x.mean(), gdf.geometry.centroid.y.mean())
+        # centroid = gdf.dissolve().centroid
+        name = self.calitp_agency_name
+
+        popup_dict = {
+            how_speed_col[how]: "Speed (miles per hour)",
+            "route_short_name": "Route",
+            # "shape_id": "Shape ID",
+            # "direction_id": "Direction ID",
+            # "stop_id": "Next Stop ID",
+            # "stop_sequence": "Next Stop Sequence",
+            "trips_per_hour": "Frequency (trips per hour)",
+            "shape_miles": "Distance from start of route (miles)",
+        }
+        # if singletrip:
+        #     popup_dict["delay_seconds"] = "Current Delay (seconds)"
+        #     popup_dict["delay_chg_sec"] = "Change in Delay (seconds)"
+        if no_title:
+            title = ""
+        else:
+            title = f"{name} {how_formatted[how]} Vehicle Speeds Between Stops{self.filter_formatted}"
+
+        g = map_utils.make_folium_choropleth_map(
+            gdf,
+            plot_col=how_speed_col[how],
+            popup_dict=popup_dict,
+            tooltip_dict=popup_dict,
+            colorscale=colorscale,
+            fig_width=size[0],
+            fig_height=size[1],
+            zoom=13,
+            centroid=[centroid[1], centroid[0]],
+            title=title,
+            legend_name="Speed (miles per hour)",
+            highlight_function=lambda x: {
+                "fillColor": "#DD1C77",
+                "fillOpacity": 0.6,
+            },
+            reduce_precision=False,
+        )
+
+        return g
+
+    def chart_delays(self, no_title=False):
+        """
+        A bar chart showing delays grouped by arrival hour for current filtered selection.
+        Currently hardcoded to 0600-2200.
+        """
+        filtered_endpoint = (
+            self._filter(self.endpoint_delay_view)
+            >> filter(_.arrival_hour > 5)
+            >> filter(_.arrival_hour < 23)
+        )
+        grouped = (
+            filtered_endpoint
+            >> group_by(_.arrival_hour)
+            >> summarize(mean_end_delay=_.delay_seconds.mean())
+        )
+        grouped["Minutes of Delay at Endpoint"] = grouped.mean_end_delay.apply(
+            lambda x: x / 60
+        )
+        grouped["Hour"] = grouped.arrival_hour
+        if no_title:
+            title = ""
+        else:
+            title = f"{self.calitp_agency_name} Mean Delays by Arrival Hour{self.filter_formatted}"
+
+        sns_plot = sns.barplot(
+            x=grouped["Hour"],
+            y=grouped["Minutes of Delay at Endpoint"],
+            ci=None,
+            palette=[cp.CALITP_CATEGORY_BOLD_COLORS[1]],
+        ).set_title(title)
+        chart = sns_plot.get_figure()
+        chart.tight_layout()
+        return chart
+
+    def chart_variability(
+        self, min_stop_seq=None, max_stop_seq=None, num_segments=None, no_title=False
+    ):
+        """
+        Chart trip speed variability, as speed between each stop segments.
+        stop_sequence_range: (min_stop, max_stop)
+        """
+        sns.set(rc={"figure.figsize": (13, 6)})
+        assert (
+            self.filter["shape_ids"] and len(self.filter["shape_ids"]) == 1
+        ), "must filter to a single shape_id"
+        _map = self.segment_speed_map()
+        to_chart = self.stop_segment_speed_view.copy()
+        if num_segments:
+            unique_stops = list(self.stop_segment_speed_view.stop_sequence.unique())[
+                :num_segments
+            ]
+            min_stop_seq = min(unique_stops)
+            max_stop_seq = max(unique_stops)
+        if min_stop_seq:
+            to_chart = to_chart >> filter(_.stop_sequence >= min_stop_seq)
+        if max_stop_seq:
+            to_chart = to_chart >> filter(_.stop_sequence <= max_stop_seq)
+        to_chart.stop_name = to_chart.stop_name.str.split("&").map(lambda x: x[-1])
+        to_chart = to_chart.rename(
+            columns={
+                "speed_mph": "Segement Speed (mph)",
+                "delay_chg_sec": "Increase in Delay (seconds)",
+                "stop_sequence": "Stop Segment ID",
+                "stop_name": "Segment Cross Street",
+            }
+        )
+        plt.xticks(rotation=65)
+        title = f"{self.calitp_agency_name} Speed Variability by Stop Segment{self.filter_formatted}"
+        if no_title:
+            title = None
+        variability_plt = sns.swarmplot(
+            x=to_chart["Segment Cross Street"],
+            y=to_chart["Segement Speed (mph)"],
+            palette=cp.CALITP_CATEGORY_BRIGHT_COLORS,
+        ).set_title(title)
+        return variability_plt
+
+    # works fine, not especially handy to agencies
+    # def describe_delayed_routes(self):
+    #     try:
+    #         most_delayed = (self._filter(self.endpoint_delay_view)
+    #                     >> group_by(_.shape_id)
+    #                     >> summarize(mean_delay_seconds = _.delay_seconds.mean())
+    #                     >> arrange(-_.mean_delay_seconds)
+    #                     >> head(5)
+    #                    )
+    #         most_delayed = most_delayed >> inner_join(_,
+    #                                self.rt_trips >> distinct(_.shape_id, _keep_all=True),
+    #                                on = 'shape_id')
+    #         most_delayed = most_delayed.apply(rt_utils.describe_most_delayed, axis=1)
+    #         display_list = most_delayed.full_description.to_list()
+    #         with_newlines = '\n * ' + '\n * '.join(display_list)
+    #         period_formatted = self.filter_period.replace('_', ' ')
+    #         display(Markdown(f'{period_formatted} most delayed routes: {with_newlines}'))
+    #     except:
+    #         # print('describe delayed routes failed!')
+    #         pass
+    #     return
+
+    def describe_slow_routes(self):
+        try:
+            slowest = (
+                self._filter(self.rt_trips)
+                >> group_by(_.shape_id)
+                >> summarize(
+                    num_trips=_.shape_id.count(),
+                    median_trip_mph=_.mean_speed_mph.median(),
+                )
+                >> arrange(_.median_trip_mph)
+                >> inner_join(
+                    _,
+                    self._filter(self.rt_trips)
+                    >> distinct(
+                        _.shape_id,
+                        _.route_id,
+                        _.route_short_name,
+                        _.route_long_name,
+                        _.route_desc,
+                        _.direction,
+                    ),
+                    on="shape_id",
+                )
+                >> head(7)
+            )
+            slowest = slowest.apply(rt_utils.describe_slowest, axis=1)
+            display_list = slowest.full_description.to_list()
+            with_newlines = "\n * " + "\n * ".join(display_list)
+            period_formatted = self.filter_period.replace("_", " ")
+            # display(slowest)
+            display(Markdown(f"{period_formatted} slowest routes: {with_newlines}"))
+        except:
+            # print('describe slow routes failed!')
+            pass
+        return
+
+
+def from_gcs(itp_id, analysis_date):
+    """Generates RtFilterMapper from cached artifacts in GCS.
+    Generate using rt_analysis.OperatorDayAnalysis.export_views_gcs()"""
+
+    month_day = analysis_date.strftime(rt_utils.MONTH_DAY_FMT)
+    trips = pd.read_parquet(f"{GCS_FILE_PATH}rt_trips/{itp_id}_{month_day}.parquet")
+    stop_delay = gpd.read_parquet(
+        f"{GCS_FILE_PATH}stop_delay_views/{itp_id}_{month_day}.parquet"
+    )
+    stop_delay["arrival_time"] = stop_delay.arrival_time.map(
+        lambda x: dt.datetime.fromisoformat(x)
+    )
+    stop_delay["actual_time"] = stop_delay.actual_time.map(
+        lambda x: dt.datetime.fromisoformat(x)
+    )
+    routelines = rt_utils.get_routelines(itp_id, analysis_date)
+    rt_day = RtFilterMapper(trips, stop_delay, routelines)
+    return rt_day

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -1,0 +1,635 @@
+import datetime as dt
+import os
+import re
+import time
+
+import branca
+import folium
+import gcsfs
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import shapely
+
+# import shared_utils
+from calitp import query_sql
+from calitp.tables import tbl
+from numba import jit
+from shared_utils import geography_utils, map_utils, utils
+from siuba import *
+
+# from zoneinfo import ZoneInfo
+# import warnings
+
+fs = gcsfs.GCSFileSystem()
+
+# set system time
+os.environ["TZ"] = "America/Los_Angeles"
+time.tzset()
+
+GCS_PROJECT = "cal-itp-data-infra"
+BUCKET_NAME = "calitp-analytics-data"
+BUCKET_DIR = "data-analyses/rt_delay"
+GCS_FILE_PATH = f"gs://{BUCKET_NAME}/{BUCKET_DIR}/"
+
+MPH_PER_MPS = 2.237  # use to convert meters/second to miles/hour
+
+# Colorscale
+ZERO_THIRTY_COLORSCALE = branca.colormap.step.RdYlGn_10.scale(vmin=0, vmax=30)
+ZERO_THIRTY_COLORSCALE.caption = "Speed (miles per hour)"
+
+# Datetime formats
+DATE_WEEKDAY_FMT = "%b %d (%a)"
+MONTH_DAY_FMT = "%m_%d"
+HOUR_MIN_FMT = "%H:%M"
+HOUR_MIN_SEC_FMT = "%H:%M:%S"
+FULL_DATE_FMT = "%Y-%m-%d"
+
+
+def convert_ts(ts):
+    pacific_dt = dt.datetime.fromtimestamp(ts)
+    return pacific_dt
+
+
+def reversed_colormap(existing):
+    return branca.colormap.LinearColormap(
+        colors=list(reversed(existing.colors)), vmin=existing.vmin, vmax=existing.vmax
+    )
+
+
+def primary_cardinal_direction(origin, destination):
+    distance_east = destination.x - origin.x
+    distance_north = destination.y - origin.y
+
+    if abs(distance_east) > abs(distance_north):
+        if distance_east > 0:
+            return "Eastbound"
+        else:
+            return "Westbound"
+    else:
+        if distance_north > 0:
+            return "Northbound"
+        else:
+            return "Southbound"
+
+
+def show_full_df(df):
+    with pd.option_context("display.max_rows", None):
+        return display(df)
+
+
+def fix_arrival_time(gtfs_timestring):
+    """Reformats a GTFS timestamp (which allows the hour to exceed 24 to mark service day continuity)
+    to standard 24-hour time.
+    """
+    split = gtfs_timestring.split(":")
+    hour = int(split[0])
+    extra_day = 0
+    if hour >= 24:
+        extra_day = 1
+        split[0] = str(hour - 24)
+        corrected = (":").join(split)
+        return corrected.strip(), extra_day
+    else:
+        return gtfs_timestring.strip(), extra_day
+
+
+def gtfs_time_to_dt(df):
+    date = df.service_date
+    timestring, extra_day = fix_arrival_time(df.arrival_time)
+    df["arrival_dt"] = dt.datetime.combine(
+        date + dt.timedelta(days=extra_day),
+        dt.datetime.strptime(timestring, HOUR_MIN_SEC_FMT).time(),
+    )
+    return df
+
+
+def check_cached(filename, subfolder="cached_views/"):
+    path = f"{GCS_FILE_PATH}{subfolder}{filename}"
+    if fs.exists(path):
+        return path
+    else:
+        return None
+
+
+def get_vehicle_positions(itp_id, analysis_date):
+    """
+    itp_id: an itp_id (string or integer)
+    analysis_date: datetime.date
+
+    Interim function for getting complete vehicle positions data for a single operator on a single date of interest.
+    To be replaced as RT views are implemented...
+
+    Currently drops positions for day after analysis date after 2AM, temporary fix to balance capturing trips crossing
+    midnight with avoiding duplicates...
+    """
+
+    next_date = analysis_date + dt.timedelta(days=1)
+    date_str = analysis_date.strftime(FULL_DATE_FMT)
+
+    start = dt.datetime.combine(analysis_date, dt.time(0))
+    end = start + dt.timedelta(days=1, seconds=2 * 60**2)
+
+    filename = f"vp_{itp_id}_{date_str}.parquet"
+    path = check_cached(filename)
+    if path:
+        print("found parquet")
+        return pd.read_parquet(path)
+    else:
+        df = query_sql(
+            f"""
+        SELECT itp_id AS calitp_itp_id, url_number AS calitp_url_number,
+        header.timestamp AS header_timestamp, vehicle.timestamp AS vehicle_timestamp,
+        vehicle.vehicle.label AS entity_id, vehicle.vehicle.id AS vehicle_id,
+        vehicle.trip.tripId AS trip_id, vehicle.position.longitude AS vehicle_longitude,
+        vehicle.position.latitude AS vehicle_latitude
+        FROM `cal-itp-data-infra.external_gtfs_rt.vehicle_positions`
+        WHERE itp_id = {itp_id} AND dt IN ("{analysis_date}", "{next_date}")
+        """
+        )
+
+        df = df >> distinct(_.trip_id, _.vehicle_timestamp, _keep_all=True)
+        df = df.dropna(subset=["vehicle_timestamp"])
+        assert not df.empty, f"no vehicle positions data found for {date_str}"
+        df.vehicle_timestamp = df.vehicle_timestamp.apply(convert_ts)
+        df.header_timestamp = df.header_timestamp.apply(convert_ts)
+        df = df >> filter(_.header_timestamp > start, _.header_timestamp < end)
+
+        # assert df.vehicle_timestamp.min() < dt.datetime.combine(analysis_date, dt.time(0)), 'rt data starts after analysis date'
+        # assert dt.datetime.combine(analysis_date, dt.time(hour=23, minute=59)) < df.vehicle_timestamp.max(), 'rt data ends early on analysis date'
+        # if not df.vehicle_timestamp.min() < dt.datetime.combine(analysis_date, dt.time(0)):
+        #     warnings.warn('rt data starts after analysis date')
+        # if not dt.datetime.combine(end) < df.vehicle_timestamp.max():
+        #     warnings.warn('rt data ends early on analysis date')
+
+        df.to_parquet(f"{GCS_FILE_PATH}cached_views/{filename}")
+        return df
+
+
+def get_routes(itp_id, analysis_date):
+    routes_on_date = (
+        tbl.views.gtfs_schedule_fact_daily_feed_routes()
+        >> filter(_.date == analysis_date)
+        >> filter(
+            _.calitp_extracted_at <= analysis_date, _.calitp_deleted_at >= analysis_date
+        )
+    )
+
+    operator_routes = tbl.views.gtfs_schedule_dim_routes() >> filter(
+        _.calitp_itp_id == itp_id
+    )
+    routes_date_joined = (
+        routes_on_date
+        >> inner_join(
+            _,
+            (
+                operator_routes
+                >> select(
+                    _.calitp_itp_id,
+                    _.route_id,
+                    _.route_key,
+                    _.route_short_name,
+                    _.route_long_name,
+                    _.route_desc,
+                    _.route_type,
+                )
+            ),
+            on="route_key",
+        )
+        >> distinct(
+            _.calitp_itp_id,
+            _.route_id,
+            _.route_short_name,
+            _.route_long_name,
+            _.route_desc,
+            _.route_type,
+        )
+        # >> collect()
+    )
+    return routes_date_joined
+
+
+def get_trips(itp_id, analysis_date, force_clear=False, route_types=None):
+    """
+    itp_id: an itp_id (string or integer)
+    analysis_date: datetime.date
+    route types: (optional) filter for certain GTFS route types
+
+    Interim function for getting complete trips data for a single operator on a single date of interest.
+    To be replaced as RT views are implemented...
+
+    Updated to include route_short_name from routes
+    """
+
+    date_str = analysis_date.strftime(FULL_DATE_FMT)
+    filename = f"trips_{itp_id}_{date_str}.parquet"
+    path = check_cached(filename)
+    if path and not force_clear:
+        print("found parquet")
+        cached = pd.read_parquet(path)
+        if not cached.empty:
+            trips = cached
+        else:
+            print(
+                "cached parquet empty, will try a fresh query"
+            )  # TODO fix logic here -- consider splitting out some of this...
+    else:
+        print("getting trips...")
+        trips = (
+            tbl.views.gtfs_schedule_fact_daily_trips()
+            >> filter(
+                _.calitp_extracted_at <= analysis_date,
+                _.calitp_deleted_at >= analysis_date,
+            )
+            >> filter(_.calitp_itp_id == itp_id)
+            >> filter(_.service_date == analysis_date)
+            >> filter(_.is_in_service == True)
+            >> select(_.trip_key, _.service_date)
+            >> inner_join(_, tbl.views.gtfs_schedule_dim_trips(), on="trip_key")
+            >> select(
+                _.calitp_itp_id,
+                _.calitp_url_number,
+                _.service_date,
+                _.trip_key,
+                _.trip_id,
+                _.route_id,
+                _.direction_id,
+                _.shape_id,
+                _.calitp_extracted_at,
+                _.calitp_deleted_at,
+            )
+            >> collect()
+            >> distinct(_.trip_id, _keep_all=True)
+            >> inner_join(
+                _,
+                get_routes(itp_id, analysis_date) >> collect(),
+                on=["calitp_itp_id", "route_id"],
+            )
+        )
+        if not path or force_clear:
+            trips.to_parquet(f"{GCS_FILE_PATH}cached_views/{filename}")
+    if route_types:
+        print(f"filtering to GTFS route types {route_types}")
+        trips = trips >> filter(_.route_type.isin(route_types))
+    return trips
+
+
+def get_stop_times(itp_id, analysis_date, force_clear=False):
+    """
+        itp_id: an itp_id (string or integer)
+    analysis_date: datetime.date
+
+    Interim function for getting complete stop times data for a single operator on a single date of interest.
+    To be replaced as RT views are implemented...
+    """
+    date_str = analysis_date.strftime(FULL_DATE_FMT)
+    filename = f"st_{itp_id}_{date_str}.parquet"
+    path = check_cached(filename)
+    if path and not force_clear:
+        print("found parquet")
+        cached = pd.read_parquet(path)
+        if not cached.empty:
+            return cached
+        else:
+            print("cached parquet empty, will try a fresh query")
+    trips_query = (
+        tbl.views.gtfs_schedule_fact_daily_trips()
+        >> filter(
+            _.calitp_extracted_at <= analysis_date, _.calitp_deleted_at >= analysis_date
+        )
+        >> filter(_.calitp_itp_id == itp_id)
+        >> filter(_.service_date == analysis_date)
+        >> filter(_.is_in_service == True)
+        >> select(_.trip_key, _.service_date)
+    )
+    trips_ix_query = (
+        trips_query
+        >> inner_join(_, tbl.views.gtfs_schedule_index_feed_trip_stops(), on="trip_key")
+        >> select(-_.calitp_url_number, -_.calitp_extracted_at, -_.calitp_deleted_at)
+    )
+    st_query = (
+        tbl.views.gtfs_schedule_dim_stop_times()
+        >> filter(_.calitp_itp_id == itp_id)
+        >> select(-_.calitp_url_number)
+    )
+    st = (
+        trips_ix_query
+        >> inner_join(_, st_query, on="stop_time_key")
+        >> mutate(stop_sequence=_.stop_sequence.astype(int))  # in SQL!
+        >> collect()
+        >> distinct(_.stop_id, _.trip_id, _keep_all=True)
+        >> arrange(_.stop_sequence)
+    )
+    st.arrival_time = st.arrival_time.str.strip()
+    st.departure_time = st.departure_time.str.strip()
+    st.to_parquet(f"{GCS_FILE_PATH}cached_views/{filename}")
+    return st
+
+
+def get_stops(itp_id, analysis_date, force_clear=False):
+    """
+    itp_id: an itp_id (string or integer)
+    analysis_date: datetime.date
+
+    Interim function for getting complete stops data for a single operator on a single date of interest.
+    To be replaced as RT views are implemented...
+    """
+    date_str = analysis_date.strftime(FULL_DATE_FMT)
+    filename = f"stops_{itp_id}_{date_str}.parquet"
+    path = check_cached(filename)
+    if path and not force_clear:
+        print("found parquet")
+        cached = gpd.read_parquet(path)
+        if not cached.empty:
+            return cached
+        else:
+            print("cached parquet empty, will try a fresh query")
+    trips_query = (
+        tbl.views.gtfs_schedule_fact_daily_trips()
+        >> filter(
+            _.calitp_extracted_at <= analysis_date, _.calitp_deleted_at >= analysis_date
+        )
+        >> filter(_.calitp_itp_id == itp_id)
+        >> filter(_.service_date == analysis_date)
+        >> filter(_.is_in_service == True)
+        >> select(_.trip_key, _.service_date)
+    )
+    trips_ix_query = (
+        trips_query
+        >> inner_join(_, tbl.views.gtfs_schedule_index_feed_trip_stops(), on="trip_key")
+        >> select(-_.calitp_url_number, -_.calitp_extracted_at, -_.calitp_deleted_at)
+    )
+    stops = (
+        tbl.views.gtfs_schedule_dim_stops()
+        >> filter(_.calitp_itp_id == itp_id)
+        >> distinct(
+            _.calitp_itp_id, _.stop_id, _.stop_lat, _.stop_lon, _.stop_name, _.stop_key
+        )
+        >> inner_join(_, trips_ix_query >> distinct(_.stop_key), on="stop_key")
+        >> collect()
+        >> distinct(
+            _.stop_id, _keep_all=True
+        )  # should be ok to drop duplicates, but must use stop_id for future joins...
+        >> select(-_.stop_key)
+    )
+
+    stops = gpd.GeoDataFrame(
+        stops,
+        geometry=gpd.points_from_xy(stops.stop_lon, stops.stop_lat),
+        crs="EPSG:4326",
+    ).to_crs(geography_utils.CA_NAD83Albers)
+    export_path = GCS_FILE_PATH + "cached_views/"
+    utils.geoparquet_gcs_export(stops, export_path, filename[:-8])
+    return stops
+
+
+def get_routelines(itp_id, analysis_date, force_clear=False):
+
+    date_str = analysis_date.strftime(FULL_DATE_FMT)
+    filename = f"routelines_{itp_id}_{date_str}.parquet"
+    path = check_cached(filename)
+    if path and not force_clear:
+        print("found parquet")
+        cached = gpd.read_parquet(path)
+        if not cached.empty:
+            return cached
+        else:
+            print("cached parquet empty, will try a fresh query")
+    else:
+        routelines = geography_utils.make_routes_gdf(
+            SELECTED_DATE=analysis_date,
+            CRS=geography_utils.CA_NAD83Albers,
+            ITP_ID_LIST=[itp_id],
+        )
+        routelines = (
+            routelines >> select(-_.pt_array) >> distinct(_.shape_id, _keep_all=True)
+        )
+        export_path = GCS_FILE_PATH + "cached_views/"
+        utils.geoparquet_gcs_export(routelines, export_path, filename)
+        return routelines
+
+
+def categorize_time_of_day(dt):
+    if dt.hour < 4:
+        return "Owl"
+    elif dt.hour < 7:
+        return "Early AM"
+    elif dt.hour < 10:
+        return "AM Peak"
+    elif dt.hour < 15:
+        return "Midday"
+    elif dt.hour < 20:
+        return "PM Peak"
+    else:
+        return "Evening"
+
+
+@jit(nopython=True)  # numba gives huge speedup here (~60x)
+def time_at_position_numba(desired_position, shape_array, dt_float_array):
+    if desired_position < shape_array.max() and desired_position > shape_array.min():
+        return np.interp(desired_position, shape_array, dt_float_array)
+    else:
+        return None
+
+
+def try_parallel(geometry):
+    try:
+        return geometry.parallel_offset(30, "right")
+    except:
+        return geometry
+
+
+def arrowize_segment(line_geometry, arrow_distance=15, buffer_distance=20):
+    """Given a linestring segment from a gtfs shape, buffer and clip to show direction of progression"""
+    try:
+        # segment = line_geometry.parallel_offset(25, 'right')
+        segment = line_geometry.simplify(tolerance=5)
+        if segment.length < 50:  # return short segments unmodified, for now
+            return segment.buffer(buffer_distance)
+        arrow_distance = max(
+            arrow_distance, line_geometry.length / 20
+        )  # test this out?
+        shift_distance = buffer_distance + 1
+
+        begin_segment = shapely.ops.substring(
+            segment, segment.length - 50, segment.length
+        )
+        r_shift = begin_segment.parallel_offset(shift_distance, "right")
+        r_pt = shapely.ops.substring(r_shift, 0, 0)
+        l_shift = begin_segment.parallel_offset(shift_distance, "left")
+        l_pt = shapely.ops.substring(l_shift, l_shift.length, l_shift.length)
+        end = shapely.ops.substring(
+            begin_segment,
+            begin_segment.length - arrow_distance,
+            begin_segment.length - arrow_distance,
+        )
+        poly = shapely.geometry.Polygon(
+            (r_pt, end, l_pt)
+        )  # triangle to cut bottom of arrow
+        # ends to the left
+        end_segment = shapely.ops.substring(segment, 0, 50)
+        end = shapely.ops.substring(end_segment, 0, 0)  # correct
+        r_shift = end_segment.parallel_offset(shift_distance, "right")
+        r_pt = shapely.ops.substring(r_shift, r_shift.length, r_shift.length)
+        r_pt2 = shapely.ops.substring(
+            r_shift, r_shift.length - arrow_distance, r_shift.length - arrow_distance
+        )
+        l_shift = end_segment.parallel_offset(shift_distance, "left")
+        l_pt = shapely.ops.substring(l_shift, 0, 0)
+        l_pt2 = shapely.ops.substring(l_shift, arrow_distance, arrow_distance)
+        t1 = shapely.geometry.Polygon(
+            (l_pt2, end, l_pt)
+        )  # triangles to cut top of arrow
+        t2 = shapely.geometry.Polygon((r_pt2, end, r_pt))
+        segment_clip_mask = shapely.geometry.MultiPolygon((poly, t1, t2))
+        # return segment_clip_mask
+
+        differences = segment.buffer(buffer_distance).difference(segment_clip_mask)
+        areas = [x.area for x in differences.geoms]
+        for geom in differences.geoms:
+            if geom.area == max(areas):
+                return geom
+    except:
+        return line_geometry.simplify(tolerance=5).buffer(buffer_distance)
+
+
+def layer_points(rt_interpolator):
+    keep_cols = [
+        "geometry",
+        "shape_meters",
+        "progressed",
+        "secs_from_last",
+        "meters_from_last",
+    ]
+
+    initial_bk_noise = (
+        rt_interpolator.position_gdf
+        >> filter(_.meters_from_last < 0)
+        >> select(*keep_cols)
+    )
+    initial_deduped = (
+        rt_interpolator.position_gdf
+        >> distinct(_.shape_meters, _keep_all=True)
+        >> select(*keep_cols)
+    )
+    cleaned = rt_interpolator.cleaned_positions >> select(*keep_cols)
+    popup_dict = {
+        "shape_meters": "shape_meters",
+        "progressed": "progressed",
+        "secs_from_last": "secs_from_last",
+        "meters_from_last": "meters_from_last",
+    }
+    layers_dict = {
+        "initial backwards noise": {
+            "df": initial_bk_noise,
+            "plot_col": "shape_meters",
+            "popup_dict": popup_dict,
+            "tooltip_dict": popup_dict,
+            "colorscale": branca.colormap.step.Blues_03,
+        },
+        "initial position deduplicated": {
+            "df": initial_deduped,
+            "plot_col": "shape_meters",
+            "popup_dict": popup_dict,
+            "tooltip_dict": popup_dict,
+            "colorscale": branca.colormap.step.Greens_03,
+        },
+        "cleaned_final": {
+            "df": cleaned,
+            "plot_col": "shape_meters",
+            "popup_dict": popup_dict,
+            "tooltip_dict": popup_dict,
+            "colorscale": branca.colormap.step.Greens_03,
+        },
+    }
+    for i in range(rt_interpolator._position_cleaning_count):
+        layers_dict[f"cleaned_{i}"] = {
+            "df": (rt_interpolator.debug_dict[f"clean_{i}"] >> select(*keep_cols)),
+            "plot_col": "shape_meters",
+            "popup_dict": popup_dict,
+            "tooltip_dict": popup_dict,
+            "colorscale": branca.colormap.step.Reds_03,
+            # 'marker':  marker
+        }
+    # return layers_dict
+    return map_utils.make_folium_multiple_layers_map(layers_dict, 900, 500)
+
+
+def map_line(gdf):
+    # gdf = gdf.buffer(1)
+    gdf = gdf.to_crs(geography_utils.WGS84)
+    centroid = gdf.geometry.iloc[0].centroid
+    m = folium.Map(
+        location=[centroid.y, centroid.x], zoom_start=13, tiles="cartodbpositron"
+    )
+    folium.GeoJson(gdf.to_json()).add_to(m)
+    return m
+
+
+def categorize_cleaning(rt_operator_day, interpolator_key):
+    rt_interpolator = rt_operator_day.position_interpolators[interpolator_key]["rt"]
+    raw = rt_interpolator.position_gdf.shape[0]
+    same_loc_dropped = (rt_interpolator.position_gdf >> distinct(_.shape_meters)).shape[
+        0
+    ]
+    cleaned = rt_interpolator.cleaned_positions.shape[0]
+    return (interpolator_key, cleaned / raw, cleaned / same_loc_dropped)
+
+
+def make_linestring(x):
+    # shapely errors if the array contains only one point
+    if len(x) > 1:
+        # each point in the array is wkt
+        # so convert them to shapely points via list comprehension
+        as_wkt = [shapely.wkt.loads(i) for i in x]
+        return shapely.geometry.LineString(as_wkt)
+
+
+def exclude_desc(desc):
+    # match descriptions that don't give additional info, like Route 602 or Route 51B
+    exclude_texts = [
+        " *Route *[0-9]*[a-z]{0,1}$",
+        " *Metro.*(Local|Rapid|Limited).*Line",
+        " *(Redwood Transit serves the communities of|is operated by Eureka Transit and serves)",
+        " *service within the Stockton Metropolitan Area",
+        " *Hopper bus can deviate",
+        " *RTD's Interregional Commuter Service is a limited-capacity service",
+    ]
+    desc_eval = [re.search(text, desc, flags=re.IGNORECASE) for text in exclude_texts]
+    # number_only = re.search(' *Route *[0-9]*[a-z]{0,1}$', desc, flags=re.IGNORECASE)
+    # metro = re.search(' *Metro.*(Local|Rapid|Limited).*Line', desc, flags=re.IGNORECASE)
+    # redwood = re.search(' *(Redwood Transit serves the communities of|is operated by Eureka Transit and serves)', desc, flags=re.IGNORECASE)
+    # return number_only or metro or redwood
+    return any(desc_eval)
+
+
+def which_desc(row):
+    long_name_valid = row.route_long_name and not exclude_desc(row.route_long_name)
+    route_desc_valid = row.route_desc and not exclude_desc(row.route_desc)
+    if route_desc_valid:
+        return f", {row.route_desc}"
+    elif long_name_valid:
+        return f", {row.route_long_name}"
+    else:
+        return ""
+
+
+def describe_most_delayed(row):
+    description = which_desc(row)
+    full_description = (
+        f"{row.route_short_name}{description}, {row.direction}: "
+        f"{round(row.mean_delay_seconds/60, 0)} minutes late on average"
+    )
+    row["full_description"] = full_description
+    return row
+
+
+def describe_slowest(row):
+    description = which_desc(row)
+    full_description = (
+        f"{row.route_short_name}{description}, {row.direction}: "
+        f"{round(row.median_trip_mph, 1)} mph median trip speed for "
+        f'{row.num_trips} trip{"s" if row.num_trips > 1 else ""}'
+    )
+    row["full_description"] = full_description
+    return row

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -435,7 +435,7 @@ def time_at_position_numba(desired_position, shape_array, dt_float_array):
 def try_parallel(geometry):
     try:
         return geometry.parallel_offset(30, "right")
-    except:
+    except Exception:
         return geometry
 
 
@@ -489,7 +489,7 @@ def arrowize_segment(line_geometry, arrow_distance=15, buffer_distance=20):
         for geom in differences.geoms:
             if geom.area == max(areas):
                 return geom
-    except:
+    except Exception:
         return line_geometry.simplify(tolerance=5).buffer(buffer_distance)
 
 

--- a/_shared_utils/shared_utils/utils.py
+++ b/_shared_utils/shared_utils/utils.py
@@ -35,6 +35,9 @@ def geoparquet_gcs_export(gdf, GCS_FILE_PATH, FILE_NAME):
     GCS_FILE_PATH: str. Ex: gs://calitp-analytics-data/data-analyses/my-folder/
     FILE_NAME: str. Filename.
     """
+    if FILE_NAME.endswith(".parquet"):
+        FILE_NAME = FILE_NAME.replace(".parquet", "")
+
     gdf.to_parquet(f"./{FILE_NAME}.parquet")
     fs.put(f"./{FILE_NAME}.parquet", f"{GCS_FILE_PATH}{FILE_NAME}.parquet")
     os.remove(f"./{FILE_NAME}.parquet")
@@ -48,6 +51,9 @@ def download_geoparquet(GCS_FILE_PATH, FILE_NAME, save_locally=False):
                 Ex: test_file (not test_file.parquet)
     save_locally: bool, defaults to False. if True, will save geoparquet locally.
     """
+    if FILE_NAME.endswith(".parquet"):
+        FILE_NAME = FILE_NAME.replace(".parquet", "")
+
     object_path = fs.open(f"{GCS_FILE_PATH}{FILE_NAME}.parquet")
     gdf = gpd.read_parquet(object_path)
 


### PR DESCRIPTION
* Make function writing to geoparquet in GCS more flexible (can take `filename` or `filename.parquet`)
* Add all RT utils into `shared_utils`, and get most of flake8/isort/black formatter things fixed