### PR TITLE
initial stop freqs table

### DIFF
--- a/ahsc_grant/create_stop_freqs_DRAFT.ipynb
+++ b/ahsc_grant/create_stop_freqs_DRAFT.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbcf5856-259a-4f51-8058-ee9c23e97db5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"CALITP_BQ_MAX_BYTES\"] = str(800_000_000_000) ## 800GB?\n",
+    "pd.set_option('display.max_columns', None) \n",
+    "\n",
+    "from calitp.tables import tbl\n",
+    "from calitp import query_sql\n",
+    "import calitp.magics\n",
+    "import branca\n",
+    "import shared_utils\n",
+    "\n",
+    "from siuba import *\n",
+    "import pandas as pd\n",
+    "\n",
+    "import datetime as dt\n",
+    "import time\n",
+    "\n",
+    "from calitp import get_engine\n",
+    "\n",
+    "engine = get_engine()\n",
+    "connection = engine.connect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9c84e5a-6c1e-46dd-be1e-bfab99eb0fe8",
+   "metadata": {},
+   "source": [
+    "Creating trips per am peak / midday / pm / other by stop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c806291-b1f3-4d8d-9a71-5f8193453257",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set testing parameters - 1 operator, 1 weekday \n",
+    "analysis_dt = dt.date(2022,6,1)\n",
+    "\n",
+    "analysis_operator = 300"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "332ee2b1-4c3c-421a-844c-17313aa54876",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(shared_utils.gtfs_utils.get_stop_times)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f07950f4-be25-4e17-9e3e-8716a35592c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pull trips per stop for each time bucket\n",
+    "## right now returning df, but consider returning dask df \n",
+    "\n",
+    "\n",
+    "stoptimes_ampeak = (shared_utils.gtfs_utils.get_stop_times(\n",
+    "    selected_date = analysis_dt,\n",
+    "    itp_id_list = [analysis_operator],\n",
+    "    departure_hours = (6, 10),\n",
+    "    get_df = True\n",
+    ")\n",
+    "    >> group_by(_.calitp_itp_id,_.stop_id)\n",
+    "    >> summarize(n_trips_ampeak = _.trip_id.count())\n",
+    "                   )\n",
+    "\n",
+    "stoptimes_midday = (shared_utils.gtfs_utils.get_stop_times(\n",
+    "    selected_date = analysis_dt,\n",
+    "    itp_id_list = [analysis_operator],\n",
+    "    departure_hours = (10, 15),\n",
+    "    get_df = True\n",
+    ")\n",
+    "    >> group_by(_.calitp_itp_id,_.stop_id)\n",
+    "    >> summarize(n_trips_midday = _.trip_id.count())\n",
+    "                   )\n",
+    "\n",
+    "stoptimes_pmpeak = (shared_utils.gtfs_utils.get_stop_times(\n",
+    "    selected_date = analysis_dt,\n",
+    "    itp_id_list = [analysis_operator],\n",
+    "    departure_hours = (15, 19),\n",
+    "    get_df = True\n",
+    ")\n",
+    "    >> group_by(_.calitp_itp_id,_.stop_id)\n",
+    "    >> summarize(n_trips_pmpeak = _.trip_id.count())\n",
+    "                   )\n",
+    "\n",
+    "# join by stop id\n",
+    "stoptimes_all = (stoptimes_ampeak\n",
+    "                 >> full_join(_,stoptimes_midday, on = [\"calitp_itp_id\",\"stop_id\"])\n",
+    "                 >> full_join(_,stoptimes_pmpeak, on = [\"calitp_itp_id\",\"stop_id\"])\n",
+    "                )\n",
+    "\n",
+    "del stoptimes_ampeak\n",
+    "del stoptimes_midday\n",
+    "del stoptimes_pmpeak"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30468160-bcd4-4c7a-92eb-6001fb5600e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(stoptimes_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67ba888f-3788-4ce8-92a4-36255bc4277d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Draft of stop-level table w/ columns for buses per am-peak/midday/pm-peak time buckets.

- Currently testing on 1 operator, 1 weekday
- todo: repeat for Sa/Su
- todo: retain stop geography
- As we add all operators, should we use dask dfs instead of pandas dfs? 

Related GH Issue: #302 