### PR TITLE
(shared_utils): back to python 3.9 type hint

### DIFF
--- a/_shared_utils/setup.py
+++ b/_shared_utils/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="shared_utils",
     packages=find_packages(),
-    version="0.1.2",
+    version="0.1.3",
     description="Shared utility functions for data analyses",
     author="Cal-ITP",
     license="Apache",

--- a/_shared_utils/shared_utils/geography_utils.py
+++ b/_shared_utils/shared_utils/geography_utils.py
@@ -3,6 +3,7 @@ Utility functions for geospatial data.
 Some functions for dealing with census tract or other geographic unit dfs.
 """
 import datetime
+from typing import Union
 
 import geopandas as gpd
 import pandas as pd
@@ -21,7 +22,7 @@ SQ_FT_PER_SQ_MI = 2.788 * 10**7
 
 
 def aggregate_by_geography(
-    df: pd.DataFrame | gpd.GeoDataFrame,
+    df: Union[pd.DataFrame, gpd.GeoDataFrame],
     group_cols: list,
     sum_cols: list = [],
     mean_cols: list = [],
@@ -54,7 +55,7 @@ def aggregate_by_geography(
     final_df = df[group_cols].drop_duplicates().reset_index()
 
     def aggregate_and_merge(
-        df: pd.DataFrame | gpd.GeoDataFrame,
+        df: Union[pd.DataFrame, gpd.GeoDataFrame],
         final_df: pd.DataFrame,
         group_cols: list,
         agg_cols: list,
@@ -121,7 +122,7 @@ def attach_geometry(
 
 # Function to construct the SQL condition for make_routes_gdf()
 def construct_condition(
-    selected_date: str | datetime.datetime, include_itp_list: list
+    selected_date: Union[str, datetime.datetime], include_itp_list: list
 ) -> str:
     def unpack_list_make_or_statement(include_itp_list: list) -> str:
         new_cond = ""
@@ -151,7 +152,7 @@ def construct_condition(
 
 # Run the sql query with the condition in long-form
 def create_shapes_for_subset(
-    selected_date: str | datetime.datetime, itp_id_list: list
+    selected_date: Union[str, datetime.datetime], itp_id_list: list
 ) -> pd.DataFrame:
     condition = construct_condition(selected_date, itp_id_list)
 
@@ -185,7 +186,7 @@ def make_linestring(x: str) -> shapely.geometry.LineString:
 
 
 def make_routes_gdf(
-    selected_date: str | datetime.datetime,
+    selected_date: Union[str, datetime.datetime],
     crs: str = "EPSG:4326",
     itp_id_list: list = None,
 ):
@@ -320,8 +321,10 @@ def create_point_geometry(
 
 
 def create_segments(
-    geometry: shapely.geometry.linestring.LineString
-    | shapely.geometry.multilinestring.MultiLineString,
+    geometry: Union[
+        shapely.geometry.linestring.LineString,
+        shapely.geometry.multilinestring.MultiLineString,
+    ],
     segment_distance: int,
 ) -> gpd.GeoSeries:
     """

--- a/_shared_utils/shared_utils/gtfs_utils.py
+++ b/_shared_utils/shared_utils/gtfs_utils.py
@@ -4,7 +4,7 @@ GTFS utils.
 Queries to grab trips, stops, routes.
 """
 import datetime
-from typing import Literal
+from typing import Literal, Union
 
 import dask.dataframe as dd
 import dask_geopandas as dg
@@ -150,12 +150,12 @@ def filter_custom_col(filter_dict: dict) -> siuba.dply.verbs.Pipeable:
 
 
 def get_route_info(
-    selected_date: str | datetime.date = YESTERDAY_DATE,
+    selected_date: Union[str, datetime.date] = YESTERDAY_DATE,
     itp_id_list: list[int] = None,
     route_cols: list[str] = None,
     get_df: bool = True,
     custom_filtering: dict = None,
-) -> pd.DataFrame | siuba.sql.verbs.LazyTbl:
+) -> Union[pd.DataFrame, siuba.sql.verbs.LazyTbl]:
 
     # Route info query
     dim_routes = (
@@ -187,11 +187,11 @@ def get_route_info(
 
 
 def get_route_shapes(
-    selected_date: str | datetime.date,
+    selected_date: Union[str, datetime.date],
     itp_id_list: list[int] = None,
     get_df: bool = True,
     crs: str = geography_utils.WGS84,
-    trip_df: siuba.sql.verbs.LazyTbl | pd.DataFrame = None,
+    trip_df: Union[siuba.sql.verbs.LazyTbl, pd.DataFrame] = None,
     custom_filtering: dict = None,
 ) -> gpd.GeoDataFrame:
     """
@@ -253,13 +253,13 @@ def get_route_shapes(
 # ----------------------------------------------------------------#
 # views.gtfs_schedule_dim_stops + views.gtfs_schedule_fact_daily_feed_stops
 def get_stops(
-    selected_date: str | datetime.date = YESTERDAY_DATE,
+    selected_date: Union[str, datetime.date] = YESTERDAY_DATE,
     itp_id_list: list[int] = None,
     stop_cols: list[str] = None,
     get_df: bool = True,
     crs: str = geography_utils.WGS84,
     custom_filtering: dict = None,
-) -> gpd.GeoDataFrame | siuba.sql.verbs.LazyTbl:
+) -> Union[gpd.GeoDataFrame, siuba.sql.verbs.LazyTbl]:
 
     # Stops query
     dim_stops = (
@@ -296,12 +296,12 @@ def get_stops(
 # ----------------------------------------------------------------#
 # views.gtfs_schedule_dim_trips + views.gtfs_schedule_fact_daily_trips + handle metrolink
 def get_trips(
-    selected_date: str | datetime.date = YESTERDAY_DATE,
+    selected_date: Union[str, datetime.date] = YESTERDAY_DATE,
     itp_id_list: list[int] = None,
     trip_cols: list[str] = None,
     get_df: bool = True,
     custom_filtering: dict = None,
-) -> pd.DataFrame | siuba.sql.verbs.LazyTbl:
+) -> Union[pd.DataFrame, siuba.sql.verbs.LazyTbl]:
 
     # Trips query
     dim_trips = (
@@ -391,7 +391,7 @@ def fix_departure_time(stop_times: dd.DataFrame) -> dd.DataFrame:
     return ddf
 
 
-def check_departure_hours_input(departure_hours: tuple | list) -> list:
+def check_departure_hours_input(departure_hours: Union[tuple, list]) -> list:
     """
     If given a tuple(start_hour, end_hour), it will return a list of the values.
     Ex: (0, 4) will return [0, 1, 2, 3]
@@ -405,14 +405,14 @@ def check_departure_hours_input(departure_hours: tuple | list) -> list:
 
 
 def get_stop_times(
-    selected_date: str | datetime.date = YESTERDAY_DATE,
+    selected_date: Union[str, datetime.date] = YESTERDAY_DATE,
     itp_id_list: list[int] = None,
     stop_time_cols: list[str] = None,
     get_df: bool = False,
-    departure_hours: tuple | list = None,
-    trip_df: pd.DataFrame | siuba.sql.verbs.LazyTbl = None,
+    departure_hours: Union[tuple, list] = None,
+    trip_df: Union[pd.DataFrame, siuba.sql.verbs.LazyTbl] = None,
     custom_filtering: dict = None,
-) -> dd.DataFrame | pd.DataFrame:
+) -> Union[dd.DataFrame, pd.DataFrame]:
     """
     Download stop times table for operator on a day.
 
@@ -522,7 +522,7 @@ def get_stop_times(
 # "universe" of operators whenever we can
 
 
-def format_date(analysis_date: datetime.date | str) -> str:
+def format_date(analysis_date: Union[datetime.date, str]) -> str:
     """
     Get date formatted correctly in all the queries
     """
@@ -534,7 +534,7 @@ def format_date(analysis_date: datetime.date | str) -> str:
 
 def all_routelines_or_stops_with_cached(
     dataset: Literal["routelines", "stops"] = "routelines",
-    analysis_date: datetime.date | str = "2022-06-15",
+    analysis_date: Union[datetime.date, str] = "2022-06-15",
     itp_id_list: list = None,
     export_path="gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/",
 ):
@@ -577,7 +577,7 @@ def all_routelines_or_stops_with_cached(
 
 def all_trips_or_stoptimes_with_cached(
     dataset: Literal["trips", "st"] = "trips",
-    analysis_date: datetime.date | str = "2022-06-15",
+    analysis_date: Union[datetime.date, str] = "2022-06-15",
     itp_id_list: list = None,
     export_path="gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/",
 ):

--- a/_shared_utils/shared_utils/portfolio_utils.py
+++ b/_shared_utils/shared_utils/portfolio_utils.py
@@ -10,6 +10,7 @@ route name, Caltrans district the same way.
 
 """
 import datetime as dt
+from typing import Union
 
 import pandas as pd
 import pandas.io.formats.style
@@ -22,7 +23,7 @@ from siuba import *
 
 
 def add_agency_name(
-    selected_date: str | dt.date = dt.date.today() + dt.timedelta(days=-1),
+    selected_date: Union[str, dt.date] = dt.date.today() + dt.timedelta(days=-1),
 ) -> pd.DataFrame:
     """
     Returns a dataframe with calitp_itp_id and the agency name used in portfolio.
@@ -95,7 +96,7 @@ def add_caltrans_district() -> pd.DataFrame:
 
 # https://github.com/cal-itp/data-analyses/blob/main/rt_delay/utils.py
 def add_route_name(
-    selected_date: str | dt.date = dt.date.today() + dt.timedelta(days=-1),
+    selected_date: Union[str, dt.date] = dt.date.today() + dt.timedelta(days=-1),
 ) -> pd.DataFrame:
     """
     selected_date: datetime or str.

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import time
 from pathlib import Path
+from typing import Union
 
 import branca
 import dask_geopandas as dg
@@ -84,8 +85,8 @@ def primary_cardinal_direction(origin, destination) -> str:
 
 
 def add_origin_destination(
-    gdf: gpd.GeoDataFrame | dg.GeoDataFrame,
-) -> gpd.GeoDataFrame | dg.GeoDataFrame:
+    gdf: Union[gpd.GeoDataFrame, dg.GeoDataFrame],
+) -> Union[gpd.GeoDataFrame, dg.GeoDataFrame]:
     """
     For a gdf, add the origin, destination columns given a linestring.
     Note: multilinestring may not work!
@@ -115,10 +116,10 @@ def add_origin_destination(
 
 
 def add_route_cardinal_direction(
-    df: gpd.GeoDataFrame | dg.GeoDataFrame,
+    df: Union[gpd.GeoDataFrame, dg.GeoDataFrame],
     origin: str = "origin",
     destination: str = "destination",
-) -> gpd.GeoDataFrame | dg.GeoDataFrame:
+) -> Union[gpd.GeoDataFrame, dg.GeoDataFrame]:
     """
     Apply cardinal direction to gdf.
 
@@ -230,9 +231,9 @@ def interpolate_arrival_times(df):
 
 def check_cached(
     filename: str,
-    GCS_FILE_PATH: str | Path = GCS_FILE_PATH,
-    subfolder: str | Path = "cached_views/",
-) -> str | Path:
+    GCS_FILE_PATH: Union[str, Path] = GCS_FILE_PATH,
+    subfolder: Union[str, Path] = "cached_views/",
+) -> Union[str, Path]:
     """
     Check GCS bucket to see if a file already is there.
     Returns the path, if it exists.
@@ -262,7 +263,7 @@ def trips_cached(itp_id: int, date_str: str) -> pd.DataFrame:
 
 
 def get_vehicle_positions(
-    itp_id: int, analysis_date: dt.date, export_path: str | Path = EXPORT_PATH
+    itp_id: int, analysis_date: dt.date, export_path: Union[str, Path] = EXPORT_PATH
 ) -> pd.DataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -358,7 +359,7 @@ def get_trips(
     analysis_date: dt.date,
     force_clear: bool = False,
     route_types: list = None,
-    export_path: str | Path = EXPORT_PATH,
+    export_path: Union[str, Path] = EXPORT_PATH,
 ) -> pd.DataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -440,7 +441,7 @@ def get_stop_times(
     itp_id: int,
     analysis_date: dt.date,
     force_clear: bool = False,
-    export_path: str | Path = EXPORT_PATH,
+    export_path: Union[str, Path] = EXPORT_PATH,
 ) -> pd.DataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -483,7 +484,7 @@ def get_stops(
     itp_id: int,
     analysis_date: dt.date,
     force_clear: bool = False,
-    export_path: str | Path = EXPORT_PATH,
+    export_path: Union[str, Path] = EXPORT_PATH,
 ) -> gpd.GeoDataFrame:
     """
     itp_id: an itp_id (string or integer)
@@ -531,7 +532,7 @@ def get_routelines(
     itp_id: int,
     analysis_date: dt.date,
     force_clear: bool = False,
-    export_path: str | Path = EXPORT_PATH,
+    export_path: Union[str, Path] = EXPORT_PATH,
 ) -> gpd.GeoDataFrame:
 
     date_str = analysis_date.strftime(FULL_DATE_FMT)
@@ -563,7 +564,7 @@ def get_routelines(
         return routelines
 
 
-def categorize_time_of_day(value: int | dt.datetime) -> str:
+def categorize_time_of_day(value: Union[int, dt.datetime]) -> str:
     if isinstance(value, int):
         hour = value
     elif isinstance(value, dt.datetime):

--- a/_shared_utils/shared_utils/utils.py
+++ b/_shared_utils/shared_utils/utils.py
@@ -1,7 +1,11 @@
+"""
+General utility functions.
+"""
 import base64
 import os
 import shutil
 from pathlib import Path
+from typing import Union
 
 import fsspec
 import geopandas as gpd
@@ -90,7 +94,7 @@ def geojson_gcs_export(
 
 # Make zipped shapefile
 # https://github.com/CityOfLosAngeles/planning-entitlements/blob/master/notebooks/utils.py
-def make_shapefile(gdf: gpd.GeoDataFrame, path: str | Path) -> tuple[Path, str]:
+def make_shapefile(gdf: gpd.GeoDataFrame, path: Union[str, Path]) -> tuple[Path, str]:
     """
     Make a zipped shapefile and save locally
     Parameters
@@ -125,7 +129,7 @@ def make_shapefile(gdf: gpd.GeoDataFrame, path: str | Path) -> tuple[Path, str]:
     return dirname, shapefile_name
 
 
-def make_zipped_shapefile(gdf: gpd.GeoDataFrame, path: str | Path):
+def make_zipped_shapefile(gdf: gpd.GeoDataFrame, path: Union[str, Path]):
     """
     Make a zipped shapefile and save locally
     Parameters


### PR DESCRIPTION
* Hub image reverted back to python 3.9 instead of 3.10
* https://github.com/cal-itp/data-infra/pull/2014
* Change type hints back to 3.9 compatibility. `Union[str, int]` instead of `str | int` for python 3.10.

