### PR TITLE
Separate get_operators util from new run_operators wrapper function

### DIFF
--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -727,6 +727,7 @@ route_type_names = {
     "12": "Monorail",
 }
 
+
 def get_operators(analysis_date, operator_list):
     """
     Function for checking the existence of rt_trips and stop_delay_views in GCS for operators on a given day.
@@ -753,5 +754,5 @@ def get_operators(analysis_date, operator_list):
             continue
         else:
             print(f"not yet run: {itp_id}")
-            op_list_runstatus[itp_id] = "not_yet_run"    
+            op_list_runstatus[itp_id] = "not_yet_run"
     return op_list_runstatus

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -726,3 +726,32 @@ route_type_names = {
     "11": "Trolleybus",
     "12": "Monorail",
 }
+
+def get_operators(analysis_date, operator_list):
+    """
+    Function for checking the existence of rt_trips and stop_delay_views in GCS for operators on a given day.
+
+    analysis_date: datetime.date
+    operator_list: list of itp_id's
+    """
+    fs_list = fs.ls(f"{GCS_FILE_PATH}rt_trips/")
+    day = str(analysis_date.day).zfill(2)
+    month = str(analysis_date.month).zfill(2)
+    # now finds ran operators on specific analysis date
+    ran_operators = [
+        int(path.split("rt_trips/")[1].split("_")[0])
+        for path in fs_list
+        if path.split("rt_trips/")[1]
+        and path.split("rt_trips/")[1].split("_")[1] == month
+        and path.split("rt_trips/")[1].split("_")[2][:2] == day
+    ]
+    op_list_runstatus = {}
+    for itp_id in operator_list:
+        if itp_id in ran_operators:
+            print(f"already ran: {itp_id}")
+            op_list_runstatus[itp_id] = "already_ran"
+            continue
+        else:
+            print(f"not yet run: {itp_id}")
+            op_list_runstatus[itp_id] = "not_yet_run"    
+    return op_list_runstatus

--- a/rt_delay/test_get_operators_util.ipynb
+++ b/rt_delay/test_get_operators_util.ipynb
@@ -45,68 +45,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "08163351-1330-48b0-9c06-718d55f39cdf",
    "metadata": {},
    "outputs": [],
    "source": [
     "# testing parameters: a date that we don't have (saturday)\n",
-    "analysis_date = dt.date(2022, 10, 1)"
+    "analysis_date = dt.date(2022, 10, 15)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "8f950e8c-e34d-4a9b-8a53-c3d7c69c9013",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fs_list = fs.ls(f'{shared_utils.rt_utils.GCS_FILE_PATH}rt_trips/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "17ae056b-8431-4f59-a595-f915a9db35c4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_operators(analysis_date, operator_list, generate_new=False):\n",
-    "    \n",
-    "    day = str(analysis_date.day).zfill(2)\n",
-    "    month = str(analysis_date.month).zfill(2)\n",
-    "    ## now finds ran operators on specific analysis date\n",
-    "    ran_operators = [int(path.split('rt_trips/')[1].split('_')[0])\n",
-    "                     for path in fs_list\n",
-    "                     if path.split('rt_trips/')[1] and path.split('rt_trips/')[1].split('_')[1] == month and path.split('rt_trips/')[1].split('_')[2][:2] == day]\n",
-    "    \n",
-    "    op_list_runstatus = {}\n",
-    "    for itp_id in operator_list:\n",
-    "        if itp_id in ran_operators:\n",
-    "            print(f'already ran: {itp_id}')\n",
-    "            op_list_runstatus[itp_id] = 'already_ran'\n",
-    "            continue\n",
-    "        else:\n",
-    "            if not generate_new:\n",
-    "                print (f'not yet run: {itp_id}')\n",
-    "                op_list_runstatus[itp_id] = 'not_yet_run'\n",
-    "            elif generate_new:\n",
-    "                print(f'calculating for agency: {itp_id}...')\n",
-    "                try:\n",
-    "                    rt_day = rt.OperatorDayAnalysis(itp_id, analysis_date)\n",
-    "                    rt_day.export_views_gcs()\n",
-    "                    print(f'complete for agency: {itp_id}')\n",
-    "                    op_list_runstatus[itp_id] = 'newly_run'\n",
-    "                except Exception as e:\n",
-    "                    print(f'rt failed for agency {itp_id}')\n",
-    "                    op_list_runstatus[itp_id] = 'new_failed_run'\n",
-    "                    print(e)\n",
-    "    return op_list_runstatus "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "7e04a9b3-800b-4d88-af69-b8a8e1887637",
    "metadata": {},
    "outputs": [
@@ -114,17 +64,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "already ran: 293\n"
+      "not yet run: 293\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{293: 'not_yet_run'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "get_operators(analysis_date,[293],generate_new=False)"
+    "shared_utils.rt_utils.get_operators(analysis_date,[293])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "7061cc43-4a92-4387-81f2-41f466958b55",
    "metadata": {},
    "outputs": [
@@ -132,21 +92,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "calculating for agency: 208...\n",
-      "found parquet\n",
-      "found parquet\n",
-      "found parquet\n",
-      "found parquet\n",
-      "found parquet\n",
-      "complete for agency: 208\n",
-      "already ran: 293\n",
-      "{208: 'newly_run', 293: 'already_ran'}\n"
+      "not yet run: 293\n",
+      "calculating for agency: 293...\n",
+      "getting trips...\n",
+      "complete for agency: 293\n"
      ]
     }
    ],
    "source": [
-    "func_results_2 = get_operators(analysis_date,[208,293],generate_new=True)\n",
-    "print(func_results_2)"
+    "rt.run_operators(analysis_date,[293])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e92f5c75-9bb9-4a10-8be0-64947b9ace08",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "already ran: 293\n",
+      "not yet run: 148\n",
+      "calculating for agency: 148...\n",
+      "getting trips...\n",
+      "complete for agency: 148\n"
+     ]
+    }
+   ],
+   "source": [
+    "rt.run_operators(analysis_date,[293,148])"
    ]
   },
   {
@@ -174,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Intermediate adjustment for Issue #491 

get_operators was previously in rt_analysis.py. Separated into 2 functions:

1. get_operators back in shared_utils.rt_utils, without dependency on rt_analysis
2. run_operators in rt_analysis runs get_operators, and then generates data for operators that don't already have intermediate data stored in GCS