### PR TITLE
Update traffic ops

### DIFF
--- a/traffic_ops/create_routes_data.py
+++ b/traffic_ops/create_routes_data.py
@@ -6,6 +6,8 @@ Operator-routes in shapes.txt need route line geometry.
 Operator-routes not in shapes.txt use stop sequence 
 to generate route line geometry.
 """
+import dask.dataframe as dd
+import dask_geopandas
 import geopandas as gpd
 import pandas as pd
 import os
@@ -24,17 +26,19 @@ def merge_shapes_to_routes(trips, routes):
     # right only means in routes, but no route that has that shape_id 
     # We probably should keep how = "left"?
     # left only means we can assemble from stop sequence?
-    m1 = pd.merge(
+    m1 = dd.merge(
             trips,
             routes,
             on = ["calitp_itp_id", "shape_id"],
             how = "left",
-            validate = "m:1",
+            #validate = "m:1",
             indicator=True
-        )
+        ).compute()
     
     # routes is a gdf, so turn it back into gdf
     m2 = gpd.GeoDataFrame(m1, geometry="geometry", crs = geography_utils.WGS84)
+    
+    m2 = dask_geopandas.from_geopandas(m2, npartitions=1)
     
     return m2
     
@@ -53,9 +57,10 @@ def routes_for_operators_in_shapes(merged_shapes_routes, route_info):
 
 def routes_for_operators_notin_shapes(merged_shapes_routes, route_info):
     missing_shapes = (merged_shapes_routes[merged_shapes_routes._merge=="left_only"]
-      .drop(columns = ["geometry", "_merge"])
+      [["calitp_itp_id", "route_id", "shape_id"]]
       .reset_index(drop=True)
      )
+    
         
     # Only grab trip info for the shape_ids that are missing, or, appear in missing_shapes
     trip_cols = ["calitp_itp_id", "route_id", "shape_id"]
@@ -138,11 +143,11 @@ def make_routes_shapefile():
     DATA_PATH = prep_data.DATA_PATH
 
     # Read in local parquets
-    stops = pd.read_parquet(f"{DATA_PATH}stops.parquet")
-    trips = pd.read_parquet(f"{DATA_PATH}trips.parquet")
-    route_info = pd.read_parquet(f"{DATA_PATH}route_info.parquet")
-    routes = gpd.read_parquet(f"{DATA_PATH}routes.parquet")
-    latest_itp_id = pd.read_parquet(f"{DATA_PATH}latest_itp_id.parquet")
+    stops = dd.read_parquet(f"{DATA_PATH}stops.parquet")
+    trips = dd.read_parquet(f"{DATA_PATH}trips.parquet")
+    route_info = dd.read_parquet(f"{DATA_PATH}route_info.parquet")
+    routes = dask_geopandas.read_parquet(f"{DATA_PATH}routes.parquet")
+    latest_itp_id = dd.read_parquet(f"{DATA_PATH}latest_itp_id.parquet")
 
     df = merge_shapes_to_routes(trips, routes)
     
@@ -159,7 +164,8 @@ def make_routes_shapefile():
     time3 = datetime.now()
     print(f"Part 2 - routes for operator-routes not in shapes.txt: {time3-time2}")
     
-    routes_assembled = (pd.concat([routes_part1, routes_part2], axis=0)
+    routes_assembled = (dd.multi.concat([routes_part1, routes_part2], axis=0)
+                        .compute()
                         .sort_values(["calitp_itp_id", "route_id"])
                         .drop_duplicates()
                         .reset_index(drop=True)
@@ -167,6 +173,7 @@ def make_routes_shapefile():
     
     # Attach agency_name
     agency_names = portfolio_utils.add_agency_name(SELECTED_DATE = prep_data.SELECTED_DATE)
+    
     
     routes_assembled2 = pd.merge(
         routes_assembled,

--- a/traffic_ops/create_routes_data.py
+++ b/traffic_ops/create_routes_data.py
@@ -37,47 +37,6 @@ def merge_shapes_to_routes(trips, routes):
     m2 = gpd.GeoDataFrame(m1, geometry="geometry", crs = geography_utils.WGS84)
     
     return m2
-
-
-def handle_metrolink(trips, routes):
-    trips = trips[trips.calitp_itp_id==323]
-    routes = routes[routes.calitp_itp_id==323]
-    
-    def map_substring(s, my_dict):
-        for key, value in my_dict.items():
-            if key in s:
-                return my_dict[key]
-        
-        
-    metrolink_shape_to_route = {
-        'SB': 'San Bernardino Line', 
-        'IE': 'Inland Emp.-Orange Co. Line',
-        # if this is after IE, it correctly maps the IEOC and OC routes with dict
-        # but, just in case, let's just break out this case for OC so it never maps onto IEOC
-        'OCin': 'Orange County Line',  
-        'OCout': 'Orange County Line',
-        'RIVER': 'Riverside Line', 
-        'AV': 'Antelope Valley Line', 
-        'VT': 'Ventura County Line',
-        'LAX': 'LAX FlyAway Bus', 
-        '91': '91 Line',
-    }    
-    
-    routes = routes.assign(
-        route_id = routes.shape_id.apply(lambda x: 
-                                         map_substring(x, metrolink_shape_to_route))
-    )
-     
-    routes2 = pd.merge(
-        routes,
-        # Drop shape_id from trips, since it's all None
-        trips.drop(columns = "shape_id"),
-        on = ["calitp_itp_id", "route_id"],
-        how = "inner",
-        indicator = True
-    )
-        
-    return routes2
     
 
 def routes_for_operators_in_shapes(merged_shapes_routes, route_info):
@@ -185,12 +144,7 @@ def make_routes_shapefile():
     routes = gpd.read_parquet(f"{DATA_PATH}routes.parquet")
     latest_itp_id = pd.read_parquet(f"{DATA_PATH}latest_itp_id.parquet")
 
-    df1 = merge_shapes_to_routes(trips, routes)
-    metrolink = handle_metrolink(trips, routes)
-    
-    df = pd.concat([df1[df1.calitp_itp_id != 323], 
-                    metrolink
-                   ], axis=0, ignore_index=True)
+    df = merge_shapes_to_routes(trips, routes)
     
     time1 = datetime.now()
     print(f"Read in data and merge shapes to routes: {time1-time0}")    

--- a/traffic_ops/make_routes_stops_shapefiles.py
+++ b/traffic_ops/make_routes_stops_shapefiles.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     time0 = datetime.now()
     
     # Create local parquets
-    #prep_data.create_local_parquets(prep_data.SELECTED_DATE) 
+    prep_data.create_local_parquets(prep_data.SELECTED_DATE) 
     print("Local parquets created")
     
     routes = create_routes_data.make_routes_shapefile()    
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     print("Geoparquets exported to GCS")
     
     # Delete local parquets
-    prep_data.delete_local_parquets()
+    #prep_data.delete_local_parquets()
     print("Local parquets deleted")
     
     time1 = datetime.now()

--- a/traffic_ops/prep_data.py
+++ b/traffic_ops/prep_data.py
@@ -3,6 +3,8 @@ Functions to query GTFS schedule data,
 save locally as parquets, 
 then clean up at the end of the script.
 """
+import dask.dataframe as dd
+
 import geopandas as gpd
 import pandas as pd
 import glob
@@ -182,12 +184,12 @@ def attach_route_name(df, route_info_df):
                          .drop_duplicates(subset=["calitp_itp_id", "route_id"])
                         )
     
-    routes = pd.merge(
+    routes = dd.merge(
         df, 
         route_info_unique,
         on = ["calitp_itp_id", "route_id"],
         how = "left",
-        validate = "m:1",
+        #validate = "m:1",
     )
 
     return routes

--- a/traffic_ops/prep_data.py
+++ b/traffic_ops/prep_data.py
@@ -15,7 +15,7 @@ from calitp import query_sql
 from datetime import datetime, date, timedelta
 from siuba import *
 
-from shared_utils import geography_utils, portfolio_utils
+from shared_utils import geography_utils, portfolio_utils, gtfs_utils
 
 GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/traffic_ops/"
 DATA_PATH = "./data/"
@@ -50,7 +50,10 @@ def grab_selected_date(SELECTED_DATE):
     
     # Trips query
     dim_trips = (tbl.views.gtfs_schedule_dim_trips()
-                >> filter(_.calitp_itp_id != 200, _.calitp_itp_id != 0)
+                >> filter(_.calitp_itp_id != 200, 
+                          _.calitp_itp_id != 0, 
+                          _.calitp_itp_id != 323
+                         )
                  >> select(*trip_cols, _.trip_key)
                  >> distinct()
                 )
@@ -71,9 +74,40 @@ def grab_selected_date(SELECTED_DATE):
     return stops, trips, route_info
 
 
+def metrolink_trips_query(SELECTED_DATE):
+    # Modify existing trips query
+    dim_trips = (tbl.views.gtfs_schedule_dim_trips()
+                 >> filter(_.calitp_itp_id==323)
+                 >> select(*trip_cols, _.trip_key, _.direction_id)
+                 >> distinct()
+                )            
+                 
+
+    metrolink_trips = (tbl.views.gtfs_schedule_fact_daily_trips()
+             >> filter(_.service_date == SELECTED_DATE, 
+                       _.is_in_service==True)
+             >> select(_.trip_key, _.service_date)
+             >> inner_join(_, dim_trips, on = "trip_key")
+             >> select(*trip_cols)
+             >> distinct()
+             >> collect()
+            )
+                 
+                 
+    return metrolink_trips
+    
+
 def create_local_parquets(SELECTED_DATE):
     time0 = datetime.now()
     stops, trips, route_info = grab_selected_date(SELECTED_DATE)
+    
+    # Original trips query excludes Metrolink
+    # Do Metrolink query separately for trips, to fill in missing shape_id values here
+    metrolink_trips = metrolink_trips_query(SELECTED_DATE)
+    
+    # Full trips table, with Metrolink concatenated
+    trips = pd.concat([trips, metrolink_trips], axis=0, ignore_index=True)
+    
     
     # Filter to the ITP_IDs present in the latest agencies.yml
     latest_itp_id = (tbl.views.gtfs_schedule_dim_feeds()

--- a/traffic_ops/requirements.txt
+++ b/traffic_ops/requirements.txt
@@ -1,0 +1,2 @@
+dask
+dask_geopandas


### PR DESCRIPTION
* Run for 7/18/22
* Use `gtfs_utils` to clean Metrolink in routes dataset
* Move routes script to use `dask`. Limitations are that `dask` only can sort on 1 column, so stay with pandas df. 
* Script overall took around 7.5 min to create routes and stops datasets. With dask on routes table only, shaved off about 1 min. 