### PR TITLE
Migrate gtfs utils

### DIFF
--- a/_shared_utils/shared_utils/dbt_for_gtfs_utils_v2.sql
+++ b/_shared_utils/shared_utils/dbt_for_gtfs_utils_v2.sql
@@ -1,0 +1,230 @@
+/*
+Move gtfs_utils_v2 into SQl to sit as dbt model to create another
+mart_* table that analysts start with.
+
+-- NEW TABLES TO ADD (rename everything if necessary) --
+1. fact_feeds (rename to something else?)
+    Purpose: see what feed_keys - organization names are present on selected day
+    Use this to query or subset against if analysts want to subset by
+    organization name, as opposed to feed_key
+
+2. mart_trips
+    Purpose: be the primary trips query for analysts to start
+    Combines: `fct_daily_scheduled_trips` + `fact_feeds` + `dim_trips` + `dim_routes`
+
+    Replace: gtfs_utils
+    v2: `gtfs_utils_v2.get_trips`
+    v1: `gtfs_utils.get_trips` + `gtfs_utils.get_route_info`
+
+3. mart_shapes
+    Purpose: shapes present on day
+    Replace: gtfs_utils_v2.get_route_shapes, gtfs_utils.get_route_shapes
+
+4. mart_stops
+    Purpose: make point geom for stops present on day
+    Replace: gtfs_utils_v2.get_stops, gtfs_utils.get_stops
+
+*/
+
+
+/* DAILY FEED KEY TO ORGANIZATION
+-- Can we add this to every table for get_trips, get_routes, ...get_stops
+-- so that we can subset by name?
+*/
+WITH dim_gtfs_datasets AS (
+    SELECT *
+    FROM {{ ref('dim_gtfs_datasets') }}
+),
+
+fct_daily_schedule_feeds AS (
+    SELECT *
+    FROM {{ ref('fct_daily_schedule_feeds') }}
+),
+
+fact_feeds AS (
+    SELECT
+        dim_gtfs_datasets.name,
+        dim_gtfs_datasets.regional_feed_type,
+
+        schedule_feeds.feed_key,
+        schedule_feeds.date as service_date,
+        schedule_feeds.feed_key,
+        schedule_feeds.base64_url,
+        schedule_feeds.gtfs_dataset_key,
+
+    FROM dim_gtfs_datasets
+        WHERE dim_gtfs_datasets.data = 'GTFS Schedule'
+    INNER JOIN fct_daily_schedule_feeds AS schedule_feeds
+        WHERE schedule_feeds.is_future is False
+        ON schedule_feeds.gtfs_dataset_key = dim_gtfs_datasets.key
+)
+
+SELECT * FROM fact_feeds
+
+
+/* MART_TRIPS
+
+expanded version, add in dim_routes, broadly useful for analysts
+to subset using route_type or route_name
+*/
+WITH fct_daily_scheduled_trips AS (
+    SELECT *
+    FROM {{ ref('fct_daily_scheduled_trips') }}
+),
+
+dim_trips AS (
+    SELECT *
+    FROM {{ ref('dim_trips') }}
+),
+
+-- This table would need to be created
+fact_feeds AS (
+    SELECT *
+    FROM {{ ref('fact_feeds') }}
+),
+
+mart_trips AS (
+    SELECT
+        fct_trips.trip_key,
+        fct_trips.service_date,
+        fct_trips.feed_key,
+        fct_trips.service_id,
+        fct_trips.trip_id,
+        fct_trips.route_key,
+        fct_trips.shape_array_key,
+        fct_trips.gtfs_dataset_key,
+        fct_trips.contains_warning_duplicate_trip_primary_key,
+        fct_trips.n_stops,
+        fct_trips.n_stop_times,
+        fct_trips.trip_first_departure_sec,
+        fct_trips.trip_last_arrival_sec,
+        fct_trips.service_hours,
+        fct_trips.contains_warning_duplicate_stop_times_primary_key,
+        fct_trips.contains_warning_missing_foreign_key_stop_id,
+
+        dim_trips.route_id,
+        dim_trips.trip_short_name,
+        dim_trips.direction_id,
+        dim_trips.block_id,
+
+        dim_routes.route_type,
+        dim_routes.route_short_name,
+        dim_routes.route_long_name,
+        dim_routes.route_desc,
+
+        fact_feeds.name,
+        fact_feeds.regional_feed_type,
+
+    FROM fct_daily_scheduled_trips
+    INNER JOIN dim_trips
+        ON fct_daily_scheduled_trips.trip_key = dim_trips.key
+    LEFT JOIN dim_routes
+        ON fct_daily_scheduled_trips.route_key = dim_routes.key
+    LEFT JOIN fact_feeds
+        ON fact_feeds.gtfs_dataset_key = fct_trips.feed_key
+    -- is this last left join correct?
+)
+
+SELECT * FROM mart_trips
+
+
+/*
+MART_SHAPES
+
+Add a column that counts how many trips occurred for that shape_id
+Might be useful way to sort later, since analysts either select 1 shape_id
+for the route based on number of trips or length
+*/
+WITH fct_daily_scheduled_trips AS (
+    SELECT *
+    FROM {{ ref('fct_daily_scheduled_trips') }}
+),
+
+
+agg_trips AS (
+    SELECT
+        service_date,
+        feed_key,
+        shape_array_key,
+        shape_id,
+        COUNT(DISTINCT trip_key) AS n_trips,
+
+    FROM fct_daily_scheduled_trips
+    GROUP BY service_date, shape_array_key
+),
+
+dim_shapes_arrays AS (
+    SELECT *
+    FROM {{ ref('dim_shapes_arrays') }}
+),
+
+mart_shapes AS (
+    SELECT
+        trips.feed_key,
+        trips.shape_array_key,
+        trips.shape_id,
+
+        dim_shapes_arrays.pt_array,
+
+    FROM agg_trips AS trips
+    INNER JOIN dim_shapes_arrays
+        ON trips.shape_array_key = dim_shapes_arrays.key
+)
+
+SELECT * FROM mart_shapes
+
+/*
+MART_STOPS
+
+pre-assemble with point geom in dbt, always WGS84
+TODO: also work in route_type from dim_routes?
+*/
+WITH fct_daily_scheduled_trips AS (
+    SELECT DISTINCT
+        stop_key,
+        route_key,
+        service_date
+    FROM {{ ref('fct_daily_scheduled_trips') }}
+),
+
+dim_stops AS (
+    SELECT *
+    FROM {{ ref('dim_stops') }}
+),
+
+dim_routes AS (
+    SELECT DISTINCT
+        key,
+        route_type,
+    FROM {{ ref('dim_routes') }}
+),
+
+stops_geom AS (
+    SELECT
+        key,
+        feed_key,
+        stop_id,
+        tts_stop_name,
+        ST_GEOGPOINT(
+            stop_lon,
+            stop_lat
+        ) AS pt_geom,
+        parent_station,
+        stop_code,
+        stop_name,
+        stop_desc,
+        location_type,
+        stop_timezone,
+        wheelchair_boarding,
+    FROM dim_stops
+),
+
+mart_stops AS (
+    FROM fct_daily_scheduled_trips
+    INNER JOIN stops_geom
+        ON fct_daily_scheduled_trips.stop_key = stops_geom.key
+    LEFT JOIN dim_routes
+        ON fct_daily_scheduled_trips.route_key = dim_routes.key
+)
+
+SELECT * FROM mart_stops

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -1,0 +1,252 @@
+"""
+Migrate gtfs_utils from v1 to v2 warehouse.
+
+Changes from v1 to v2:
+1. new feed_key to organization_name table created.
+    Should probably stage in dbt anyway to see what feeds / names
+    are there for the same day?
+    Rather than subsetting by feed_keys, join this new table to
+    all subsequent queries, so analysts can query by org name too.
+
+2. get_trips: expand and move to dbt
+    Rework trips query to better reflect how we use this query as our
+    base query.
+    Bring in route columns we might use to subset
+    (route_type, route_short_name, route_long_name).
+
+    Move this joining into dbt to be a mart_trips table that analysts go to first.
+
+3. get_route_info: deprecate.
+    Instead, expand the trips query to incorporate our most-used
+    route columns from dim_routes to help with subsetting. See #2
+
+4. get_route_shapes: change make_routes_gdf to take pd.DataFrame,
+    keep in gtfs_utils_v2
+    Use dask.apply to apply the make_linestring function.
+    Move this new make_routes_gdf over to geography_utils when it's ready
+    and replace that.
+
+5. get_stops: move to dbt
+    set this up so that point geometry can be created in dbt.
+    Add a mart_stops table that analysts go to first.
+
+6. get_stop_times: TODO
+    TODO. think more on what functions typically come from stop_times.
+    Aggregation, for sure, and that can be handled if it returns dask.dataframe
+    as in previous get_stop_times.
+
+    With new timestamp that's numeric, we might want to add subsetting by departure
+    hour on top of that so we don't have to do the calculation of seconds to
+    departure hour more.
+
+    But are these common use cases enough to justify a new dbt table that
+    acts as mart_stop_times? Leaning towards no for now...
+
+"""
+
+# import os
+# os.environ["CALITP_BQ_MAX_BYTES"] = str(200_000_000_000)
+
+import datetime
+from typing import Union
+
+import dask.dataframe as dd
+
+# import dask_geopandas as dg
+import geopandas as gpd
+import pandas as pd
+import siuba  # need this to do type hint in functions
+from calitp.tables import tbls
+from shared_utils import geography_utils
+from siuba import *
+
+GCS_PROJECT = "cal-itp-data-infra"
+
+# YESTERDAY_DATE = datetime.date.today() + datetime.timedelta(days=-1)
+
+
+def daily_feed_to_organization(
+    selected_date: Union[str, datetime.date], get_df: bool = True
+) -> Union[pd.DataFrame, siuba.sql.verbs.LazyTbl]:
+    """
+    Select a date, find what feeds are present, and
+    merge in organization name.
+    """
+    dim_gtfs_datasets = (
+        tbls.mart_transit_database.dim_gtfs_datasets()
+        >> filter(_["data"] == "GTFS Schedule")
+        >> rename(gtfs_dataset_key="key")
+        >> select(_.gtfs_dataset_key, _.name, _.regional_feed_type)
+        >> distinct()
+    )
+
+    fact_feeds = (
+        tbls.mart_gtfs.fct_daily_schedule_feeds()
+        >> filter((_.date == selected_date))
+        >> inner_join(_, dim_gtfs_datasets, on="gtfs_dataset_key")
+    )
+
+    if get_df:
+        fact_feeds = fact_feeds >> collect()
+
+    return fact_feeds
+
+
+def get_trips(
+    selected_date: Union[str, datetime.date],
+    subset_feeds: list = None,
+    get_df: bool = True,
+) -> Union[pd.DataFrame, siuba.sql.verbs.LazyTbl]:
+    """
+    Modify this for dbt so that we always have route_info query too.
+
+    TODO: metrolink fix.
+    """
+    trips = (
+        tbls.mart_gtfs.fct_daily_scheduled_trips()
+        >> filter(_.service_date == selected_date)
+        >> filter(_.feed_key.isin(subset_feeds))
+        >> inner_join(
+            _,
+            (tbls.mart_gtfs.dim_trips() >> rename(trip_key="key")),
+            on="trip_key",
+        )
+        >> inner_join(
+            _,
+            (
+                tbls.mart_gfs.dim_routes()
+                >> rename(route_key="key")
+                >> select(
+                    _.route_key,
+                    _.route_type,
+                    _.route_short_name,
+                    _.route_long_name,
+                    _.route_desc,
+                )
+            ),
+            on="route_key",
+        )
+        >> distinct()
+    )
+
+    if get_df:
+        trips = trips >> collect()
+
+    return trips
+
+
+def get_route_info(
+    selected_date: Union[str, datetime.date],
+    subset_feeds: list = None,
+    get_df: bool = True,
+) -> Union[pd.DataFrame, siuba.sql.verbs.LazyTbl]:
+    """
+    Want to deprecate this one in v2...bring in columns needed for routes
+    into the expanded trips query. give as much flexibility for
+    subsetting there.
+    """
+    routes = (
+        tbls.mart_gtfs.fct_daily_scheduled_trips()
+        >> filter(_.service_date == selected_date)
+        >> filter(_.feed_key.isin(subset_feeds))
+        >> select(_.route_key, _.service_date)
+        >> distinct()
+        >> inner_join(
+            _, (tbls.mart_gtfs.dim_routes() >> rename(route_key="key")), on="route_key"
+        )
+        >> distinct()
+    )
+
+    if get_df:
+        routes = routes >> collect()
+
+    return routes
+
+
+def make_routes_gdf_NEW(
+    df: pd.DataFrame,
+    crs: str = "EPSG:4326",
+) -> gpd.GeoDataFrame:
+    """
+    Parameters:
+
+    crs: str, a projected coordinate reference system.
+        Defaults to EPSG:4326 (WGS84)
+    """
+    # Use apply to use map_partitions
+    # https://stackoverflow.com/questions/70829491/dask-map-partitions-meta-when-using-lambda-function-to-add-column
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    ddf["geometry"] = ddf.pt_array.apply(
+        geography_utils.make_linestring, meta=("geometry", "geometry")
+    )
+    shapes = ddf.compute()
+
+    # apply the function
+    # df["geometry"] = df.pt_array.apply(geography_utils.make_linestring)
+
+    # convert to geopandas; geometry column contains the linestring, re-project if needed
+    gdf = gpd.GeoDataFrame(
+        shapes.drop(columns="pt_array"), geometry="geometry", crs=geography_utils.WGS84
+    ).to_crs(crs)
+
+    return gdf
+
+
+def get_route_shapes(
+    selected_date: Union[str, datetime.date],
+    subset_feeds: list = None,
+    get_df: bool = True,
+    crs: str = geography_utils.WGS84,
+) -> gpd.GeoDataFrame:
+    """
+    TODO: move make_routes_gdf back to geography_utils later
+    but this needs a pd.DataFrame going in...so keep it here for now
+    """
+
+    route_shapes = (
+        tbls.mart_gtfs.fct_daily_scheduled_trips()
+        >> filter(_.service_date == selected_date)
+        >> filter(_.feed_key.isin(subset_feeds))
+        >> select(_.shape_array_key, _.service_date)
+        >> inner_join(
+            _,
+            (tbls.mart_gtfs.dim_shapes_arrays() >> rename(shape_array_key="key")),
+            on="shape_array_key",
+        )
+        >> collect()
+    )
+
+    shapes_gdf = make_routes_gdf_NEW(route_shapes, crs=crs)
+
+    return shapes_gdf
+
+
+def get_stops(
+    selected_date: Union[str, datetime.date],
+    subset_feeds: list = None,
+    get_df: bool = True,
+) -> Union[pd.DataFrame, siuba.sql.verbs.LazyTbl]:
+    """ """
+    stops = (
+        tbls.mart_gtfs.fct_daily_scheduled_trips()
+        >> filter(_.service_date == selected_date)
+        >> filter(_.feed_key.isin(subset_feeds))
+        >> select(_.stop_key, _.service_date)
+        >> distinct()
+        >> inner_join(
+            _, (tbls.mart_gtfs.dim_stops() >> rename(stop_key="key")), on="stop_key"
+        )
+        >> distinct()
+    )
+
+    if get_df:
+        stops = stops >> collect()
+        stops = geography_utils.create_point_geometry(stops, crs=crs).drop(
+            columns=["stop_lon", "stop_lat"]
+        )
+
+    return stops
+
+
+# TODO: stop_times.


### PR DESCRIPTION
### `gtfs_utils`
* Set up initial `gtfs_utils_v2.py` to mimic what was done in `gtfs_utils`, but leave out the subsetting columns and subsetting by other columns
* Rework some of the logic, no need for subsetting, but need some new tables. We want to move a lot more quickly as dbt models:
   a. Expand `get_trips` in v2 to encompass `get_route_info`, since these are typically used together
   b. Deprecate `get_route_info` then? Leave in script for now, but don't move into dbt
   c. `get_route_shapes` is straightforward move, simply update the `make_linestring` function to use dask to apply it. Add a count of how many trips occurred for this `shape_id` that might be useful.
   d. `get_stops` is straightforward move, also add in `route_type` 
   e. new table: `feed_key` to `organization name` table created so analysts have option to subset by `organization name` or `feed_key`
* TODO: think more about how `get_stop_times` would be joined / subsetted / aggregated. Need to make the Metrolink fix that was in `gtfs_utils` for `get_trips`.
* #564 