### PR TITLE
Amtrak bus

### DIFF
--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -1,3 +1,5 @@
 -e .
 cpi==1.0.5
 xmltodict==0.13.0
+dask==2022.05.2
+dask_geopandas==0.2.0

--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -3,3 +3,4 @@ cpi==1.0.5
 xmltodict==0.13.0
 dask==2022.05.2
 dask_geopandas==0.2.0
+dask-bigquery==2022.05.0

--- a/_shared_utils/shared_utils/gtfs_utils.py
+++ b/_shared_utils/shared_utils/gtfs_utils.py
@@ -1,5 +1,7 @@
 """
-GTFS utils
+GTFS utils.
+
+Queries to grab trips, stops, routes.
 
 TODO: move over some of the rt_utils
 over here, if it addresses GTFS schedule data more generally,
@@ -7,7 +9,20 @@ such as cleaning/reformatting arrival times.
 
 Leave the RT-specific analysis there.
 """
+import datetime
+
+import geopandas as gpd
 import pandas as pd
+from calitp.tables import tbl
+from shared_utils import geography_utils
+from siuba import *
+
+# import os
+# os.environ["CALITP_BQ_MAX_BYTES"] = str(200_000_000_000)
+
+
+YESTERDAY_DATE = datetime.date.today() + datetime.timedelta(days=-1)
+
 
 METROLINK_SHAPE_TO_ROUTE = {
     "AVin": "Antelope Valley Line",
@@ -62,3 +77,150 @@ def fill_in_metrolink_trips_df_with_shape_id(trips: pd.DataFrame) -> pd.DataFram
     )
 
     return df
+
+
+def get_route_info(
+    selected_date: str | datetime.date = YESTERDAY_DATE,
+    itp_id_list: list[int] = None,
+    route_cols: list[str] = None,
+    get_df: bool = True,
+) -> pd.DataFrame:
+
+    # Route info query
+    dim_routes = tbl.views.gtfs_schedule_dim_routes() >> distinct()
+
+    routes = (
+        tbl.views.gtfs_schedule_fact_daily_feed_routes()
+        >> filter(_.date == selected_date)
+        >> inner_join(
+            _, dim_routes, on=["route_key", "calitp_extracted_at", "calitp_deleted_at"]
+        )
+        >> distinct()
+    )
+
+    if itp_id_list is not None:
+        routes = routes >> filter(_.calitp_itp_id.isin(itp_id_list))
+
+    if route_cols is not None:
+        routes = routes >> select(*route_cols)
+
+    if get_df is True:
+        routes = routes >> collect()
+
+    return routes
+
+
+def get_stops(
+    selected_date: str | datetime.date = YESTERDAY_DATE,
+    itp_id_list: list[int] = None,
+    stop_cols: list[str] = None,
+    get_df: bool = True,
+) -> gpd.GeoDataFrame:
+
+    # Stops query
+    dim_stops = tbl.views.gtfs_schedule_dim_stops() >> distinct()
+
+    stops = (
+        tbl.views.gtfs_schedule_fact_daily_feed_stops()
+        >> filter(_.date == selected_date)
+        >> inner_join(
+            _, dim_stops, on=["stop_key", "calitp_extracted_at", "calitp_deleted_at"]
+        )
+        >> distinct()
+    )
+
+    if itp_id_list is not None:
+        stops = stops >> filter(_.calitp_itp_id.isin(itp_id_list))
+
+    if stop_cols is not None:
+        stops = stops >> select(*stop_cols)
+
+    if get_df is True:
+        stops = geography_utils.create_point_geometry(stops >> collect()).drop(
+            columns=["stop_lon", "stop_lat"]
+        )
+
+    return stops
+
+
+def get_trips(
+    selected_date: str | datetime.date = YESTERDAY_DATE,
+    itp_id_list: list[int] = None,
+    trip_cols: list[str] = None,
+    get_df: bool = True,
+) -> pd.DataFrame:
+
+    # Trips query
+    dim_trips = tbl.views.gtfs_schedule_dim_trips() >> distinct()
+
+    trips = (
+        tbl.views.gtfs_schedule_fact_daily_trips()
+        >> filter(_.service_date == selected_date, _.is_in_service == True)
+        >> inner_join(
+            _,
+            dim_trips,
+            on=[
+                "trip_key",
+                "trip_id",
+                "route_id",
+                "service_id",
+                "calitp_itp_id",
+                "calitp_url_number",
+                "calitp_extracted_at",
+                "calitp_deleted_at",
+            ],
+        )
+        >> distinct()
+    )
+
+    if itp_id_list is not None:
+        trips = trips >> filter(_.calitp_itp_id.isin(itp_id_list))
+
+    if trip_cols is not None:
+        trips = trips >> select(*trip_cols)
+
+    if get_df is True:
+        trips = trips >> collect()
+
+    return trips
+
+
+def get_trips_with_stop_times(
+    selected_date: str | datetime.date = YESTERDAY_DATE,
+    itp_id_list: list[int] = None,
+    departure_hours: list[int] = None,
+    trip_stop_time_cols: list[str] = None,
+    get_df: bool = True,
+) -> pd.DataFrame:
+
+    trips = get_trips(
+        selected_date=selected_date,
+        itp_id_list=itp_id_list,
+        trip_cols=None,
+        get_df=False,
+    )
+
+    # Join to stop_times, since stop_times always depends on trip_id
+    # No other way to filter stop_times by date
+    trips_with_stop_times = tbl.views.gtfs_schedule_dim_stop_times() >> inner_join(
+        _,
+        # Drop these columns,
+        # the inner join will either return 0 rows or _x, _y
+        # Can't use in merge_cols
+        # because they are different values
+        trips >> select(-_.calitp_hash, -_.calitp_extracted_at, -_.calitp_deleted_at),
+        on=["calitp_itp_id", "calitp_url_number", "trip_id"],
+    )
+
+    if itp_id_list is not None:
+        trips_with_stop_times = trips_with_stop_times >> filter(
+            _.calitp_itp_id.isin(itp_id_list)
+        )
+
+    if trip_stop_time_cols is not None:
+        trips_with_stop_times = trips_with_stop_times >> select(*trip_stop_time_cols)
+
+    if get_df is True:
+        trips_with_stop_times = trips_with_stop_times >> collect()
+
+    return trips_with_stop_times

--- a/bus_service_increase/F1_regional_bus_queries.py
+++ b/bus_service_increase/F1_regional_bus_queries.py
@@ -1,0 +1,133 @@
+"""
+Warehouse queries for regional bus network.
+
+Amtrak thruway buses + local buses that run the same
+origin/destination.
+
+Adapt bus_service_increase/warehouse_queries.py
+and traffic_ops/prep_data.py
+"""
+import datetime
+import geopandas as gpd
+import os
+import pandas as pd
+
+os.environ["CALITP_BQ_MAX_BYTES"] = str(100_000_000_000)
+
+from calitp.tables import tbl
+from siuba import *
+
+from shared_utils import geography_utils
+
+SELECTED_DATE = "2022-7-29"
+itp_id = 13
+
+stop_cols = ["calitp_itp_id", "stop_id", 
+             "stop_lat", "stop_lon", 
+             "stop_name", "stop_code"
+            ]
+
+trip_cols = ["calitp_itp_id", "route_id", "shape_id", "trip_id"]   
+
+route_cols = ["calitp_itp_id", "route_id", 
+              "route_type", "route_long_name"]
+
+stop_time_cols = ["stop_id", 
+                  "stop_sequence", "stop_sequence_rank", 
+                  "departure_time"
+                 ]
+
+def get_routes(SELECTED_DATE: str | datetime.date, 
+               itp_id: int) -> pd.DataFrame:
+    dim_routes = (tbl.views.gtfs_schedule_dim_routes()
+                  >> filter(_.calitp_itp_id == itp_id)
+                  >> select(*route_cols + ["route_key"])
+                  >> distinct() 
+                 )
+    
+    routes = (tbl.views.gtfs_schedule_fact_daily_feed_routes()
+              >> filter(_.date == SELECTED_DATE)
+              >> select(_.route_key, _.date)
+              >> inner_join(_, dim_routes, on = "route_key")
+              >> select(*route_cols)
+              >> distinct()
+              >> collect()
+             )
+
+    return routes
+
+
+def get_trips_with_stop_times(SELECTED_DATE: str | datetime.date, 
+                              itp_id: int) -> pd.DataFrame:
+    # Trips query
+    dim_trips = (tbl.views.gtfs_schedule_dim_trips()
+                >> filter(_.calitp_itp_id == itp_id)
+                 >> select(*trip_cols, _.trip_key)
+                 >> distinct()
+                )
+
+    trips = (tbl.views.gtfs_schedule_fact_daily_trips()
+             >> filter(_.service_date == SELECTED_DATE, 
+                       _.is_in_service==True)
+             >> select(_.trip_key, _.service_date)
+             >> inner_join(_, dim_trips, on = "trip_key")
+             >> select(*trip_cols)
+             >> distinct()
+            )
+    
+    
+    # Join to stop_times, since stop_times always depends on trip_id
+    # No other way to filter stop_times by date
+    trips_with_stop_times = (tbl.views.gtfs_schedule_dim_stop_times()
+                             >> filter(_.calitp_itp_id == itp_id)
+                             >> inner_join(_, trips, 
+                                           on = ["calitp_itp_id", "trip_id"])
+                             >> select(*trip_cols, *stop_time_cols)
+                             >> collect()
+                            )
+    
+    return trips_with_stop_times
+
+
+def get_stops(SELECTED_DATE: str | datetime.date, 
+              itp_id: int) -> gpd.GeoDataFrame:
+    # Stops query
+    dim_stops = (tbl.views.gtfs_schedule_dim_stops()
+                 >> filter(_.calitp_itp_id == itp_id)
+                 >> select(*stop_cols, _.stop_key)
+                 >> distinct()
+                )
+
+    stops = (tbl.views.gtfs_schedule_fact_daily_feed_stops()
+             >> filter(_.date == SELECTED_DATE)
+             >> select(_.stop_key, _.date)
+             >> inner_join(_, dim_stops, on = "stop_key")
+             >> select(*stop_cols)
+             >> distinct()
+             >> collect()
+            )
+    
+    stops = (geography_utils.create_point_geometry(stops)
+             .drop(columns = ["stop_lon", "stop_lat"])
+            )
+    
+    return stops
+
+
+def grab_selected_date(SELECTED_DATE: str | datetime.date, 
+                       itp_id: int):
+    routes = geography_utils.make_routes_gdf(SELECTED_DATE, 
+                                ITP_ID_LIST = [itp_id]).drop(columns="pt_array")
+    route_info = get_routes(SELECTED_DATE, itp_id)
+    trips_with_stop_times = get_trips_with_stop_times(SELECTED_DATE, itp_id)
+    stops = get_stops(SELECTED_DATE, itp_id)
+    
+    routes.to_parquet("./data/amtrak_routes.parquet")
+    route_info.to_parquet("./data/amtrak_route_info.parquet")
+    trips_with_stop_times.to_parquet("./data/amtrak_trips_with_stop_times.parquet")
+    stops.to_parquet("./data/amtrak_stops.parquet")
+
+
+if __name__=="__main__":
+    
+    grab_selected_date(SELECTED_DATE, itp_id)

--- a/example_report/docs_notes.md
+++ b/example_report/docs_notes.md
@@ -1,9 +1,0 @@
-# Rework Docs
-
-* Analysts drop their own Markdown files within `data-analyses/example_report` for someone else to consolidate into 1 doc
-    * highlight interesting tidbits of code, techniques, or StackOverflow/websites for figuring out very specific things (arrowizing, sorting legend order, inflation, etc)
-    * also hold practice exercises
-        * URLs redirecting to tutorials in `best-practices` will need to be fixed
-        * Tutorials held in `example_report`
-        * Analyst knowledge consolidation held in `data-infra/docs`
-    * clean up `example_report`, potentially consolidating the `example_charts`, `example_maps` and `shared_utils_examples` into one notebook, which can be referenced in from docs. `style-guide-examples` can stand alone. standardize naming (underscores vs dashes).

--- a/traffic_ops/create_routes_data.py
+++ b/traffic_ops/create_routes_data.py
@@ -147,7 +147,6 @@ def make_routes_shapefile():
     trips = dd.read_parquet(f"{DATA_PATH}trips.parquet")
     route_info = dd.read_parquet(f"{DATA_PATH}route_info.parquet")
     routes = dask_geopandas.read_parquet(f"{DATA_PATH}routes.parquet")
-    latest_itp_id = dd.read_parquet(f"{DATA_PATH}latest_itp_id.parquet")
 
     df = merge_shapes_to_routes(trips, routes)
     

--- a/traffic_ops/create_routes_data.py
+++ b/traffic_ops/create_routes_data.py
@@ -183,15 +183,20 @@ def make_routes_shapefile():
         validate = "m:1"
     )
     
-    routes_assembled2 = (prep_data.filter_latest_itp_id(routes_assembled2, 
-                                                        latest_itp_id, 
-                                                        itp_id_col = "calitp_itp_id")
-                         # Any renaming to be done before exporting
-                         .rename(columns = prep_data.RENAME_COLS)
-                         .sort_values(["itp_id", "route_id"])
-                         .reset_index(drop=True)
-                        )
+    latest_itp_id = portfolio_utils.latest_itp_id(SELECTED_DATE = prep_data.SELECTED_DATE)
     
+    routes_assembled2 = (pd.merge(
+        routes_assembled2, 
+        latest_itp_id,
+        on = "calitp_itp_id",
+        how = "inner",
+        validate = "m:1")
+     # Any renaming to be done before exporting
+     .rename(columns = prep_data.RENAME_COLS)
+     .sort_values(["itp_id", "route_id"])
+     .reset_index(drop=True)
+    )
+
     print(f"Routes script total execution time: {time3-time0}")
 
     return routes_assembled2

--- a/traffic_ops/create_stops_data.py
+++ b/traffic_ops/create_stops_data.py
@@ -97,7 +97,6 @@ def make_stops_shapefile():
     # Read in local parquets
     stops = pd.read_parquet(f"{DATA_PATH}stops.parquet")
     route_info = pd.read_parquet(f"{DATA_PATH}route_info.parquet")
-    latest_itp_id = pd.read_parquet(f"{DATA_PATH}latest_itp_id.parquet")
 
     df = create_stops_data(stops)
         

--- a/traffic_ops/create_stops_data.py
+++ b/traffic_ops/create_stops_data.py
@@ -109,8 +109,12 @@ def make_stops_shapefile():
     time2 = datetime.now()
     print(f"Attach route and operator info to stops: {time2-time1}")
     
-    df2 = (prep_data.filter_latest_itp_id(df2, latest_itp_id, 
-                                          itp_id_col = "calitp_itp_id")
+    latest_itp_id = portfolio_utils.latest_itp_id(SELECTED_DATE = prep_data.SELECTED_DATE)
+
+    df2 = (pd.merge(df2, 
+                    latest_itp_id,
+                    on = "calitp_itp_id",
+                    how = "inner")
            # Any renaming to be done before exporting
            .rename(columns = prep_data.RENAME_COLS)
            .sort_values(["itp_id", "route_id", "stop_id"])

--- a/traffic_ops/prep_data.py
+++ b/traffic_ops/prep_data.py
@@ -94,7 +94,8 @@ def metrolink_trips_query(SELECTED_DATE):
              >> distinct()
              >> collect()
             )
-                 
+    
+    # Fill in the missing shape_id value, then drop direction_id
     corrected_metrolink = gtfs_utils.fill_in_metrolink_trips_df_with_shape_id(
         metrolink_trips).drop(columns = "direction_id")
                   


### PR DESCRIPTION
* Initial work for #315 to query Amtrak thruway buses for origin/destination between regions
* **Wonder**: why are we running the same GTFS schedule queries so often...but not quite the same? Can we abstract this and put in `shared_utils`? Main differences are just returning different columns (all or a subset), the date, and operator.

Ex: `tbl.views.gtfs_schedule_dim_trips()` always joined to `tbl.views.gtfs_schedule_fact_daily_trips()` using `trip_key`, and we're doing this repeatedly. Hard to remember exactly, so let's at least generalize based on an analysis date, operators of interest, subset of columns to keep in the end. Also, Metrolink trips are known to be missing `shape_id` values, so let's always apply the fix to fill it in so we have the right trip data!

* Catch error in `traffic_ops` scripts to actually use the `gtfs_utils` to fix Metrolink trip info.
* Add `dask`, `dask_geopandas`, `dask_bigquery` to `shared_utils/requirements.txt`

TODO: 
* `stop_times` is big, and there is function that uses `dask_bigquery` to read it in and allow the subsetting to happen by departure hour. Wait until later when there's a definite use case how `stop_times` is commonly used to figure out a better function.
* Reorganize `traffic_ops` scripts now into `gtfs_schedule` work, and use these `gtfs_utils` to simplify the prepping of the data 