### PR TITLE
Efficient gtfs utils

### DIFF
--- a/_shared_utils/shared_utils/gtfs_utils.py
+++ b/_shared_utils/shared_utils/gtfs_utils.py
@@ -379,12 +379,12 @@ def get_stop_times(
             )
             >> distinct()
         )
-    # When a pre-existing table is given, convert it to pd.DataFrame
-    # even if a LazyTbl is given
+    # When a pre-existing table is given, leave as LzyTbl
+    # But how to handle pd.DataFrame?
     elif trip_df is not None:
         keep_cols = ["trip_key"]
         if isinstance(trip_df, siuba.sql.verbs.LazyTbl):
-            trips_on_day = trip_df >> collect() >> select(keep_cols)
+            trips_on_day = trip_df >> select(keep_cols)
         elif isinstance(trip_df, pd.DataFrame):
             trips_on_day = trip_df[keep_cols]
 

--- a/_shared_utils/shared_utils/gtfs_utils.py
+++ b/_shared_utils/shared_utils/gtfs_utils.py
@@ -126,7 +126,7 @@ def get_route_info(
     itp_id_list: list[int] = None,
     route_cols: list[str] = None,
     get_df: bool = True,
-) -> pd.DataFrame:
+) -> pd.DataFrame | siuba.sql.verbs.LazyTbl:
 
     # Route info query
     dim_routes = (


### PR DESCRIPTION
* Fix the fact that the entire query for all operators is called in the first query, before filtering down to subset of operators.
* Add back the `gtfs_schedule_index_feed_trip_stops` table for `stop_times`  to filter down to `stop_times` that occurred on that day.
* Rerun HQTA `stop_times` download. Change `stop_times` download to only occur if first 3 files are present and non-empty, to avoid computationally expensive downloads whenever possible. Can debug why any of the first 3 files have empty rows by itself. 
* Allow a `trips pd.DataFrame` to be supplied for queries if needed, and if not, run a fresh query.