### PR TITLE
add ca_transit_routes_feed to shared_data_catalog

### DIFF
--- a/_shared_utils/shared_utils/shared_data_catalog.yml
+++ b/_shared_utils/shared_utils/shared_data_catalog.yml
@@ -14,10 +14,16 @@ sources:
       urlpath: gs://calitp-analytics-data/data-analyses/ca_county_centroids.parquet
   ca_transit_routes:
     driver: geoparquet
-    description: CA transit routes with line geometry (open data)
+    description: CA transit routes with line geometry at the operator-level (open data)
     args:
       # source: traffic_ops/make_routes_stops_shapefiles.py.py
       urlpath: gs://calitp-analytics-data/data-analyses/traffic_ops/ca_transit_routes.parquet
+  ca_transit_routes_feed:
+    driver: geoparquet
+    description: CA transit routes with line geometry at the feed-level (not on open data)
+    args:
+      # source: traffic_ops/make_routes_stops_shapefiles.py.py
+      urlpath: gs://calitp-analytics-data/data-analyses/traffic_ops/ca_transit_routes_feed.parquet
   ca_transit_stops:
     driver: geoparquet
     description: CA transit stops with point geometry (open data)

--- a/traffic_ops/create_routes_data.py
+++ b/traffic_ops/create_routes_data.py
@@ -7,8 +7,6 @@ import dask_geopandas as dg
 import geopandas as gpd
 import pandas as pd
 
-from datetime import datetime
-
 import prep_data
 from shared_utils import geography_utils, portfolio_utils
 from bus_service_utils import gtfs_build
@@ -20,36 +18,48 @@ remove_trip_cols = ["service_date", "calitp_extracted_at", "calitp_deleted_at"]
 
 
 def merge_trips_to_routes(trips: dd.DataFrame, 
-                          routes: dg.GeoDataFrame) -> dg.GeoDataFrame:
+                          routes: dg.GeoDataFrame, 
+                          group_cols: list = ["calitp_itp_id", "shape_id"]
+                         ) -> dg.GeoDataFrame:
     # Routes or trips can contain multiple calitp_url_numbers 
     # for same calitp_itp_id-shape_id. Drop these now
     # dask can only sort by 1 column!
-    shape_id_cols = ["calitp_itp_id", "shape_id"]
-    
-    routes = (routes.sort_values("calitp_url_number")
-              .drop_duplicates(subset=shape_id_cols)
+    # when publishing to open data portal, we want it at operator level, not feed level
+    if group_cols == ["calitp_itp_id", "shape_id"]:
+        routes = (routes.sort_values("calitp_url_number")
+              .drop_duplicates(subset=group_cols)
               .reset_index(drop=True)
-    )
-    
-    trips = (trips.sort_values("calitp_url_number")
+        )
+        
+        trips = (trips.sort_values("calitp_url_number")
              .drop_duplicates(subset=["calitp_itp_id", "trip_id"])
              .reset_index(drop=True)
             .drop(columns = remove_trip_cols)
-    )
+        )
+        
+    else:
+        routes = (routes
+          .drop_duplicates(subset=group_cols)
+          .reset_index(drop=True)
+        )
+        trips = (trips.drop_duplicates(
+            subset=["calitp_itp_id", "calitp_url_number", "trip_id"])
+             .reset_index(drop=True)
+            .drop(columns = remove_trip_cols)
+        )
+
     
     # Left only means in trips, but shape_id not found in shapes.txt
     # right only means in routes, but no route that has that shape_id 
     # only 1% falls into right_only
-    keep_cols = [
-        'calitp_itp_id', 'route_id', 'shape_id', 
+    keep_cols = group_cols + ['route_id', 
         'route_type', 'geometry',
     ]
-    
     
     m1 = gtfs_build.merge_routes_trips(
         routes, 
         trips, 
-        shape_id_cols,
+        group_cols,
         crs = f"EPSG: {routes.crs.to_epsg()}"
     )
     
@@ -109,28 +119,24 @@ def add_route_agency_name(df: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     return with_latest_id
 
 
-# Assemble routes file
-def make_routes_shapefile():
-    time0 = datetime.now()
-    
+def create_routes_file_for_export(analysis_date: str, 
+                                  group_cols: list) -> gpd.GeoDataFrame:
     # Read in local parquets
     trips = dd.read_parquet(
-        f"{prep_data.COMPILED_CACHED_GCS}trips_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}trips_{analysis_date}_all.parquet")
     routes = dg.read_parquet(
-        f"{prep_data.COMPILED_CACHED_GCS}routelines_{prep_data.ANALYSIS_DATE}_all.parquet")
+        f"{prep_data.COMPILED_CACHED_GCS}routelines_{analysis_date}_all.parquet")
 
-    df = merge_trips_to_routes(trips, routes)
-    
-    time1 = datetime.now()
-    print(f"Read in data and merge shapes to routes: {time1-time0}")        
+    df = merge_trips_to_routes(
+        trips, 
+        routes, 
+        group_cols = group_cols
+    )
     
     routes_with_names = (add_route_agency_name(df)
-                         .sort_values(["itp_id", "route_id"])
-                         .reset_index(drop=True)
-                         .drop_duplicates()
-                        )
+                 .sort_values(["itp_id", "route_id"])
+                 .reset_index(drop=True)
+                 .drop_duplicates()
+                )
     
-    time3 = datetime.now()
-    print(f"Routes script total execution time: {time3-time0}")
-
     return routes_with_names

--- a/traffic_ops/make_routes_stops_shapefiles.py
+++ b/traffic_ops/make_routes_stops_shapefiles.py
@@ -17,23 +17,75 @@ import create_routes_data
 import create_stops_data
 from shared_utils import utils
 
+def export_to_subfolder(analysis_date: str):
+    """
+    We always overwrite the same geoparquets each month, and point our
+    shared_utils/shared_data_catalog.yml to the latest file.
+    
+    But, save historical exports just in case.
+    """
+    files = ["ca_transit_routes", "ca_transit_stops", "ca_transit_routes_feed"]
+        
+    for f in files:
+        gdf = gpd.read_parquet(f"{prep_data.TRAFFIC_OPS_GCS}{f}.parquet")
+        
+        utils.geoparquet_gcs_export(
+            gdf, 
+            f"{prep_data.TRAFFIC_OPS_GCS}export/", 
+            f"{f}_{analysis_date}"
+        )
+        
+    print("All 3 files written to export subfolder")
+    
 
 if __name__ == "__main__":
     assert os.getcwd().endswith("traffic_ops"), "this script must be run from traffic_ops directory!"
-
+    
     time0 = datetime.now()
     
     # Create local parquets
     prep_data.create_local_parquets(prep_data.ANALYSIS_DATE) 
     print("Local parquets created")
     
-    routes = create_routes_data.make_routes_shapefile()   
-    utils.geoparquet_gcs_export(routes, prep_data.TRAFFIC_OPS_GCS, "ca_transit_routes")
-
-    stops = create_stops_data.make_stops_shapefile()    
-    utils.geoparquet_gcs_export(stops, prep_data.TRAFFIC_OPS_GCS, "ca_transit_stops")
+    # Make an operator level file (this is published)
+    operator_level_cols = ["calitp_itp_id", "shape_id"]
+    
+    routes = create_routes_data.create_routes_file_for_export(
+        prep_data.ANALYSIS_DATE, operator_level_cols)  
+    
+    utils.geoparquet_gcs_export(
+        routes, 
+        prep_data.TRAFFIC_OPS_GCS, 
+        "ca_transit_routes"
+    )
+    
+    # Make a feed level file (not published externally, publish to GCS for internal use)
+    feed_level_cols = ["calitp_itp_id", "calitp_url_number", "shape_id"]
+    
+    feed_routes = create_routes_data.create_routes_file_for_export(
+        prep_data.ANALYSIS_DATE, feed_level_cols
+    )
+    
+    utils.geoparquet_gcs_export(
+        feed_routes, 
+        prep_data.TRAFFIC_OPS_GCS, 
+        "ca_transit_routes_feed"
+    )
+    
+    # Make stops file
+    stops = create_stops_data.make_stops_shapefile()  
+    
+    utils.geoparquet_gcs_export(
+        stops, 
+        prep_data.TRAFFIC_OPS_GCS, 
+        "ca_transit_stops"
+    )
     
     print("Geoparquets exported to GCS")
-        
+    
+    # Export all to its subfolder too
+    export_to_subfolder(prep_data.ANALYSIS_DATE)
+    
     time1 = datetime.now()
     print(f"Total run time for routes/stops script: {time1-time0}")
+    


### PR DESCRIPTION
* Add `ca_transit_routes_feed.parquet`. Instead of showing geospatial version of `ca_transit_routes` at the operator-level (no more `url_number`), do it at the feed-level
* Add this to the `shared_utils/shared_data_catalog.yml`...which always shows the most recent month's export on open data portal
* Rework workflow to create both of these while creating the open data portal datasets
* Backfill for Aug, Sep, Oct for `ca_transit_routes_feed` in the folder: `gs://calitp-analytics-data/data-analyses/traffic_ops/export/` and archive some of our past published geoparquets.
* [Slack thread](https://cal-itp.slack.com/archives/C02KH3DGZL7/p1668022440002579?thread_ts=1668020098.971129&cid=C02KH3DGZL7) cc @evansiroky 

TODO: when v2 is ready, make sure this gets updated from `itp_id` and `url_number` to `feed_key` and `name`