### PR TITLE
update aug 2022 metadata for open data, set up editions tracker

### DIFF
--- a/_shared_utils/shared_utils/rt_dates.py
+++ b/_shared_utils/shared_utils/rt_dates.py
@@ -15,6 +15,14 @@ DATES = {
 }
 
 
+# Metadata edition for open data portal datasets
+METADATA_EDITION = {
+    "may2022": 1,
+    "jun2022": 2,
+    "jul2022": 3,
+    "aug2022": 4,
+}
+
 # Planning and Modal Advisory Committee (PMAC) - quarterly
 PMAC = {
     "Q1_2022": "2022-02-08",

--- a/open_data/arcgis_script.py
+++ b/open_data/arcgis_script.py
@@ -17,8 +17,6 @@ import os
 
 arcpy.env.workspace = "C:\Users\s153936\Documents\ArcGIS"
 #arcpy.env.workspace = ARCGIS_PATH
-ENTERPRISE_PATH  = 'C:\Users\s153936\Documents\ArcGIS\AppData\Roaming\ESRI\Desktop10.8\ArcCatalog\HQrail(edit)@sv03tmcsqlprd1.sde'
-
 
 # Set local variables
 in_features = [
@@ -150,4 +148,12 @@ for f in in_features:
     except:
         pass
 
-## (8) Move from file gdb to enterprise gdb?
+## (8) Move from file gdb to enterprise gdb
+# License Select must be set to Advanced for this to work
+ENTERPRISE_DATABASE = "Database Connections/HQrail(edit)@sv03tmcsqlprd1.sde"
+
+for f in in_features:
+    arcpy.FeatureClassToFeatureClass_conversion(
+        in_features = out_location + '/' + f,
+        out_path = ENTERPRISE_DATABASE,
+        out_name = f)

--- a/open_data/metadata_update.py
+++ b/open_data/metadata_update.py
@@ -4,6 +4,7 @@ Overwrite XML metadata using JSON.
 Analyst inputs a dictionary of values to overwrite.
 Convert JSON back to XML to feed in ArcGIS.
 """
+import os
 import pandas as pd
 import xml.etree.ElementTree as ET
 import xmltodict
@@ -205,6 +206,9 @@ def update_metadata_xml(XML_FILE, DATASET_INFO, first_run=False):
     
     # Overwrite existing XML file
     OUTPUT_FOLDER = "run_in_esri/"
+    if not os.path.exists(f"./{METADATA_FOLDER}{OUTPUT_FOLDER}"):
+        os.makedirs(f"./{METADATA_FOLDER}{OUTPUT_FOLDER}")
+    
     FILE = f"{XML_FILE.split(METADATA_FOLDER)[1]}"
         
     with open(f"{METADATA_FOLDER}{OUTPUT_FOLDER}{FILE}", 'w') as f:

--- a/open_data/metadata_xml/ca_hq_transit_areas.xml
+++ b/open_data/metadata_xml/ca_hq_transit_areas.xml
@@ -4,7 +4,7 @@
 		<citation>
 			<citeinfo>
 				<title>ca_hq_transit_areas</title>
-				<edition>3</edition>
+				<edition>4</edition>
 				<geoform>vector digital data</geoform>
 				<pubinfo>
 					<publish>California Integrated Travel Project</publish>
@@ -33,9 +33,9 @@
 		<spdom>
 			<bounding>
 				<westbc>-124.207791</westbc>
-				<eastbc>-114.481010</eastbc>
-				<northbc>45.333621</northbc>
-				<southbc>32.536991</southbc>
+				<eastbc>-114.590865</eastbc>
+				<northbc>41.767820</northbc>
+				<southbc>32.537144</southbc>
 			</bounding>
 		</spdom>
 		<keywords>
@@ -72,7 +72,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>GT-polygon composed of chains</sdtstype>
-				<ptvctcnt>64917</ptvctcnt>
+				<ptvctcnt>27597</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -131,6 +131,9 @@
 			</attr>
 			<attr>
 				<attrlabl>hqta_details</attrlabl>
+			</attr>
+			<attr>
+				<attrlabl>route_id</attrlabl>
 			</attr>
 			<attr>
 				<attrlabl>Shape_Length</attrlabl>

--- a/open_data/metadata_xml/ca_hq_transit_stops.xml
+++ b/open_data/metadata_xml/ca_hq_transit_stops.xml
@@ -4,7 +4,7 @@
 		<citation>
 			<citeinfo>
 				<title>ca_hq_transit_stops</title>
-				<edition>3</edition>
+				<edition>4</edition>
 				<geoform>vector digital data</geoform>
 				<pubinfo>
 					<publish>California Integrated Travel Project</publish>
@@ -33,9 +33,9 @@
 		<spdom>
 			<bounding>
 				<westbc>-124.196667</westbc>
-				<eastbc>-114.490902</eastbc>
-				<northbc>45.325336</northbc>
-				<southbc>32.544258</southbc>
+				<eastbc>-114.599841</eastbc>
+				<northbc>41.756498</northbc>
+				<southbc>32.544566</southbc>
 			</bounding>
 		</spdom>
 		<keywords>
@@ -72,7 +72,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>Entity point</sdtstype>
-				<ptvctcnt>61138</ptvctcnt>
+				<ptvctcnt>64104</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -125,6 +125,9 @@
 			</attr>
 			<attr>
 				<attrlabl>hqta_type</attrlabl>
+			</attr>
+			<attr>
+				<attrlabl>route_id</attrlabl>
 			</attr>
 			<attr>
 				<attrlabl>agency_primary</attrlabl>

--- a/open_data/metadata_xml/ca_transit_routes.xml
+++ b/open_data/metadata_xml/ca_transit_routes.xml
@@ -4,7 +4,7 @@
 		<citation>
 			<citeinfo>
 				<title>ca_transit_routes</title>
-				<edition>3</edition>
+				<edition>4</edition>
 				<geoform>vector digital data</geoform>
 				<pubinfo>
 					<publish>California Integrated Travel Project</publish>
@@ -70,7 +70,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>String</sdtstype>
-				<ptvctcnt>7456</ptvctcnt>
+				<ptvctcnt>7791</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>

--- a/open_data/metadata_xml/ca_transit_stops.xml
+++ b/open_data/metadata_xml/ca_transit_stops.xml
@@ -4,7 +4,7 @@
 		<citation>
 			<citeinfo>
 				<title>ca_transit_stops</title>
-				<edition>3</edition>
+				<edition>4</edition>
 				<geoform>vector digital data</geoform>
 				<pubinfo>
 					<publish>California Integrated Travel Project</publish>
@@ -70,7 +70,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>Entity point</sdtstype>
-				<ptvctcnt>108010</ptvctcnt>
+				<ptvctcnt>109643</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>

--- a/open_data/validation.py
+++ b/open_data/validation.py
@@ -12,6 +12,8 @@ in `metadata_update`.
 """
 import pandas as pd
 
+from shared_utils import rt_dates
+
 # Function to put in list of keywords (MINIMUM 5 needed)
 def fill_in_keyword_list(topic='transportation', keyword_list = []):
     if len(keyword_list) >= 5:
@@ -84,13 +86,16 @@ def check_dates(string):
         
 # First time metadata is generated off of template, it holds '-999' as value
 # Subsequent updates, pull it, and add 1
+# Can't get edition to show up when exporting file gdb, so it always gets reset to 1
 def check_edition_add_one(metadata):
     input_edition = metadata["idinfo"]["citation"]["citeinfo"]["edition"]
     
     if input_edition == '-999':
         new_edition = str(1)
-    else:
-        new_edition = str(int(input_edition) + 1)
+        
+        # Replace to largest 
+        possible_editions = list(rt_dates.METADATA_EDITION.values())        
+        new_edition = str(max(possible_editions))
     
     return new_edition
 


### PR DESCRIPTION
* Update Aug 2022 open data portal datasets via enterprise geodatabase
* `ArcLicenseSelect` > `Advanced` to have permissions to write new schema
* Update `arcgis_script` to write file gdb to enterprise gdb after metadata updates
* **Fix**: metadata edition keeps getting reset to 1, track edition in `shared_utils/rt_dates`

GH issue: #399 