### PR TITLE
Better buses on highways

### DIFF
--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -4,3 +4,5 @@ xmltodict==0.13.0
 dask==2022.05.2
 dask_geopandas==0.2.0
 dask-bigquery==2022.05.0
+loguru==0.6.0
+mapclassify==2.4.3

--- a/_shared_utils/shared_utils/gtfs_utils.py
+++ b/_shared_utils/shared_utils/gtfs_utils.py
@@ -540,7 +540,7 @@ def all_routelines_or_stops_with_cached(
     dataset: Literal["routelines", "stops"] = "routelines",
     analysis_date: datetime.date | str = "2022-06-15",
     itp_id_list: list = ALL_ITP_IDS,
-    export_path="gs://calitp-analytics-data/data-analyses/traffic_ops/",
+    export_path="gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/",
 ):
     """
     Use cached files whenever possible, instead of running fresh query.
@@ -572,7 +572,7 @@ def all_trips_or_stoptimes_with_cached(
     dataset: Literal["trips", "st"] = "trips",
     analysis_date: datetime.date | str = "2022-06-15",
     itp_id_list: list = ALL_ITP_IDS,
-    export_path="gs://calitp-analytics-data/data-analyses/traffic_ops/",
+    export_path="gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/",
 ):
     """
     Use cached files whenever possible, instead of running fresh query.

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -12,8 +12,6 @@ import numpy as np
 import pandas as pd
 import shapely
 from calitp import query_sql
-
-# from calitp.tables import tbl
 from numba import jit
 from shared_utils import geography_utils, gtfs_utils, map_utils, utils
 from siuba import *
@@ -154,7 +152,9 @@ def trips_cached(itp_id: int, date_str: str) -> pd.DataFrame:
         return None
 
 
-def get_vehicle_positions(itp_id: int, analysis_date: dt.date) -> pd.DataFrame:
+def get_vehicle_positions(
+    itp_id: int, analysis_date: dt.date, export_path: str | Path = EXPORT_PATH
+) -> pd.DataFrame:
     """
     itp_id: an itp_id (string or integer)
     analysis_date: datetime.date
@@ -216,7 +216,7 @@ def get_vehicle_positions(itp_id: int, analysis_date: dt.date) -> pd.DataFrame:
         # if not dt.datetime.combine(end) < df.vehicle_timestamp.max():
         #     warnings.warn('rt data ends early on analysis date')
 
-        df.to_parquet(f"{EXPORT_PATH}{filename}")
+        df.to_parquet(f"{export_path}{filename}")
         return df
 
 
@@ -250,6 +250,7 @@ def get_trips(
     analysis_date: dt.date,
     force_clear: bool = False,
     route_types: list = None,
+    export_path: str | Path = EXPORT_PATH,
 ) -> pd.DataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -318,7 +319,7 @@ def get_trips(
         trips = trips.drop_duplicates(subset="trip_id").reset_index(drop=True)
 
         if not path or force_clear:
-            trips.to_parquet(f"{EXPORT_PATH}{filename}")
+            trips.to_parquet(f"{export_path}{filename}")
 
     if route_types:
         print(f"filtering to GTFS route types {route_types}")
@@ -328,7 +329,10 @@ def get_trips(
 
 
 def get_stop_times(
-    itp_id: int, analysis_date: dt.date, force_clear: bool = False
+    itp_id: int,
+    analysis_date: dt.date,
+    force_clear: bool = False,
+    export_path: str | Path = EXPORT_PATH,
 ) -> pd.DataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -362,13 +366,16 @@ def get_stop_times(
         departure_hours=None,  # no filtering, return all departure hours
     )
 
-    st.to_parquet(f"{EXPORT_PATH}{filename}")
+    st.to_parquet(f"{export_path}{filename}")
 
     return st
 
 
 def get_stops(
-    itp_id: int, analysis_date: dt.date, force_clear: bool = False
+    itp_id: int,
+    analysis_date: dt.date,
+    force_clear: bool = False,
+    export_path: str | Path = EXPORT_PATH,
 ) -> gpd.GeoDataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -407,13 +414,16 @@ def get_stops(
         crs=geography_utils.CA_NAD83Albers,
     )
 
-    utils.geoparquet_gcs_export(stops, EXPORT_PATH, filename)
+    utils.geoparquet_gcs_export(stops, export_path, filename)
 
     return stops
 
 
 def get_routelines(
-    itp_id: int, analysis_date: dt.date, force_clear: bool = False
+    itp_id: int,
+    analysis_date: dt.date,
+    force_clear: bool = False,
+    export_path: str | Path = EXPORT_PATH,
 ) -> gpd.GeoDataFrame:
 
     date_str = analysis_date.strftime(FULL_DATE_FMT)
@@ -440,7 +450,7 @@ def get_routelines(
             trip_df=trip_df_setting,
         )
 
-        utils.geoparquet_gcs_export(routelines, EXPORT_PATH, filename)
+        utils.geoparquet_gcs_export(routelines, export_path, filename)
 
         return routelines
 

--- a/bus_service_increase/D1_pmac_routes.py
+++ b/bus_service_increase/D1_pmac_routes.py
@@ -14,7 +14,7 @@ import create_parallel_corridors
 import utils
 from shared_utils import gtfs_utils, geography_utils, portfolio_utils, rt_dates
 
-COMPILED_CACHED_GCS = "gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/"
+COMPILED_CACHED_GCS = f"gs://{utils.BUCKET_NAME}/data-analyses/rt_delay/compiled_cached_views/"
 ANALYSIS_DATE = rt_dates.PMAC["Q2_2022"] 
 
 def get_total_service_hours(selected_date):

--- a/bus_service_increase/D1_pmac_routes.py
+++ b/bus_service_increase/D1_pmac_routes.py
@@ -92,4 +92,4 @@ if __name__ == "__main__":
     )    
     
     # Get aggregated service hours by shape_id
-    #get_total_service_hours(ANALYSIS_DATE)
+    get_total_service_hours(ANALYSIS_DATE)

--- a/bus_service_increase/D1_pmac_routes.py
+++ b/bus_service_increase/D1_pmac_routes.py
@@ -14,7 +14,7 @@ import create_parallel_corridors
 import utils
 from shared_utils import gtfs_utils, geography_utils, portfolio_utils, rt_dates
 
-TRAFFIC_OPS_GCS = "gs://calitp-analytics-data/data-analyses/traffic_ops/"
+COMPILED_CACHED_GCS = "gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/"
 ANALYSIS_DATE = rt_dates.PMAC["Q2_2022"] 
 
 def get_total_service_hours(selected_date):
@@ -59,8 +59,8 @@ if __name__ == "__main__":
     # Use concatenated routelines and trips from traffic_ops work
     # Use the datasets with Amtrak added back in (rt_delay always excludes Amtrak)
     routelines = gpd.read_parquet(
-        f"{TRAFFIC_OPS_GCS}routelines_{ANALYSIS_DATE}_all.parquet")
-    trips = pd.read_parquet(f"{TRAFFIC_OPS_GCS}trips_{ANALYSIS_DATE}_all.parquet")
+        f"{COMPILED_CACHED_GCS}routelines_{ANALYSIS_DATE}_all.parquet")
+    trips = pd.read_parquet(f"{COMPILED_CACHED_GCS}trips_{ANALYSIS_DATE}_all.parquet")
     
     shape_id_cols = ["calitp_itp_id", "calitp_url_number", "shape_id"]
     

--- a/bus_service_increase/D2_pmac.ipynb
+++ b/bus_service_increase/D2_pmac.ipynb
@@ -65,9 +65,9 @@
     {
      "data": {
       "text/plain": [
-       "both          2949\n",
+       "both          2913\n",
+       "left_only       36\n",
        "right_only      32\n",
-       "left_only        0\n",
        "Name: _merge, dtype: int64"
       ]
      },
@@ -91,11 +91,11 @@
       "text/plain": [
        "105    17\n",
        "294     5\n",
-       "314     3\n",
        "194     3\n",
+       "314     3\n",
        "127     2\n",
-       "282     1\n",
        "246     1\n",
+       "282     1\n",
        "Name: itp_id, dtype: int64"
       ]
      },
@@ -161,25 +161,25 @@
        "      <th>0</th>\n",
        "      <td>parallel</td>\n",
        "      <td>1997</td>\n",
-       "      <td>67.7</td>\n",
+       "      <td>68.6</td>\n",
        "      <td>71816</td>\n",
-       "      <td>65.7</td>\n",
+       "      <td>66.7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>on_shn</td>\n",
        "      <td>66</td>\n",
-       "      <td>2.2</td>\n",
+       "      <td>2.3</td>\n",
        "      <td>1409</td>\n",
        "      <td>1.3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>other</td>\n",
-       "      <td>886</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>36167</td>\n",
-       "      <td>33.1</td>\n",
+       "      <td>850</td>\n",
+       "      <td>29.2</td>\n",
+       "      <td>34451</td>\n",
+       "      <td>32.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -187,14 +187,14 @@
       ],
       "text/plain": [
        "   category  unique_route  pct_unique_route  total_service_hours  \\\n",
-       "0  parallel          1997              67.7                71816   \n",
-       "2    on_shn            66               2.2                 1409   \n",
-       "1     other           886              30.0                36167   \n",
+       "0  parallel          1997              68.6                71816   \n",
+       "2    on_shn            66               2.3                 1409   \n",
+       "1     other           850              29.2                34451   \n",
        "\n",
        "   pct_total_service_hours  \n",
-       "0                     65.7  \n",
+       "0                     66.7  \n",
        "2                      1.3  \n",
-       "1                     33.1  "
+       "1                     32.0  "
       ]
      },
      "execution_count": 6,
@@ -251,8 +251,8 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>All</td>\n",
-       "      <td>109392</td>\n",
-       "      <td>2949</td>\n",
+       "      <td>107676</td>\n",
+       "      <td>2913</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -260,7 +260,7 @@
       ],
       "text/plain": [
        "  category  total_service_hours  unique_route\n",
-       "0      All               109392          2949"
+       "0      All               107676          2913"
       ]
      },
      "execution_count": 7,
@@ -285,7 +285,7 @@
     {
      "data": {
       "text/plain": [
-       "other    325\n",
+       "other    289\n",
        "Name: category, dtype: int64"
       ]
      },
@@ -627,13 +627,13 @@
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-53ccf579c7db483f9976c709291f6bee\"></div>\n",
+       "<div id=\"altair-viz-508d2feec2ff4edd9a509c7aec3ccc28\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-53ccf579c7db483f9976c709291f6bee\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-53ccf579c7db483f9976c709291f6bee\");\n",
+       "    if (outputDiv.id !== \"altair-viz-508d2feec2ff4edd9a509c7aec3ccc28\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-508d2feec2ff4edd9a509c7aec3ccc28\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -693,13 +693,13 @@
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-d160ca6490344fec95b7740c1a593185\"></div>\n",
+       "<div id=\"altair-viz-42050c1cfab940f7aad6477ff2857e2c\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-d160ca6490344fec95b7740c1a593185\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-d160ca6490344fec95b7740c1a593185\");\n",
+       "    if (outputDiv.id !== \"altair-viz-42050c1cfab940f7aad6477ff2857e2c\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-42050c1cfab940f7aad6477ff2857e2c\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",

--- a/bus_service_increase/D3_historical_pmac.ipynb
+++ b/bus_service_increase/D3_historical_pmac.ipynb
@@ -26,6 +26,16 @@
       "/opt/conda/lib/python3.10/site-packages/geopandas/_compat.py:112: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
       "  warnings.warn(\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "RendererRegistry.enable('html')"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -99,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "2a4f3bb4-d1aa-4f72-acf0-a14dd233d6da",
    "metadata": {},
    "outputs": [
@@ -108,7 +118,7 @@
      "output_type": "stream",
      "text": [
       "Q1_2022: 91271\n",
-      "Q2_2022: 109392\n"
+      "Q2_2022: 107676\n"
      ]
     }
    ],
@@ -119,7 +129,99 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
+   "id": "0e477d05-92c6-421d-b877-fa34648fb768",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>category</th>\n",
+       "      <th>total_service_hours</th>\n",
+       "      <th>unique_route</th>\n",
+       "      <th>pct_total_service_hours</th>\n",
+       "      <th>pct_unique_route</th>\n",
+       "      <th>qtr</th>\n",
+       "      <th>service_date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>parallel</td>\n",
+       "      <td>69435</td>\n",
+       "      <td>1977</td>\n",
+       "      <td>76.1</td>\n",
+       "      <td>75.1</td>\n",
+       "      <td>Q1_2022</td>\n",
+       "      <td>2022-02-08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>on_shn</td>\n",
+       "      <td>1229</td>\n",
+       "      <td>59</td>\n",
+       "      <td>1.3</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>Q1_2022</td>\n",
+       "      <td>2022-02-08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>other</td>\n",
+       "      <td>20607</td>\n",
+       "      <td>596</td>\n",
+       "      <td>22.6</td>\n",
+       "      <td>22.6</td>\n",
+       "      <td>Q1_2022</td>\n",
+       "      <td>2022-02-08</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   category  total_service_hours  unique_route  pct_total_service_hours  \\\n",
+       "0  parallel                69435          1977                     76.1   \n",
+       "2    on_shn                 1229            59                      1.3   \n",
+       "1     other                20607           596                     22.6   \n",
+       "\n",
+       "   pct_unique_route      qtr service_date  \n",
+       "0              75.1  Q1_2022   2022-02-08  \n",
+       "2               2.2  Q1_2022   2022-02-08  \n",
+       "1              22.6  Q1_2022   2022-02-08  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dfs[\"Q1_2022\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "a9be1e56-3364-4476-8e99-0a88e20f11ec",
    "metadata": {},
    "outputs": [],
@@ -167,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "bab7f691-fec3-4c5e-9042-e9ff6d8246a6",
    "metadata": {},
    "outputs": [
@@ -175,47 +277,47 @@
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_02324 th {\n",
+       "#T_51d85 th {\n",
        "  text-align: center;\n",
        "}\n",
-       "#T_02324_row0_col0, #T_02324_row1_col0, #T_02324_row2_col0 {\n",
+       "#T_51d85_row0_col0, #T_51d85_row1_col0, #T_51d85_row2_col0 {\n",
        "  text-align: left;\n",
        "}\n",
-       "#T_02324_row0_col1, #T_02324_row0_col2, #T_02324_row0_col3, #T_02324_row0_col4, #T_02324_row1_col1, #T_02324_row1_col2, #T_02324_row1_col3, #T_02324_row1_col4, #T_02324_row2_col1, #T_02324_row2_col2, #T_02324_row2_col3, #T_02324_row2_col4 {\n",
+       "#T_51d85_row0_col1, #T_51d85_row0_col2, #T_51d85_row0_col3, #T_51d85_row0_col4, #T_51d85_row1_col1, #T_51d85_row1_col2, #T_51d85_row1_col3, #T_51d85_row1_col4, #T_51d85_row2_col1, #T_51d85_row2_col2, #T_51d85_row2_col3, #T_51d85_row2_col4 {\n",
        "  text-align: center;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_02324\">\n",
+       "<table id=\"T_51d85\">\n",
        "  <thead>\n",
        "    <tr>\n",
-       "      <th id=\"T_02324_level0_col0\" class=\"col_heading level0 col0\" >category</th>\n",
-       "      <th id=\"T_02324_level0_col1\" class=\"col_heading level0 col1\" >current</th>\n",
-       "      <th id=\"T_02324_level0_col2\" class=\"col_heading level0 col2\" >prior</th>\n",
-       "      <th id=\"T_02324_level0_col3\" class=\"col_heading level0 col3\" >change</th>\n",
-       "      <th id=\"T_02324_level0_col4\" class=\"col_heading level0 col4\" >pct_change</th>\n",
+       "      <th id=\"T_51d85_level0_col0\" class=\"col_heading level0 col0\" >category</th>\n",
+       "      <th id=\"T_51d85_level0_col1\" class=\"col_heading level0 col1\" >current</th>\n",
+       "      <th id=\"T_51d85_level0_col2\" class=\"col_heading level0 col2\" >prior</th>\n",
+       "      <th id=\"T_51d85_level0_col3\" class=\"col_heading level0 col3\" >change</th>\n",
+       "      <th id=\"T_51d85_level0_col4\" class=\"col_heading level0 col4\" >pct_change</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <td id=\"T_02324_row0_col0\" class=\"data row0 col0\" >parallel</td>\n",
-       "      <td id=\"T_02324_row0_col1\" class=\"data row0 col1\" >71,816</td>\n",
-       "      <td id=\"T_02324_row0_col2\" class=\"data row0 col2\" >69,435</td>\n",
-       "      <td id=\"T_02324_row0_col3\" class=\"data row0 col3\" >2,381</td>\n",
-       "      <td id=\"T_02324_row0_col4\" class=\"data row0 col4\" >0.034</td>\n",
+       "      <td id=\"T_51d85_row0_col0\" class=\"data row0 col0\" >parallel</td>\n",
+       "      <td id=\"T_51d85_row0_col1\" class=\"data row0 col1\" >71,816</td>\n",
+       "      <td id=\"T_51d85_row0_col2\" class=\"data row0 col2\" >69,435</td>\n",
+       "      <td id=\"T_51d85_row0_col3\" class=\"data row0 col3\" >2,381</td>\n",
+       "      <td id=\"T_51d85_row0_col4\" class=\"data row0 col4\" >0.034</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_02324_row1_col0\" class=\"data row1 col0\" >on_shn</td>\n",
-       "      <td id=\"T_02324_row1_col1\" class=\"data row1 col1\" >1,409</td>\n",
-       "      <td id=\"T_02324_row1_col2\" class=\"data row1 col2\" >1,229</td>\n",
-       "      <td id=\"T_02324_row1_col3\" class=\"data row1 col3\" >180</td>\n",
-       "      <td id=\"T_02324_row1_col4\" class=\"data row1 col4\" >0.146</td>\n",
+       "      <td id=\"T_51d85_row1_col0\" class=\"data row1 col0\" >on_shn</td>\n",
+       "      <td id=\"T_51d85_row1_col1\" class=\"data row1 col1\" >1,409</td>\n",
+       "      <td id=\"T_51d85_row1_col2\" class=\"data row1 col2\" >1,229</td>\n",
+       "      <td id=\"T_51d85_row1_col3\" class=\"data row1 col3\" >180</td>\n",
+       "      <td id=\"T_51d85_row1_col4\" class=\"data row1 col4\" >0.146</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_02324_row2_col0\" class=\"data row2 col0\" >other</td>\n",
-       "      <td id=\"T_02324_row2_col1\" class=\"data row2 col1\" >36,167</td>\n",
-       "      <td id=\"T_02324_row2_col2\" class=\"data row2 col2\" >20,607</td>\n",
-       "      <td id=\"T_02324_row2_col3\" class=\"data row2 col3\" >15,560</td>\n",
-       "      <td id=\"T_02324_row2_col4\" class=\"data row2 col4\" >0.755</td>\n",
+       "      <td id=\"T_51d85_row2_col0\" class=\"data row2 col0\" >other</td>\n",
+       "      <td id=\"T_51d85_row2_col1\" class=\"data row2 col1\" >34,451</td>\n",
+       "      <td id=\"T_51d85_row2_col2\" class=\"data row2 col2\" >20,607</td>\n",
+       "      <td id=\"T_51d85_row2_col3\" class=\"data row2 col3\" >13,844</td>\n",
+       "      <td id=\"T_51d85_row2_col4\" class=\"data row2 col4\" >0.672</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
@@ -234,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "24373ead-01da-4f97-afc1-77a780a16109",
    "metadata": {},
    "outputs": [
@@ -242,47 +344,47 @@
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_1f38c th {\n",
+       "#T_8252e th {\n",
        "  text-align: center;\n",
        "}\n",
-       "#T_1f38c_row0_col0, #T_1f38c_row1_col0, #T_1f38c_row2_col0 {\n",
+       "#T_8252e_row0_col0, #T_8252e_row1_col0, #T_8252e_row2_col0 {\n",
        "  text-align: left;\n",
        "}\n",
-       "#T_1f38c_row0_col1, #T_1f38c_row0_col2, #T_1f38c_row0_col3, #T_1f38c_row0_col4, #T_1f38c_row1_col1, #T_1f38c_row1_col2, #T_1f38c_row1_col3, #T_1f38c_row1_col4, #T_1f38c_row2_col1, #T_1f38c_row2_col2, #T_1f38c_row2_col3, #T_1f38c_row2_col4 {\n",
+       "#T_8252e_row0_col1, #T_8252e_row0_col2, #T_8252e_row0_col3, #T_8252e_row0_col4, #T_8252e_row1_col1, #T_8252e_row1_col2, #T_8252e_row1_col3, #T_8252e_row1_col4, #T_8252e_row2_col1, #T_8252e_row2_col2, #T_8252e_row2_col3, #T_8252e_row2_col4 {\n",
        "  text-align: center;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_1f38c\">\n",
+       "<table id=\"T_8252e\">\n",
        "  <thead>\n",
        "    <tr>\n",
-       "      <th id=\"T_1f38c_level0_col0\" class=\"col_heading level0 col0\" >category</th>\n",
-       "      <th id=\"T_1f38c_level0_col1\" class=\"col_heading level0 col1\" >current</th>\n",
-       "      <th id=\"T_1f38c_level0_col2\" class=\"col_heading level0 col2\" >prior</th>\n",
-       "      <th id=\"T_1f38c_level0_col3\" class=\"col_heading level0 col3\" >change</th>\n",
-       "      <th id=\"T_1f38c_level0_col4\" class=\"col_heading level0 col4\" >pct_change</th>\n",
+       "      <th id=\"T_8252e_level0_col0\" class=\"col_heading level0 col0\" >category</th>\n",
+       "      <th id=\"T_8252e_level0_col1\" class=\"col_heading level0 col1\" >current</th>\n",
+       "      <th id=\"T_8252e_level0_col2\" class=\"col_heading level0 col2\" >prior</th>\n",
+       "      <th id=\"T_8252e_level0_col3\" class=\"col_heading level0 col3\" >change</th>\n",
+       "      <th id=\"T_8252e_level0_col4\" class=\"col_heading level0 col4\" >pct_change</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <td id=\"T_1f38c_row0_col0\" class=\"data row0 col0\" >parallel</td>\n",
-       "      <td id=\"T_1f38c_row0_col1\" class=\"data row0 col1\" >1,997</td>\n",
-       "      <td id=\"T_1f38c_row0_col2\" class=\"data row0 col2\" >1,977</td>\n",
-       "      <td id=\"T_1f38c_row0_col3\" class=\"data row0 col3\" >20</td>\n",
-       "      <td id=\"T_1f38c_row0_col4\" class=\"data row0 col4\" >0.010</td>\n",
+       "      <td id=\"T_8252e_row0_col0\" class=\"data row0 col0\" >parallel</td>\n",
+       "      <td id=\"T_8252e_row0_col1\" class=\"data row0 col1\" >1,997</td>\n",
+       "      <td id=\"T_8252e_row0_col2\" class=\"data row0 col2\" >1,977</td>\n",
+       "      <td id=\"T_8252e_row0_col3\" class=\"data row0 col3\" >20</td>\n",
+       "      <td id=\"T_8252e_row0_col4\" class=\"data row0 col4\" >0.010</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_1f38c_row1_col0\" class=\"data row1 col0\" >on_shn</td>\n",
-       "      <td id=\"T_1f38c_row1_col1\" class=\"data row1 col1\" >66</td>\n",
-       "      <td id=\"T_1f38c_row1_col2\" class=\"data row1 col2\" >59</td>\n",
-       "      <td id=\"T_1f38c_row1_col3\" class=\"data row1 col3\" >7</td>\n",
-       "      <td id=\"T_1f38c_row1_col4\" class=\"data row1 col4\" >0.119</td>\n",
+       "      <td id=\"T_8252e_row1_col0\" class=\"data row1 col0\" >on_shn</td>\n",
+       "      <td id=\"T_8252e_row1_col1\" class=\"data row1 col1\" >66</td>\n",
+       "      <td id=\"T_8252e_row1_col2\" class=\"data row1 col2\" >59</td>\n",
+       "      <td id=\"T_8252e_row1_col3\" class=\"data row1 col3\" >7</td>\n",
+       "      <td id=\"T_8252e_row1_col4\" class=\"data row1 col4\" >0.119</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_1f38c_row2_col0\" class=\"data row2 col0\" >other</td>\n",
-       "      <td id=\"T_1f38c_row2_col1\" class=\"data row2 col1\" >886</td>\n",
-       "      <td id=\"T_1f38c_row2_col2\" class=\"data row2 col2\" >596</td>\n",
-       "      <td id=\"T_1f38c_row2_col3\" class=\"data row2 col3\" >290</td>\n",
-       "      <td id=\"T_1f38c_row2_col4\" class=\"data row2 col4\" >0.487</td>\n",
+       "      <td id=\"T_8252e_row2_col0\" class=\"data row2 col0\" >other</td>\n",
+       "      <td id=\"T_8252e_row2_col1\" class=\"data row2 col1\" >850</td>\n",
+       "      <td id=\"T_8252e_row2_col2\" class=\"data row2 col2\" >596</td>\n",
+       "      <td id=\"T_8252e_row2_col3\" class=\"data row2 col3\" >254</td>\n",
+       "      <td id=\"T_8252e_row2_col4\" class=\"data row2 col4\" >0.426</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
@@ -301,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "aef85c8c-8677-4373-a218-9cac0510a45f",
    "metadata": {},
    "outputs": [],
@@ -332,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "49ff1d75-b455-4fe4-9c95-c4a1b53ce24d",
    "metadata": {},
    "outputs": [
@@ -340,13 +442,13 @@
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-2732cedca7f24b0b9db514e89debc56c\"></div>\n",
+       "<div id=\"altair-viz-6489ff7a7b4b411393c0836c648e061a\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-2732cedca7f24b0b9db514e89debc56c\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-2732cedca7f24b0b9db514e89debc56c\");\n",
+       "    if (outputDiv.id !== \"altair-viz-6489ff7a7b4b411393c0836c648e061a\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-6489ff7a7b4b411393c0836c648e061a\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -392,14 +494,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-4083d1250d5972c7fb73b13015544886\"}, \"mark\": \"bar\", \"encoding\": {\"color\": {\"field\": \"qtr\", \"scale\": {\"range\": [\"#2EA8CE\", \"#EB9F3C\", \"#F4D837\", \"#51BF9D\", \"#8CBCCB\", \"#9487C0\"]}, \"type\": \"nominal\"}, \"column\": {\"field\": \"category\", \"sort\": [\"Parallel\", \"On SHN\", \"Other\"], \"title\": \"Category\", \"type\": \"nominal\"}, \"x\": {\"field\": \"qtr\", \"title\": \"\", \"type\": \"nominal\"}, \"y\": {\"field\": \"total_service_hours\", \"title\": \"Total Service Hours\", \"type\": \"quantitative\"}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-4083d1250d5972c7fb73b13015544886\": [{\"category\": \"Parallel\", \"total_service_hours\": 69435, \"unique_route\": 1977, \"pct_total_service_hours\": 76.1, \"pct_unique_route\": 75.1, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1229, \"unique_route\": 59, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.1999999999999997, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 20607, \"unique_route\": 596, \"pct_total_service_hours\": 22.6, \"pct_unique_route\": 22.6, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Parallel\", \"total_service_hours\": 71816, \"unique_route\": 1997, \"pct_total_service_hours\": 65.7, \"pct_unique_route\": 67.7, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1409, \"unique_route\": 66, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.1999999999999997, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 36167, \"unique_route\": 886, \"pct_total_service_hours\": 33.1, \"pct_unique_route\": 30.0, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-9135605bad3c4dc5c8e491e70c71fcf5\"}, \"mark\": \"bar\", \"encoding\": {\"color\": {\"field\": \"qtr\", \"scale\": {\"range\": [\"#2EA8CE\", \"#EB9F3C\", \"#F4D837\", \"#51BF9D\", \"#8CBCCB\", \"#9487C0\"]}, \"type\": \"nominal\"}, \"column\": {\"field\": \"category\", \"sort\": [\"Parallel\", \"On SHN\", \"Other\"], \"title\": \"Category\", \"type\": \"nominal\"}, \"x\": {\"field\": \"qtr\", \"title\": \"\", \"type\": \"nominal\"}, \"y\": {\"field\": \"total_service_hours\", \"title\": \"Total Service Hours\", \"type\": \"quantitative\"}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-9135605bad3c4dc5c8e491e70c71fcf5\": [{\"category\": \"Parallel\", \"total_service_hours\": 69435, \"unique_route\": 1977, \"pct_total_service_hours\": 76.1, \"pct_unique_route\": 75.1, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1229, \"unique_route\": 59, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.1999999999999997, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 20607, \"unique_route\": 596, \"pct_total_service_hours\": 22.6, \"pct_unique_route\": 22.6, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Parallel\", \"total_service_hours\": 71816, \"unique_route\": 1997, \"pct_total_service_hours\": 66.7, \"pct_unique_route\": 68.60000000000001, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1409, \"unique_route\": 66, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.3, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 34451, \"unique_route\": 850, \"pct_total_service_hours\": 32.0, \"pct_unique_route\": 29.2, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -412,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "797144d7-9822-470c-b13c-a3beca5d7c09",
    "metadata": {},
    "outputs": [
@@ -420,13 +522,13 @@
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-bdcd576528774172af872c547bcacc8c\"></div>\n",
+       "<div id=\"altair-viz-7e8246b4f67e4d71807620539057d406\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
        "  (function(spec, embedOpt){\n",
        "    let outputDiv = document.currentScript.previousElementSibling;\n",
-       "    if (outputDiv.id !== \"altair-viz-bdcd576528774172af872c547bcacc8c\") {\n",
-       "      outputDiv = document.getElementById(\"altair-viz-bdcd576528774172af872c547bcacc8c\");\n",
+       "    if (outputDiv.id !== \"altair-viz-7e8246b4f67e4d71807620539057d406\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-7e8246b4f67e4d71807620539057d406\");\n",
        "    }\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
@@ -472,14 +574,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-4083d1250d5972c7fb73b13015544886\"}, \"mark\": \"bar\", \"encoding\": {\"color\": {\"field\": \"qtr\", \"scale\": {\"range\": [\"#2EA8CE\", \"#EB9F3C\", \"#F4D837\", \"#51BF9D\", \"#8CBCCB\", \"#9487C0\"]}, \"type\": \"nominal\"}, \"column\": {\"field\": \"category\", \"sort\": [\"Parallel\", \"On SHN\", \"Other\"], \"title\": \"Category\", \"type\": \"nominal\"}, \"x\": {\"field\": \"qtr\", \"title\": \"\", \"type\": \"nominal\"}, \"y\": {\"field\": \"unique_route\", \"title\": \"Unique Route\", \"type\": \"quantitative\"}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-4083d1250d5972c7fb73b13015544886\": [{\"category\": \"Parallel\", \"total_service_hours\": 69435, \"unique_route\": 1977, \"pct_total_service_hours\": 76.1, \"pct_unique_route\": 75.1, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1229, \"unique_route\": 59, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.1999999999999997, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 20607, \"unique_route\": 596, \"pct_total_service_hours\": 22.6, \"pct_unique_route\": 22.6, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Parallel\", \"total_service_hours\": 71816, \"unique_route\": 1997, \"pct_total_service_hours\": 65.7, \"pct_unique_route\": 67.7, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1409, \"unique_route\": 66, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.1999999999999997, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 36167, \"unique_route\": 886, \"pct_total_service_hours\": 33.1, \"pct_unique_route\": 30.0, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-9135605bad3c4dc5c8e491e70c71fcf5\"}, \"mark\": \"bar\", \"encoding\": {\"color\": {\"field\": \"qtr\", \"scale\": {\"range\": [\"#2EA8CE\", \"#EB9F3C\", \"#F4D837\", \"#51BF9D\", \"#8CBCCB\", \"#9487C0\"]}, \"type\": \"nominal\"}, \"column\": {\"field\": \"category\", \"sort\": [\"Parallel\", \"On SHN\", \"Other\"], \"title\": \"Category\", \"type\": \"nominal\"}, \"x\": {\"field\": \"qtr\", \"title\": \"\", \"type\": \"nominal\"}, \"y\": {\"field\": \"unique_route\", \"title\": \"Unique Route\", \"type\": \"quantitative\"}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-9135605bad3c4dc5c8e491e70c71fcf5\": [{\"category\": \"Parallel\", \"total_service_hours\": 69435, \"unique_route\": 1977, \"pct_total_service_hours\": 76.1, \"pct_unique_route\": 75.1, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1229, \"unique_route\": 59, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.1999999999999997, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 20607, \"unique_route\": 596, \"pct_total_service_hours\": 22.6, \"pct_unique_route\": 22.6, \"qtr\": \"Q1\", \"service_date\": \"2022-02-08\", \"year\": 2022}, {\"category\": \"Parallel\", \"total_service_hours\": 71816, \"unique_route\": 1997, \"pct_total_service_hours\": 66.7, \"pct_unique_route\": 68.60000000000001, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"On SHN\", \"total_service_hours\": 1409, \"unique_route\": 66, \"pct_total_service_hours\": 1.3, \"pct_unique_route\": 2.3, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}, {\"category\": \"Other\", \"total_service_hours\": 34451, \"unique_route\": 850, \"pct_total_service_hours\": 32.0, \"pct_unique_route\": 29.2, \"qtr\": \"Q2\", \"service_date\": \"2022-05-04\", \"year\": 2022}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/bus_service_increase/G2_aggregated_stats.py
+++ b/bus_service_increase/G2_aggregated_stats.py
@@ -27,8 +27,7 @@ from utils import GCS_FILE_PATH
 
 ANALYSIS_DATE = rt_dates.DATES["may2022"]
 catalog = intake.open_catalog("*.yml")
-TRAFFIC_OPS_GCS = 'gs://calitp-analytics-data/data-analyses/traffic_ops/'
-
+COMPILED_CACHED_GCS = "gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/"
 
 def subset_trips_and_stop_times(trips: dd.DataFrame, 
                                 stop_times: dd.DataFrame,
@@ -295,14 +294,14 @@ if __name__=="__main__":
         dataset="st",
         analysis_date = ANALYSIS_DATE,
         itp_id_list = keep_itp_ids,
-        export_path = GCS_FILE_PATH
+        export_path = COMPILED_CACHED_GCS
     )
     
     # stops already cached for 5/4
     '''
     # (2) Combine stop_times and trips, and filter to routes that appear in bus_routes
-    stop_times = dd.read_parquet(f"{GCS_FILE_PATH}st_{ANALYSIS_DATE}.parquet")
-    trips = dd.read_parquet(f"{TRAFFIC_OPS_GCS}trips_{ANALYSIS_DATE}.parquet")
+    stop_times = dd.read_parquet(f"{COMPILED_CACHED_GCS}st_{ANALYSIS_DATE}.parquet")
+    trips = dd.read_parquet(f"{COMPILED_CACHED_GCS}trips_{ANALYSIS_DATE}.parquet")
         
     # Subset stop times and merge with trips
     stop_times_with_hr = subset_trips_and_stop_times(

--- a/bus_service_increase/G2_aggregated_stats.py
+++ b/bus_service_increase/G2_aggregated_stats.py
@@ -310,15 +310,16 @@ if __name__=="__main__":
         itp_id_list = keep_itp_ids, 
         route_list = keep_routes
     )
+    
+    stop_times_with_hr.compute().to_parquet(f"./data/stop_times_for_routes_on_shn.parquet")
 
     # (3) Aggregate to route-level
     route_cols = ["calitp_itp_id", "service_date", "route_id"]
     
-    # (3a) All stops on route
-    by_route_all_stops = compile_peak_all_day_aggregated_stats(
-        stop_times_with_hr, route_cols)
+    by_route = compile_peak_all_day_aggregated_stats(
+        stop_times_with_hr, route_cols, stat_cols = {"trip_id": "nunique"})
     
-    by_route_all_stops.to_parquet(
+    by_route.to_parquet(
         f"{GCS_FILE_PATH}bus_routes_on_hwys_aggregated_stats.parquet")    
     
     

--- a/bus_service_increase/G2_aggregated_stats.py
+++ b/bus_service_increase/G2_aggregated_stats.py
@@ -78,32 +78,50 @@ def subset_trips_and_stop_times(trips: dd.DataFrame,
 
 def aggregate_stat_by_time_of_day(df: dd.DataFrame, 
                                   group_cols: list, 
-                                  stat_col: dict = {"trip_id": "nunique"}
-                                 ) -> dd.DataFrame:
+                                  stat_cols: dict = {"trip_id": "nunique", 
+                                                    "departure_hour": "count",
+                                                    "stop_id": "nunique"}
+                                 ) -> pd.DataFrame:
     """
     Aggregate given different group_cols.
-    
-    Avoid merging together, since dask df requires setting of metadata,
-    and there isn't an easy way to pre-define what the metadata is in group_cols
     """    
-    for key, value in stat_col.items():
-        use_col = key
-        agg = value
-        
-    # nunique seems to not work in groupby.agg
-    # even though https://github.com/dask/dask/pull/8479 seems to resolve it?
-    # alternative is to use nunique as series
-    if agg=="nunique":
-        agg_df = (df.groupby(group_cols)[use_col].nunique()
+    
+    def group_and_aggregate(df: dd.DataFrame, 
+                            group_cols: list, 
+                            agg_col: str, agg_func: str) -> pd.DataFrame:
+        # nunique seems to not work in groupby.agg
+        # even though https://github.com/dask/dask/pull/8479 seems to resolve it?
+        # alternative is to use nunique as series
+        if agg_func=="nunique":
+            agg_df = (df.groupby(group_cols)[agg_col].nunique()
                     .reset_index()
                  )
-    else:
-        agg_df = (df.groupby(group_cols)
-                .agg({use_col: agg})
-                .reset_index()
-                 )
+        else:
+            agg_df = (df.groupby(group_cols)
+                      .agg({agg_col: agg_func})
+                      .reset_index()
+                     )
         
-    return agg_df
+        # return pd.DataFrame for now, since it's not clear what the metadata should be
+        # if we are inputting different things in stats_col
+        return agg_df.compute()
+    
+    final = pd.DataFrame()
+    
+    for agg_col, agg_func in stat_cols.items():
+        agg_df = group_and_aggregate(df, group_cols, agg_col, agg_func)
+        
+        # If it's empty, just add our new table of aggregations in with concat
+        if final.empty:
+            final = pd.concat([final, agg_df], axis=0, ignore_index=True)
+        
+        # If it's not empty, do a merge
+        else:
+            final = pd.merge(
+                final, agg_df, on = group_cols, how = "left"
+            )
+    
+    return final
         
 
 def reshape_long_to_wide(df: pd.DataFrame, 
@@ -149,7 +167,10 @@ def reshape_long_to_wide(df: pd.DataFrame,
     return reshaped
 
 
-def long_to_wide_format(df: pd.DataFrame, group_cols: list) -> pd.DataFrame:
+def long_to_wide_format(df: pd.DataFrame, 
+                        group_cols: list, 
+                        stat_cols: list = ["trips", "stop_arrivals", "stops"]
+                       ) -> pd.DataFrame:
     """
     Take the long df, which is structured where each row is 
     a route_id-time_of_day combination, and columns are 
@@ -166,46 +187,75 @@ def long_to_wide_format(df: pd.DataFrame, group_cols: list) -> pd.DataFrame:
     # doing a sum of nunique across categories is not the same as counting nunique over a larger group
     time_of_day_sorted = ['peak', 'all_day']
     
-    df_wide = reshape_long_to_wide(
-        df, group_cols = group_cols, 
-        long_col = "time_of_day", 
-        value_col="trips", long_col_sort_order = time_of_day_sorted)
+    df_wide = pd.DataFrame()
     
+    for c in stat_cols:
+        one_stat_wide = reshape_long_to_wide(
+            df, group_cols = group_cols,
+            long_col = "time_of_day",
+            value_col = c, long_col_sort_order = time_of_day_sorted
+        )
+        
+        # for the first column to reshape, just concatenate it
+        if df_wide.empty:
+            df_wide = pd.concat([df_wide, one_stat_wide], axis=0)
+        else:
+            df_wide = pd.merge(
+                df_wide,
+                one_stat_wide, 
+                on = group_cols,
+                how = "left"
+            )
     
     return df_wide
 
 
-def compile_all_aggregated_stats(stop_times_with_time_of_day: dd.DataFrame,
-                                 group_cols: list
-                                ) -> pd.DataFrame:
-        
+def compile_peak_all_day_aggregated_stats(
+    stop_times_with_time_of_day: dd.DataFrame,
+    group_cols: list,
+    stat_cols: dict = {"trip_id": "nunique", 
+                       "departure_hour": "count", 
+                       "stop_id": "nunique"}) -> pd.DataFrame:
+    
+    rename_aggregated_cols = {
+        "trip_id": "trips", 
+        "departure_hour": "stop_arrivals",
+        "stop_id": "stops"
+    }
+    
+    # Peak Hours
     peak_bins = ["AM Peak", "PM Peak"]
     
     stop_times_peak = stop_times_with_time_of_day[
         stop_times_with_time_of_day.time_of_day.isin(peak_bins)
     ].assign(time_of_day="peak")
-
-    by_route_peak = aggregate_stat_by_time_of_day(
+    
+    peak_table = aggregate_stat_by_time_of_day(
         stop_times_peak, 
         group_cols + ["time_of_day"], 
-        stat_col = {"trip_id": "nunique"}
-    ).rename(columns = {"trip_id": "trips"}).compute()
-    
-
+        stat_cols = stat_cols
+    ).rename(columns = rename_aggregated_cols)
+        
+    # All day    
     stop_times_all_day = stop_times_with_time_of_day.assign(time_of_day="all_day")
 
-    by_route_all_day = aggregate_stat_by_time_of_day(
+    all_day_table = aggregate_stat_by_time_of_day(
         stop_times_all_day, 
         group_cols + ["time_of_day"],
-        stat_col = {"trip_id": "nunique"}
-    ).rename(columns = {"trip_id": "trips"}).compute()
+        stat_cols = stat_cols
+    ).rename(columns = rename_aggregated_cols)
 
-    by_route = pd.concat(
-        [by_route_peak, by_route_all_day], axis=0)
+    df = pd.concat(
+        [peak_table, all_day_table], axis=0)
     
-    by_route_wide = long_to_wide_format(by_route, group_cols)
+    # Reshape from long to wide (do it for each aggregated stat separately and merge)
+    aggregated_stats_cols = [c for c in df.columns if c not in group_cols and 
+                             c != "time_of_day"]
+    
+    df_wide = long_to_wide_format(df, group_cols, 
+                                  stat_cols = aggregated_stats_cols)
 
-    return by_route_wide
+    return df_wide
 
 
 def get_competitive_routes() -> pd.DataFrame:
@@ -265,7 +315,8 @@ if __name__=="__main__":
     route_cols = ["calitp_itp_id", "service_date", "route_id"]
     
     # (3a) All stops on route
-    by_route_all_stops = compile_all_aggregated_stats(stop_times_with_hr, route_cols)
+    by_route_all_stops = compile_peak_all_day_aggregated_stats(
+        stop_times_with_hr, route_cols)
     
     by_route_all_stops.to_parquet(
         f"{GCS_FILE_PATH}bus_routes_on_hwys_aggregated_stats.parquet")    

--- a/bus_service_increase/G3_highway_segment_stats.py
+++ b/bus_service_increase/G3_highway_segment_stats.py
@@ -1,26 +1,44 @@
 """
 Compile route-level data for mapping / viz?
 """
+import dask.dataframe as dd
 import intake
 import geopandas as gpd
 import pandas as pd
 
+import G2_aggregated_stats
 from shared_utils import geography_utils, utils
 from utils import GCS_FILE_PATH
+from G1_get_buses_on_shn import ANALYSIS_DATE, TRAFFIC_OPS_GCS
 
 catalog = intake.open_catalog("*.yml")
 
 highway_cols = ["District", "County", "Route", "RouteType", "hwy_segment_id"]
 route_cols = ["calitp_itp_id", "route_id"]
+route_segment_cols = route_cols + ["hwy_segment_id"]
 
 
-def sjoin_route_stats_to_highway_segments(
-    highways: gpd.GeoDataFrame, bus_routes: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+def draw_buffer(gdf: gpd.GeoDataFrame, buffer: int = 50):
+    gdf2 = gdf.to_crs(geography_utils.CA_StatePlane)
+    
+    gdf_poly = gdf2.assign(
+        geometry = gdf2.geometry.buffer(buffer)
+    )
+    
+    return gdf_poly
+
+
+def sjoin_bus_routes_to_hwy_segments(highways: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """
     Highways segments are for all CA.
     Bus routes contains the routes where at least 50% of route runs on SHN.
     """
-    # Spatial join to find the highway segments with buses that run on SHN    
+    bus_routes = catalog.bus_routes_on_hwys.read().rename(
+        columns = {"itp_id": "calitp_itp_id"})
+    
+    # Spatial join to find the highway segments with buses that run on SHN  
+    # Highways is polygon, bus_routes is linestring 
+    # Put highways on left because that's the geom I want to keep
     s1 = gpd.sjoin(
         highways[highway_cols + ["geometry"]].drop_duplicates(),
         bus_routes[route_cols + ["geometry"]].drop_duplicates(),
@@ -31,58 +49,113 @@ def sjoin_route_stats_to_highway_segments(
     return s1 
 
 
-def aggregate_to_hwy_segments(highway_segments: gpd.GeoDataFrame, 
-                              route_stats: pd.DataFrame) -> gpd.GeoDataFrame:
+def spatial_join_stops_to_highway_segments(
+    highways: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Spatial join highway segments polygon to stops.
+    """
+    stops = gpd.read_parquet(f"{TRAFFIC_OPS_GCS}stops_{ANALYSIS_DATE}.parquet")
     
-    segments_with_route_stats = pd.merge(
-        highway_segments,
-        route_stats,
-        on = route_cols,
+    stops_on_hwys = gpd.sjoin(
+        stops.to_crs(geography_utils.CA_StatePlane), 
+        highways.to_crs(geography_utils.CA_StatePlane)[["hwy_segment_id", "geometry"]],
         how = "inner",
-        validate = "m:1"
+        predicate="intersects"
+    ).drop(columns = "index_right")
+
+    # Only keep sjoin if it's the same calitp_itp_id
+    stops_on_hwys2 = (stops_on_hwys.drop_duplicates(
+        subset=["calitp_itp_id", "stop_id", "hwy_segment_id"]
+        ).reset_index(drop=True)
     )
+    
+    return stops_on_hwys2
+
+
+def aggregate_to_hwy_segment(gdf: gpd.GeoDataFrame, 
+                             group_cols: list) -> gpd.GeoDataFrame:
     
     sum_cols = [
-        "trips_peak", "trips_all_day", 
-        "stop_arrivals_peak", "stop_arrivals_all_day",
-        "stops_peak", "stops_all_day"
+        'trips_peak', 'trips_all_day', 
+        'stop_arrivals_peak', 'stop_arrivals_all_day',
+        'stops_peak', 'stops_all_day'
     ]
     
-    segment_stats = geography_utils.aggregate_by_geography(
-        segments_with_route_stats,
-        group_cols = highway_cols + ["service_date"],
+    segment = geography_utils.aggregate_by_geography(
+        gdf,
+        group_cols = group_cols,
         sum_cols = sum_cols,
-        nunique_cols = route_cols,
-    ).rename(columns = {"calitp_itp_id": "num_itp_id", 
-                        "route_id": "num_route_id"})
-
-    segment_stats2 = geography_utils.attach_geometry(
-        segment_stats,
-        segments_with_route_stats[highway_cols + ["geometry"]].drop_duplicates(),
-        merge_col = highway_cols,
-        join="inner"
     )
     
-    return segment_stats2
-
+    segment_with_geom = geography_utils.attach_geometry(
+        segment,
+        gdf[group_cols + ["geometry"]].drop_duplicates(),
+        merge_col = group_cols,
+        join = "inner"
+    )
+    
+    segment_with_geom[sum_cols] = segment_with_geom[sum_cols].astype(int)
+    segment_with_geom = segment_with_geom.reindex(columns = group_cols + 
+                                                  sum_cols + ["geometry"])
+    
+    return segment_with_geom
+    
 
 if __name__=="__main__":
 
-    # (1) Spatial join to keep highway segments that have buses running on SHN
-    bus_routes = catalog.bus_routes_on_hwys.read().rename(
-        columns = {"itp_id": "calitp_itp_id"})
-
+    # (1) Highway segments, draw buffer of 50 ft
     highways = catalog.segmented_highways.read()
+    highways_polygon = draw_buffer(highways, buffer=50)
     
-    highways_with_buses = sjoin_route_stats_to_highway_segments(
-        highways, bus_routes)
+    # (2) Spatial join to keep highway segments that have buses running on SHN
+    highway_segments_with_bus = sjoin_bus_routes_to_hwy_segments(highways_polygon)
     
-    # (2) Just use stats at route-level for stops that actually fall on SHN
-    stats_on_hwy = catalog.bus_stops_aggregated_stats.read()
+    # (3) Spatial join stops to highway segments
+    stops_on_hwy = spatial_join_stops_to_highway_segments(highways_polygon)
     
-    highway_stats = aggregate_to_hwy_segments(
-        highways_with_buses, stats_on_hwy)
+    # (4a) Filter the stop_times table down to stops attached to hwy segments
+    stop_times_with_hr = catalog.stop_times_for_routes_on_shn.read()
     
-    utils.geoparquet_gcs_export(highway_stats, 
+    stop_times_on_hwy = pd.merge(
+        stop_times_with_hr, 
+        stops_on_hwy[["calitp_itp_id", "stop_id", "hwy_segment_id"]],
+        on = ["calitp_itp_id", "stop_id"],
+        how = "inner"
+    )
+    
+    stop_times_on_hwy = dd.from_pandas(stop_times_on_hwy, npartitions=1)
+    
+    # (4b) Aggregate stops and stop_times to segments 
+    by_route_segment = G2_aggregated_stats.compile_peak_all_day_aggregated_stats(
+        stop_times_on_hwy, route_segment_cols, 
+        stat_cols = {"departure_hour": "count", 
+                     "stop_id": "nunique"})
+    
+    # (5) Merge in the trip, stop_times, and stops aggregated stats
+    # (5a) Merge in trip stats at route-level 
+    route_stats = catalog.bus_routes_aggregated_stats.read()
+    
+    keep_cols = route_cols + ["service_date", "trips_peak", "trips_all_day"]
+    
+    segments_with_trips = pd.merge(
+        highway_segments_with_bus, 
+        route_stats[keep_cols],
+        on = route_cols,
+        how = "inner",
+    )
+    
+    # (5b) Merge in stop_times and stops by segment
+    segments_with_stops = pd.merge(
+        segments_with_trips,
+        by_route_segment,
+        on = route_segment_cols,
+        how = "left"
+    )
+    
+    # (5c) Now aggregate to hwy_segment_id, since there can be multiple routes 
+    # on same segment_id
+    segments_with_geom = aggregate_to_hwy_segment(segments_with_stops, highway_cols)
+
+    utils.geoparquet_gcs_export(segments_with_geom, 
                                 GCS_FILE_PATH, 
                                 "highway_segment_stats")

--- a/bus_service_increase/G4_plot-segments.ipynb
+++ b/bus_service_increase/G4_plot-segments.ipynb
@@ -1,0 +1,125 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b7100acd-128a-4083-9e40-a33dee118238",
+   "metadata": {},
+   "source": [
+    "# Plot routes on SHN\n",
+    "\n",
+    "See what highway corridors show up.\n",
+    "\n",
+    "Can span multiple operators. These corridors, if improved, would benefit all operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4142b039-4dad-444c-aed2-3e43ee4a88c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#import branca\n",
+    "import intake\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "\n",
+    "#import create_calenviroscreen_lehd_data\n",
+    "from shared_utils import geography_utils #, map_utils \n",
+    "\n",
+    "catalog = intake.open_catalog(\"*.yml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51d19063-62e0-47a8-a431-7e322b626d7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = catalog.highway_segment_stats.read()\n",
+    "\n",
+    "gdf = gdf.assign(\n",
+    "    geometry = gdf.geometry.to_crs(\n",
+    "        geography_utils.CA_StatePlane).buffer(300).to_crs(geography_utils.WGS84)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "920ad16f-1e95-40b6-b879-90524a21e832",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_highway_corridor(gdf, hwy_route, plot_col):\n",
+    "\n",
+    "    plot_df = gdf[gdf.Route==hwy_route]\n",
+    "    \n",
+    "    #plot_df = create_calenviroscreen_lehd_data.define_equity_groups(\n",
+    "    #    plot_df, percentile_col = [plot_col], num_groups=4)\n",
+    "    \n",
+    "    \n",
+    "    m = plot_df.explore(plot_col, cmap = \"cividis\", \n",
+    "                        tiles = \"CartoDB positron\")\n",
+    "    \n",
+    "    display(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abf0ca2b-c907-492c-a210-755465ae9a8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for stat in [\"trips_all_day\", \"stop_arrivals_peak\", \"stops_all_day\"]:\n",
+    "    print(f\"{stat.replace('_', ' ').title()}\")\n",
+    "    plot_highway_corridor(gdf[gdf.District.isin([7, 12])], \n",
+    "                          hwy_route=1, plot_col=stat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ab773f5-7374-4215-96f5-399b4f70f73c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for stat in [\"trips_all_day\", \"stop_arrivals_peak\", \"stops_all_day\"]:\n",
+    "    print(f\"{stat.replace('_', ' ').title()}\")\n",
+    "    plot_highway_corridor(gdf[gdf.District.isin([4])], \n",
+    "                          hwy_route=101, plot_col=stat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e43c46be-ec90-4a27-b720-1a6369b3621b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/bus_service_increase/G5_calculate_speeds_all_operators.py
+++ b/bus_service_increase/G5_calculate_speeds_all_operators.py
@@ -1,0 +1,133 @@
+"""
+Get the generated speedmap metrics.
+
+Calculate once for each operator, then concatenate and save.
+
+Based on rt_delay/rt_filter_map_plot.py,
+and just expand to do grouping across trips / operators.
+
+
+The rt_trips parquets have speed by trip-level
+#df = pd.read_parquet(f"{GCS_FILE_PATH}rt_trips/{itp_id}_{date}.parquet")
+
+Need this script to keep it at stop-id level, speed for stop-to-stop segments.
+This is still point data, calculated at the stop-id level.
+"""
+import geopandas as gpd
+import glob
+import os
+import pandas as pd
+
+from shared_utils import (rt_utils, rt_dates, 
+                          geography_utils, gtfs_utils, utils)
+
+analysis_date = rt_dates.DATES["may2022"]
+
+month = analysis_date.split('-')[1]
+day = analysis_date.split('-')[2]
+
+
+def generate_speeds(df, itp_id):
+    trip_cols = [
+        "calitp_itp_id", "route_id", 
+        "shape_id", "trip_id",
+    ]
+
+    sort_cols = trip_cols + ["stop_sequence"]
+
+    df = (df.assign(
+            calitp_itp_id = itp_id,
+            arrival_time = pd.to_datetime(df.arrival_time),
+            actual_time = pd.to_datetime(df.actual_time),
+        ).sort_values(sort_cols)
+          .reset_index(drop=True)
+    )
+    
+    # Do the shift to grab prior metric, so we can calculate change
+    df = df.assign(
+        actual_time_last = (df.sort_values(sort_cols)
+                            .groupby(trip_cols)["actual_time"]
+                            .apply(lambda x: x.shift(1))
+                           ),
+        last_loc = (df.sort_values(sort_cols)
+                    .groupby(trip_cols)["shape_meters"]
+                    .apply(lambda x: x.shift(1))
+                   ),
+        delay_prior = (df.sort_values(sort_cols)
+                       .groupby(trip_cols)["delay_seconds"]
+                       .apply(lambda x: x.shift(1))
+                      )
+    )
+    
+    
+    df = df.assign(
+        seconds_from_last = df.apply(
+            lambda x: pd.Timedelta(x.actual_time-x.actual_time_last).seconds, 
+            axis=1),
+        meters_from_last = df.shape_meters - df.last_loc,
+        delay_chg_sec = df.delay_seconds - df.delay_prior,
+    )
+    
+    df = df.assign(
+        speed_mph = (df.meters_from_last / df.seconds_from_last) * rt_utils.MPH_PER_MPS
+    )
+    
+    keep_cols = sort_cols + ["actual_time", "arrival_time", 
+                             "seconds_from_last", 
+                             "meters_from_last", "delay_chg_sec", 
+                             "speed_mph", "geometry"]
+    
+    df2 = df[keep_cols].astype({
+        "stop_sequence": int, 
+        "seconds_from_last": "Int64", 
+        "delay_chg_sec": "Int64"
+    })
+    
+    return df2
+
+
+if __name__ == "__main__":
+    
+    ALL_ITP_IDS = gtfs_utils.ALL_ITP_IDS
+    
+    # get the date format, which uses underscore, not hyphens
+    date = f"{month}_{day}"
+
+    gdf = gpd.GeoDataFrame()
+    
+    for itp_id in ALL_ITP_IDS:
+
+        filename = f"{itp_id}_{date}.parquet"
+
+        path = rt_utils.check_cached(filename, 
+                                     GCS_FILE_PATH = rt_utils.GCS_FILE_PATH, 
+                                     subfolder = "stop_delay_views/")
+
+        if path:    
+            df = gpd.read_parquet(path)
+            
+            df2 = generate_speeds(df, itp_id).to_crs(geography_utils.WGS84)
+            print(f"{itp_id}: finished")
+            
+            df.to_parquet(f"./data/speeds_{itp_id}_{date}.parquet")
+  
+            gdf = pd.concat([gdf, df2], axis=0, ignore_index=True)
+
+    
+    gdf = gdf.sort_values(["calitp_itp_id", "route_id", 
+                           "trip_id", "stop_sequence"]).reset_index(drop=True)
+    
+    utils.geoparquet_gcs_export(gdf, 
+                                f"{rt_utils.GCS_FILE_PATH}segment_speed_views/", 
+                                f"all_operators_{analysis_date}"
+                               )
+    
+    print("Concatenated, exported all operators to GCS")
+    
+    for f in glob.glob("./data/speeds_*.parquet"):
+        os.remove(f)
+    
+    print("Remove all local parquets")        
+
+
+

--- a/bus_service_increase/catalog.yml
+++ b/bus_service_increase/catalog.yml
@@ -113,4 +113,15 @@ sources:
     args:
       # source: bus_service_increase/G3_highway_segment_stats.py
       urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/highway_segment_stats.parquet
-     
+  speeds_by_stop:
+    driver: geoparquet
+    description: Speed calculated at the stop-level for all operators. Based on rt_filter_map_plot.py.
+    args:
+      # source: bus_service_increase/G5_calculate_speeds_all_operators.py
+      urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/segment_speed_views/all_operators_2022-05-04.parquet     
+  speeds_by_trip:
+    driver: geoparquet
+    description: Speed summary stat at the trip-level for all operators. 
+    args:
+      # source: bus_service_increase/G5_calculate_speeds_all_operators.py
+      urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/rt_trips/all_operators_2022-05-04.parquet

--- a/bus_service_increase/catalog.yml
+++ b/bus_service_increase/catalog.yml
@@ -95,21 +95,21 @@ sources:
     args:
       # source: bus_service_increase/G1_better_buses_data.py
       urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/segmented_highways.parquet
+  stop_times_for_routes_on_shn:
+    driver: parquet
+    description: Stop times table for just routes on SHN (intermediate file to use in G2 and G3).
+    args:
+      # source: bus_service_increase/G2_aggregated_stats.py
+      urlpath: ./data/stop_times_for_routes_on_shn.parquet  
   bus_routes_aggregated_stats:
     driver: parquet
     description: Aggregated stats for stop times and trips by route_id for all stops on the route.
     args:
       # source: bus_service_increase/G2_aggregated_stats.py
       urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/bus_routes_on_hwys_aggregated_stats.parquet
-  bus_stops_aggregated_stats:
-    driver: parquet
-    description: Aggregated stats for stop times and trips by route_id for only stops that fall on SHN on the route.
-    args:
-      # source: bus_service_increase/G2_aggregated_stats.py
-      urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/bus_stops_on_hwys_aggregated_stats.parquet
   highway_segment_stats:
     driver: geoparquet
-    description: Route stats for only stops that fall on SHN joined to highway segments, aggregated by highway segments.
+    description: At highway 1 mile segment level, have the number of trips, stop arrivals, and stops across operators.
     args:
       # source: bus_service_increase/G3_highway_segment_stats.py
       urlpath: gs://calitp-analytics-data/data-analyses/bus_service_increase/highway_segment_stats.parquet

--- a/bus_service_increase/create_calenviroscreen_lehd_data.py
+++ b/bus_service_increase/create_calenviroscreen_lehd_data.py
@@ -39,10 +39,15 @@ def define_equity_groups(df: pd.DataFrame,
     """
     
     for col in percentile_col:
-        new_col = f"{col}_group"
         # -999 should be replaced as NaN, so it doesn't throw off the binning of groups
-        df[col] = df[col].replace(-999, np.nan)
-        df[new_col] = pd.cut(df[col], bins=num_groups, labels=False) + 1
+        df = (df.assign(
+                col = df[col].replace(-999, np.nan),
+                new_col = pd.cut(df[col], bins=num_groups, labels=False) + 1
+            ).drop(columns = col) # drop original column and use the one with replaced values
+            .rename(columns = {
+                "col": col, 
+                "new_col": f"{col}_group"})
+             )
 
     return df
 

--- a/bus_service_increase/pmac_utils.py
+++ b/bus_service_increase/pmac_utils.py
@@ -5,7 +5,7 @@ import altair as alt
 import geopandas as gpd
 import pandas as pd
 
-from D1_pmac_routes import TRAFFIC_OPS_GCS
+from D1_pmac_routes import COMPILED_CACHED_GCS
 from utils import GCS_FILE_PATH
 from shared_utils import geography_utils
 
@@ -26,7 +26,7 @@ def calculate_route_level_service_hours(date_str) -> pd.DataFrame:
         columns = {"calitp_itp_id": "itp_id"})
     
     trips = pd.read_parquet(
-        f"{TRAFFIC_OPS_GCS}trips_{date_str}.parquet").rename(
+        f"{COMPILED_CACHED_GCS}trips_{date_str}.parquet").rename(
         columns = {"calitp_itp_id": "itp_id"})
     
     # Aggregate trips with service hours (at shape_id level) up to route_id
@@ -202,8 +202,10 @@ def add_percent(df: pd.DataFrame, col_list: list) -> pd.DataFrame:
     return df
 
 #https://stackoverflow.com/questions/23482668/sorting-by-a-custom-list-in-pandas
-def sort_by_column(df: pd.DataFrame, col: str = "category", 
-                   sort_key: list = ["parallel", "on_shn", "other"]) -> pd.DataFrame:
+def sort_by_column(df: pd.DataFrame, 
+                   col: str = "category", 
+                   sort_key: list = ["parallel", "on_shn", "other"]
+                  ) -> pd.DataFrame:
     # Custom sort order for categorical variable
     df = df.sort_values(col, 
                         key=lambda c: c.map(lambda e: sort_key.index(e)))

--- a/traffic_ops/create_routes_data.py
+++ b/traffic_ops/create_routes_data.py
@@ -114,9 +114,9 @@ def make_routes_shapefile():
     
     # Read in local parquets
     trips = dd.read_parquet(
-        f"{prep_data.GCS_FILE_PATH}trips_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}trips_{prep_data.ANALYSIS_DATE}_all.parquet")
     routes = dg.read_parquet(
-        f"{prep_data.GCS_FILE_PATH}routelines_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}routelines_{prep_data.ANALYSIS_DATE}_all.parquet")
 
     df = merge_trips_to_routes(trips, routes)
     

--- a/traffic_ops/create_stops_data.py
+++ b/traffic_ops/create_stops_data.py
@@ -68,11 +68,11 @@ def make_stops_shapefile():
 
     # Read in local parquets
     stops = dg.read_parquet(
-        f"{prep_data.GCS_FILE_PATH}stops_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}stops_{prep_data.ANALYSIS_DATE}_all.parquet")
     trips = dd.read_parquet(
-        f"{prep_data.GCS_FILE_PATH}trips_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}trips_{prep_data.ANALYSIS_DATE}_all.parquet")
     stop_times = dd.read_parquet(
-        f"{prep_data.GCS_FILE_PATH}st_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}st_{prep_data.ANALYSIS_DATE}_all.parquet")
     
     time1 = datetime.now()
     print(f"Get rid of duplicates: {time1-time0}")

--- a/traffic_ops/make_routes_stops_shapefiles.py
+++ b/traffic_ops/make_routes_stops_shapefiles.py
@@ -28,10 +28,10 @@ if __name__ == "__main__":
     print("Local parquets created")
     
     routes = create_routes_data.make_routes_shapefile()   
-    utils.geoparquet_gcs_export(routes, prep_data.GCS_FILE_PATH, "ca_transit_routes")
+    utils.geoparquet_gcs_export(routes, prep_data.TRAFFIC_OPS_GCS, "ca_transit_routes")
 
     stops = create_stops_data.make_stops_shapefile()    
-    utils.geoparquet_gcs_export(stops, prep_data.GCS_FILE_PATH, "ca_transit_stops")
+    utils.geoparquet_gcs_export(stops, prep_data.TRAFFIC_OPS_GCS, "ca_transit_stops")
     
     print("Geoparquets exported to GCS")
         

--- a/traffic_ops/move-parquets-to-new-folder.py
+++ b/traffic_ops/move-parquets-to-new-folder.py
@@ -1,0 +1,57 @@
+"""
+Move the cached parquets (compiled across operators) into the same
+folder: `rt_delay/compiled_cached_views/`
+
+These are used in `traffic_ops` and `bus_service_increase` scripts for PMAC,
+but should reside closer to where the individual operator parquets are
+to minimize confusion.
+"""
+import geopandas as gpd
+import pandas as pd
+from typing import Literal
+
+from shared_utils import utils, rt_dates
+
+dates_in_gcs = [
+    rt_dates.DATES["feb2022"], 
+    rt_dates.DATES["may2022"], 
+    rt_dates.DATES["jul2022"]
+]
+
+def move_parquets(dataset: Literal["trips", "st", "stops", "routelines"] = "trips", 
+                  date: str = "2022-02-08", 
+                  filename: str = "",
+                  old_folder: str = "", 
+                  new_folder: str = ""):
+    
+    if dataset in ["trips", "st"]:
+        df = pd.read_parquet(f"{old_folder}{filename}.parquet")
+        df.to_parquet(f"{new_folder}{filename}.parquet")
+        print(f"Moved to: {new_folder}{filename}.parquet")
+    
+    elif dataset in ["stops", "routelines"]:
+        df = gpd.read_parquet(f"{old_folder}{filename}.parquet")
+        utils.geoparquet_gcs_export(df, 
+                                    new_folder,
+                                    filename
+        )
+        print(f"Moved to: {new_folder}{filename}.parqruet")
+
+        
+if __name__ == "__main__":   
+    BUCKET = "gs://calitp-analytics-data/data-analyses/"
+    
+    for date in dates_in_gcs:
+        for d in ["stops", "routelines", "trips", "st"]:
+            for f in [f"{d}_{date}" , f"{d}_{date}_all"]:
+                try:
+                    move_parquets(
+                        dataset = d, 
+                        date = date, 
+                        filename = f,
+                        old_folder = f"{BUCKET}traffic_ops/",
+                        #old_folder = f"{BUCKET}bus_service_increase/",
+                        new_folder = f"{BUCKET}rt_delay/compiled_cached_views/",
+                    )
+                except:
+                    pass

--- a/traffic_ops/prep_data.py
+++ b/traffic_ops/prep_data.py
@@ -20,7 +20,9 @@ from shared_utils import geography_utils, gtfs_utils, utils, rt_dates
 
 ANALYSIS_DATE = gtfs_utils.format_date(rt_dates.DATES["jul2022"])
 
-GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/traffic_ops/"
+GCS = "gs://calitp-analytics-data/data-analyses/"
+TRAFFIC_OPS_GCS = f"{GCS}traffic_ops/"
+COMPILED_CACHED_GCS = f"{GCS}rt_delay/compiled_cached_views/"
 DATA_PATH = "./data/"
 
 
@@ -32,26 +34,25 @@ def grab_selected_date(selected_date: str):
     gtfs_utils.all_routelines_or_stops_with_cached(
         dataset = "stops",
         analysis_date = selected_date,
-        export_path = GCS_FILE_PATH
+        export_path = COMPILED_CACHED_GCS
     )
     
     gtfs_utils.all_trips_or_stoptimes_with_cached(
         dataset = "trips",
         analysis_date = selected_date,
-        export_path = GCS_FILE_PATH
+        export_path = COMPILED_CACHED_GCS
     )
     
     gtfs_utils.all_routelines_or_stops_with_cached(
         dataset = "routelines",
         analysis_date = selected_date,
-        export_path = GCS_FILE_PATH
+        export_path = COMPILED_CACHED_GCS
     )
-    
     
     gtfs_utils.all_trips_or_stoptimes_with_cached(
         dataset = "st",
         analysis_date = selected_date,
-        export_path = GCS_FILE_PATH
+        export_path = COMPILED_CACHED_GCS
     )
     
     # stops, trips, stop_times, and routes save directly to GCS already
@@ -138,7 +139,7 @@ def grab_amtrak(selected_date: datetime.date | str
 
 def concatenate_amtrak(
     selected_date: datetime.date | str = "2022-05-04", 
-    export_path: str = GCS_FILE_PATH):
+    export_path: str = COMPILED_CACHED_GCS):
     """
     Grab the cached file on selected date for trips, stops, routelines.
     Concatenate Amtrak.
@@ -175,7 +176,8 @@ def concatenate_amtrak(
                     ], axis=0)
                     .astype({"trip_key": "Int64"})
                 ).compute()
-    utils.geoparquet_gcs_export(routelines_all, export_path, f"routelines_{date_str}_all")
+    utils.geoparquet_gcs_export(routelines_all, 
+                                export_path, f"routelines_{date_str}_all")
     
     st = dd.read_parquet(f"{export_path}st_{date_str}.parquet")
     st_all = (dd.multi.concat([
@@ -192,7 +194,7 @@ def concatenate_amtrak(
 def create_local_parquets(selected_date):
     grab_selected_date(selected_date) 
     grab_amtrak(selected_date)
-    concatenate_amtrak(selected_date, GCS_FILE_PATH)
+    concatenate_amtrak(selected_date, COMPILED_CACHED_GCS)
 
         
 #----------------------------------------------------#        

--- a/traffic_ops/prep_data.py
+++ b/traffic_ops/prep_data.py
@@ -11,7 +11,6 @@ import dask_geopandas as dg
 import datetime
 import geopandas as gpd
 import pandas as pd
-import glob
 
 from siuba import *
 from typing import Literal


### PR DESCRIPTION
### Clean up
* Add `loguru` and `mapclassify` to `requirements.txt` so we can use `gdf.explore()`
* Decision to move compiled GCS parquets across operators into `rt_delay` subfolders. Change all the file paths for PMAC, traffic_ops projects to point there.
* `traffic_ops/move-parquets-to-new-folder`: move all these parquets from different locations, consolidate into 1 place that other proj can pull from
* `rt_utils`: allow export to other folders, but default is `rt_delay/cached_views`

### Better Buses
* Create some aggregated statistics joined to 1-mile highway segments
* `G2_aggregated_stats`: correctly aggregate stats for peak periods (AM/PM peak) and all day across more granular time-of-day bins. Make sure `count` and `nunique` is used correctly so we're not double-counting when it doesn't make sense.
* `G3_highway_segment_stats`: Add spatial join of routes to highway segments, stops to highway segments, and then add in aggregated stats at the highway segment-level. 
* `G4_plot_segments`: some interactive maps, by district / highway route. plot the number of trips / stop arrivals / stops by highway segment. plot quartiles instead of raw, so we can better pick out segments of interest. TODO: add in speed. Want to identify where lots of trips pass through at relatively slow speeds.
* `G5_calculate_speeds_all_operators`: Concatenate, across operators, the RT segment speeds at the stop-level (speeds between stops) and mean speed at the trip-level, save in GCS
* Add all the parquets created into `catalog`

TODO: figure out how to calculate weighted average of speed at stop-level across operators or routes, then join to highway segment, so that the 1-mile segment has an average speed statistic that can be plotted

Epic: #370 