### PR TITLE
Trips v1 v2

### DIFF
--- a/gtfs_utils_v2/compare_trips_v1_v2.ipynb
+++ b/gtfs_utils_v2/compare_trips_v1_v2.ipynb
@@ -1,0 +1,1062 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0469029f-11b1-459b-87c4-fd90ac78c576",
+   "metadata": {},
+   "source": [
+    "# Merge v1 and v2 to see which trip_ids are present\n",
+    "\n",
+    "* Start with Oct, then do the same for Nov (but it doesn't appear that schedule data changes much between these 2 dates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5aeecfbf-29df-4028-b92a-8fa2b8e547a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#import os\n",
+    "#os.environ[\"CALITP_BQ_MAX_BYTES\"] = str(1_000_000_000_000)\n",
+    "\n",
+    "import dask.dataframe as dd\n",
+    "import pandas as pd\n",
+    "\n",
+    "#from calitp.tables import tbls\n",
+    "#from siuba import *\n",
+    "\n",
+    "#from shared_utils import rt_utils, gtfs_utils\n",
+    "from shared_utils import rt_dates, geography_utils\n",
+    "\n",
+    "V1_PATH = f\"./v1_data/\"\n",
+    "V2_PATH = \"./v2_data/\"\n",
+    "\n",
+    "oct_date = rt_dates.DATES[\"oct2022\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4dbbec28-4e21-41f8-a2e3-0effa867f26f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'''\n",
+    "ALL_ITP_IDS = (tbls.gtfs_schedule.agency()\n",
+    "               >> distinct(_.calitp_itp_id)\n",
+    "               >> filter(_.calitp_itp_id != 200)\n",
+    "               >> collect()\n",
+    "              ).calitp_itp_id.tolist()\n",
+    "\n",
+    "trips_oct = gtfs_utils.get_trips(\n",
+    "    selected_date = oct_date,\n",
+    "    itp_id_list = ALL_ITP_IDS,\n",
+    "    get_df = True\n",
+    ")\n",
+    "\n",
+    "trips_oct.to_parquet(f\"{V1_PATH}trips_{oct_date}.parquet\")\n",
+    "\n",
+    "trips_nov = gtfs_utils.get_trips(\n",
+    "    selected_date = nov_date,\n",
+    "    itp_id_list = ALL_ITP_IDS,\n",
+    "    get_df = True\n",
+    ")\n",
+    "\n",
+    "trips_nov.to_parquet(f\"{V1_PATH}trips_{nov_date}.parquet\")\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b6cc2e9f-1b3e-4408-b8ae-fa1c9b79e210",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "daily_feeds = pd.read_parquet(\n",
+    "    f\"{V2_PATH}daily_feeds_orgs_{oct_date}.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "efdf69eb-8a6f-4197-a6dd-7b1dd8305b48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v1_id = [\"calitp_itp_id\", \"calitp_url_number\"]\n",
+    "v2_id = [\"feed_key\", \"name\"]\n",
+    "\n",
+    "def import_v1_v2_trips(date: str) -> pd.DataFrame:\n",
+    "    keep_cols = [\n",
+    "        \"trip_id\", \"route_id\", \"shape_id\",\n",
+    "        \"service_hours\"\n",
+    "    ]\n",
+    "    \n",
+    "    df1 = pd.read_parquet(f\"{V1_PATH}trips_{date}.parquet\")\n",
+    "    df1 = df1[v1_id + keep_cols]\n",
+    "    \n",
+    "    df2 = pd.read_parquet(f\"{V2_PATH}trips_{date}.parquet\")\n",
+    "    feed_to_name = pd.read_parquet(\n",
+    "        f\"{V2_PATH}daily_feeds_orgs_{date}.parquet\")\n",
+    "    \n",
+    "    df2 = (df2.rename(columns = {\n",
+    "            \"feed_key_x\": \"feed_key\",\n",
+    "            \"trip_id_x\": \"trip_id\", \n",
+    "            \"route_id_x\": \"route_id\"})\n",
+    "           [[\"feed_key\"] + keep_cols]\n",
+    "          )\n",
+    "    \n",
+    "    exclude_types = [\"Regional Precursor Feed\", \"Combined Regional Feed\"]\n",
+    "    feed_to_name2 = feed_to_name[\n",
+    "        (~feed_to_name.regional_feed_type.isin(exclude_types)) & \n",
+    "        (feed_to_name.is_future == False)\n",
+    "    ].drop_duplicates()\n",
+    "    \n",
+    "    df2 = pd.merge(\n",
+    "        df2,\n",
+    "        feed_to_name2[v2_id + [\"regional_feed_type\"]],\n",
+    "        on = \"feed_key\",\n",
+    "        how = \"outer\",\n",
+    "        validate = \"m:1\"\n",
+    "    )\n",
+    "    \n",
+    "    return df1, df2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "da6ac249-ad4c-46a9-ba80-135ca1597e0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oct1, oct2 = import_v1_v2_trips(oct_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "df1c62e0-1137-40fa-b30a-c262e34e64ca",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(113752.53305555556, 124056.98027777777)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct1.service_hours.sum(), oct2.service_hours.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "607708b1-267b-448a-9253-22dc875b5a6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trip_cols = [\"trip_id\", \"route_id\", \"shape_id\"]\n",
+    "\n",
+    "oct_merge = pd.merge(\n",
+    "    oct1.drop_duplicates(subset=trip_cols), \n",
+    "    oct2.drop_duplicates(subset=trip_cols), \n",
+    "    on = [\"trip_id\", \"route_id\", \"shape_id\", \"service_hours\"],\n",
+    "    how = \"outer\",\n",
+    "    validate = \"1:1\",\n",
+    "    indicator = True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e0f87c2-0b1a-43c4-8176-3d8c584dcf58",
+   "metadata": {},
+   "source": [
+    "## Found in v1 and v2\n",
+    "\n",
+    "Majority is in both, good!\n",
+    "\n",
+    "Need to figure out which feeds to keep in v2 to get at the very small number of missing trips in v1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9fb6e79e-dec5-49b0-b44f-da836325065e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "both          112736\n",
+       "right_only     28880\n",
+       "left_only       4252\n",
+       "Name: _merge, dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct_merge._merge.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3aea33ca-903e-4607-82e4-1f7a49b231ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "113752.53305555556"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct1.drop_duplicates(subset=v1_id + [\"trip_id\"]).service_hours.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1e5d985e-62f6-4b2f-9ed1-badd1a759432",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "94786.39361111113"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# In reality, url_number is not kept, so see how many hours we actually want\n",
+    "oct1.drop_duplicates(\n",
+    "    subset=[\"calitp_itp_id\", \"trip_id\"]).service_hours.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d42b555c-82d4-4415-af1c-1d9e2715c521",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Beaumont?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "66d9c4eb-5db1-4aa4-a8ce-979003f74256",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>_merge</th>\n",
+       "      <th>service_hours</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>left_only</td>\n",
+       "      <td>3097.896667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>right_only</td>\n",
+       "      <td>21332.336111</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>both</td>\n",
+       "      <td>87973.435278</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       _merge  service_hours\n",
+       "0   left_only    3097.896667\n",
+       "1  right_only   21332.336111\n",
+       "2        both   87973.435278"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct_merge.groupby('_merge').agg({\"service_hours\": \"sum\"}).reset_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c371648-bb57-493c-b8a9-a2edf1dc6e9c",
+   "metadata": {},
+   "source": [
+    "## Issue 1: Metrolink\n",
+    "\n",
+    "Once we find Metrolink, there's the same number of observations in both v1 and v2.\n",
+    "\n",
+    "As long as the Metrolink fix can be perpetrated in dbt or through `gtfs_utils_v2`, we'll be good."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6432584f-77ac-4978-8ae0-f40d8fa49d24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrolink1 = oct1[oct1.calitp_itp_id==323]\n",
+    "metrolink2 = oct2[(oct2.name.str.contains(\"Metrolink\")) & \n",
+    "                  (oct2.name.notna())]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3856fc87-2020-4ab7-b7d7-5c93b1da693f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "feed key: 55dfff37f64595b6b8ca3fd3e5499d0d\n",
+      "name: Metrolink Schedule\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"feed key: {metrolink2.feed_key.iloc[0]}\")\n",
+    "print(f\"name: {metrolink2.name.iloc[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "484afcd3-0b3c-4a4a-a6ab-65b0d9f439a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(225.58333333333334, 225.58333333333334)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "metrolink1.service_hours.sum(), metrolink2.service_hours.sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47b6fbed-7966-47db-bb84-c27a38c176ea",
+   "metadata": {},
+   "source": [
+    "## Issue 2: Non-Metrolink"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5fb8f6a6-ea97-4815-9ac2-5c47e0a34369",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oct_issues = oct_merge[(oct_merge._merge!=\"both\") & \n",
+    "                       (oct_merge.calitp_itp_id != 323) & \n",
+    "                       (oct_merge.name != \"Metrolink Schedule\")\n",
+    "                      ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1564ca77-697e-4823-b7d1-2bc1dc229c49",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "right_only    28742\n",
+       "left_only      4114\n",
+       "both              0\n",
+       "Name: _merge, dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct_issues._merge.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "eab07bb0-4838-4beb-89ea-b1408e9f6d00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def separate_v1_v2(merged_df):\n",
+    "    \n",
+    "    keep_cols = [\n",
+    "        \"trip_id\", \"route_id\", \"shape_id\",\n",
+    "        \"service_hours\"\n",
+    "    ]\n",
+    "    \n",
+    "    v1 = merged_df[merged_df._merge==\"left_only\"][v1_id + keep_cols]\n",
+    "    \n",
+    "    v2 = merged_df[merged_df._merge==\"right_only\"][v2_id + keep_cols]\n",
+    "    \n",
+    "    return v1, v2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ccf436ba-4b99-44d4-8fe1-69ca41fb8ea3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v1, v2 = separate_v1_v2(oct_issues)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "0d679673-763e-4baa-b36c-8d940a55570c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "both          4\n",
+       "left_only     0\n",
+       "right_only    0\n",
+       "Name: _merge, dtype: int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "    v1,\n",
+    "    v2,\n",
+    "    on = [\"route_id\", \"service_hours\"],\n",
+    "    how = \"inner\",\n",
+    "    indicator=True\n",
+    ")._merge.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "205d2ab7-f1e7-4a64-b098-15d498e4a63d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "both          30\n",
+       "left_only      0\n",
+       "right_only     0\n",
+       "Name: _merge, dtype: int64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "    v1,\n",
+    "    v2,\n",
+    "    on = [\"route_id\"],\n",
+    "    how = \"inner\",\n",
+    "    indicator=True\n",
+    ")._merge.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "86c07207-7243-4107-acc2-82d6ce4554f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "both          8\n",
+       "left_only     0\n",
+       "right_only    0\n",
+       "Name: _merge, dtype: int64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "    v1,\n",
+    "    v2,\n",
+    "    on = [\"shape_id\", \"route_id\"],\n",
+    "    how = \"inner\",\n",
+    "    indicator=True\n",
+    ")._merge.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "804b820a-2153-4b15-b7b0-2b33cc03d910",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v1_agg = geography_utils.aggregate_by_geography(\n",
+    "    v1, \n",
+    "    group_cols = v1_id,\n",
+    "    nunique_cols = [\"shape_id\", \"route_id\", \"trip_id\"],\n",
+    "    sum_cols = [\"service_hours\"],\n",
+    "    rename_cols = True\n",
+    ").sort_values(by = [\"trip_id_nunique\", \"route_id_nunique\", \n",
+    "                    \"service_hours_sum\"], \n",
+    "              ascending=[True, True, True]\n",
+    "             ).reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "bf1bb63d-fbd2-4562-9097-a38e761adf9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v2_agg = geography_utils.aggregate_by_geography(\n",
+    "    v2,\n",
+    "    group_cols = v2_id,\n",
+    "    nunique_cols = [\"shape_id\", \"route_id\", \"trip_id\"],\n",
+    "    sum_cols = [\"service_hours\"],\n",
+    "    rename_cols = True\n",
+    ").sort_values(by = [\"trip_id_nunique\", \"route_id_nunique\", \n",
+    "                    \"service_hours_sum\"], \n",
+    "              ascending=[True, True, True]\n",
+    "             ).reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "0aa1b066-3fd6-4eb2-bf77-103d0cbb5a41",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2872.3133333333335"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v1_agg.service_hours_sum.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "a073df37-6202-4bfe-aadd-e1ff1242b479",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.75"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v2_agg.service_hours_sum.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "17375e8b-5305-44e5-a358-b68b13a8cac3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "21106.75277777778"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geography_utils.aggregate_by_geography(\n",
+    "    v2,\n",
+    "    group_cols = [\"feed_key\"],\n",
+    "    nunique_cols = [\"shape_id\", \"route_id\", \"trip_id\"],\n",
+    "    sum_cols = [\"service_hours\"],\n",
+    "    rename_cols = True\n",
+    ").sort_values(by = [\"trip_id_nunique\", \"route_id_nunique\", \n",
+    "                    \"service_hours_sum\"], \n",
+    "              ascending=[True, True, True]\n",
+    "             ).reset_index(drop=True).service_hours_sum.sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66321125-7062-4ee2-97af-865532aa6e69",
+   "metadata": {},
+   "source": [
+    "Something happens once `name` is included. \n",
+    "\n",
+    "The 21k extra hours drops down to 3??"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "a5db977f-a0ff-4949-ba27-560bcf31db45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v1_unique_feeds  = oct_merge[v1_id + [\"_merge\"]].drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "dd9cba20-733e-40fc-8231-0ac6b61c4be6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "left_only     197\n",
+       "both           14\n",
+       "right_only      0\n",
+       "Name: unmerged, dtype: int64"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v1_unmerged = pd.merge(\n",
+    "    v1_unique_feeds,\n",
+    "    v1_agg,\n",
+    "    on = v1_id,\n",
+    "    how = \"outer\",\n",
+    "    validate = \"m:1\",\n",
+    "    indicator = \"unmerged\"\n",
+    ")\n",
+    "\n",
+    "v1_unmerged.unmerged.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "6fe291ec-9183-4697-8491-522d7014263f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>_merge</th>\n",
+       "      <th>service_hours_sum</th>\n",
+       "      <th>route_id_nunique</th>\n",
+       "      <th>shape_id_nunique</th>\n",
+       "      <th>trip_id_nunique</th>\n",
+       "      <th>unmerged</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>36.597222</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>23.0</td>\n",
+       "      <td>157.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>both</td>\n",
+       "      <td>36.597222</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>23.0</td>\n",
+       "      <td>157.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>4.416667</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>both</td>\n",
+       "      <td>4.416667</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50</th>\n",
+       "      <td>367.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>45.004722</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55</th>\n",
+       "      <td>346.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>147.333333</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>39.0</td>\n",
+       "      <td>137.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>87</th>\n",
+       "      <td>280.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>83.166667</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>141.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>108</th>\n",
+       "      <td>127.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>293.483333</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>206.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>126</th>\n",
+       "      <td>127.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>33.000000</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>61.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>133</th>\n",
+       "      <td>117.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>39.416667</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>15.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>187</th>\n",
+       "      <td>14.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>251.694722</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>841.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>188</th>\n",
+       "      <td>14.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>both</td>\n",
+       "      <td>251.694722</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>841.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>197</th>\n",
+       "      <td>290.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>1269.700000</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>171.0</td>\n",
+       "      <td>1385.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>199</th>\n",
+       "      <td>484.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>left_only</td>\n",
+       "      <td>668.500000</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>73.0</td>\n",
+       "      <td>1077.0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number     _merge  service_hours_sum  \\\n",
+       "8            247.0                1.0  left_only          36.597222   \n",
+       "9            247.0                1.0       both          36.597222   \n",
+       "19            34.0                0.0  left_only           4.416667   \n",
+       "20            34.0                0.0       both           4.416667   \n",
+       "50           367.0                0.0  left_only          45.004722   \n",
+       "55           346.0                0.0  left_only         147.333333   \n",
+       "87           280.0                0.0  left_only          83.166667   \n",
+       "108          127.0                1.0  left_only         293.483333   \n",
+       "126          127.0                2.0  left_only          33.000000   \n",
+       "133          117.0                0.0  left_only          39.416667   \n",
+       "187           14.0                0.0  left_only         251.694722   \n",
+       "188           14.0                0.0       both         251.694722   \n",
+       "197          290.0                0.0  left_only        1269.700000   \n",
+       "199          484.0                0.0  left_only         668.500000   \n",
+       "\n",
+       "     route_id_nunique  shape_id_nunique  trip_id_nunique unmerged  \n",
+       "8                 8.0              23.0            157.0     both  \n",
+       "9                 8.0              23.0            157.0     both  \n",
+       "19                1.0               2.0              4.0     both  \n",
+       "20                1.0               2.0              4.0     both  \n",
+       "50                3.0               4.0             65.0     both  \n",
+       "55               10.0              39.0            137.0     both  \n",
+       "87                6.0              33.0            141.0     both  \n",
+       "108              10.0              21.0            206.0     both  \n",
+       "126               4.0              13.0             61.0     both  \n",
+       "133               7.0              15.0             40.0     both  \n",
+       "187               9.0              30.0            841.0     both  \n",
+       "188               9.0              30.0            841.0     both  \n",
+       "197              70.0             171.0           1385.0     both  \n",
+       "199              30.0              73.0           1077.0     both  "
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v1_unmerged[v1_unmerged.unmerged==\"both\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36a18c9a-c663-43cf-8b61-5a55aa45e04e",
+   "metadata": {},
+   "source": [
+    "Try another approach:\n",
+    "\n",
+    "We always narrow down to operator-trips\n",
+    "\n",
+    "Need to figure out how to do the same in v2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "3c041eb8-6c5b-4385-9863-5285662d5241",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "94786.39361111113"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct1.drop_duplicates(subset=[\"calitp_itp_id\", \"trip_id\"]\n",
+    "                    ).service_hours.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "0fe80d03-408b-4a82-b7a6-fdca4de6aa32",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "123796.93027777778"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct2.drop_duplicates(subset=[\"name\", \"trip_id\"]\n",
+    "                    ).service_hours.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b74e45aa-d14d-404a-ac1b-4922d8717ec3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtfs_utils_v2/compare_trips_v1_v2.ipynb
+++ b/gtfs_utils_v2/compare_trips_v1_v2.ipynb
@@ -5,9 +5,35 @@
    "id": "0469029f-11b1-459b-87c4-fd90ac78c576",
    "metadata": {},
    "source": [
-    "# Merge v1 and v2 to see which trip_ids are present\n",
+    "# Merge v1 and v2 trip tables \n",
     "\n",
-    "* Start with Oct, then do the same for Nov (but it doesn't appear that schedule data changes much between these 2 dates)"
+    "* Start with Oct, then do the same for Nov (but it doesn't appear that schedule data changes much between these 2 dates)\n",
+    "* Merge trip tables, merging on `route_id-shape_id-trip_id-service_hours`\n",
+    "* Allow a `m:m` merge at the trip-level, since we won't have a way to link `itp_id-url_number` to `feed_key-name` otherwise.\n",
+    "* Aggregate up to the operator level to deep dive into how those merges performed.\n",
+    "\n",
+    "### 4 major cases to explore\n",
+    "#### (1): v1 and v2 merged, and there are 1 or 2 feeds present.\n",
+    "* These are the most clean cut cases, where generally there's a primary feed with `url_number==0`. In general, the MTC feed is excluded, and agency feeds are used.\n",
+    "#### (2): v1 and v2 merged, and there are more than 2 feeds present.\n",
+    "* Take a closer look at these to make sure that dropping precursor feeds or just doing regional subfeeds will handle it correctly.\n",
+    "#### (3): v1 and v2 resulted in left_only and both merge values\n",
+    "* Get into why this happens. Let's just keep the feeds that give us the `both` instead of `left` (in v1 with `itp_id-url_number` but not v2 with `feed_key-name` \n",
+    "* We will throw away some feeds from v1, or `url_numbers` here\n",
+    "#### (4): v1 and v2 resulted in left_only and right_only merge values\n",
+    "* None fit this case\n",
+    "\n",
+    "### Double check aggregate feeds\n",
+    "* Discover that v1 still comes up with way more hours than v2.\n",
+    "* Dive into each operator, and find that in v2, for the same `feed_key`, it was stored as different `itp_ids` in v1. \n",
+    "* Dropping duplicates in v1 only handles *within* operator differences, aka, multiple feeds, as indicated by multiple `url_numbers`. \n",
+    "* But, since these are stored as different `itp_ids`, but linked to the same organization in Airtable, v2 now stores them under the same `feed_key`, and drop duplicates would drop a lot more.\n",
+    "\n",
+    "\n",
+    "### Set up function to query feeds on a given day\n",
+    "As a result of the above findings, how should the `feed_keys` be queried in a way to find the organizations we want?\n",
+    "\n",
+    "Allow subset of feeds to be found by operators to **include** or **exclude**."
    ]
   },
   {
@@ -25,54 +51,12 @@
     }
    ],
    "source": [
-    "#import os\n",
-    "#os.environ[\"CALITP_BQ_MAX_BYTES\"] = str(1_000_000_000_000)\n",
-    "\n",
-    "import dask.dataframe as dd\n",
     "import pandas as pd\n",
     "\n",
-    "#from calitp.tables import tbls\n",
-    "#from siuba import *\n",
-    "\n",
-    "#from shared_utils import rt_utils, gtfs_utils\n",
     "from shared_utils import rt_dates, geography_utils\n",
     "\n",
-    "V1_PATH = f\"./v1_data/\"\n",
-    "V2_PATH = \"./v2_data/\"\n",
-    "\n",
-    "oct_date = rt_dates.DATES[\"oct2022\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4dbbec28-4e21-41f8-a2e3-0effa867f26f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "'''\n",
-    "ALL_ITP_IDS = (tbls.gtfs_schedule.agency()\n",
-    "               >> distinct(_.calitp_itp_id)\n",
-    "               >> filter(_.calitp_itp_id != 200)\n",
-    "               >> collect()\n",
-    "              ).calitp_itp_id.tolist()\n",
-    "\n",
-    "trips_oct = gtfs_utils.get_trips(\n",
-    "    selected_date = oct_date,\n",
-    "    itp_id_list = ALL_ITP_IDS,\n",
-    "    get_df = True\n",
-    ")\n",
-    "\n",
-    "trips_oct.to_parquet(f\"{V1_PATH}trips_{oct_date}.parquet\")\n",
-    "\n",
-    "trips_nov = gtfs_utils.get_trips(\n",
-    "    selected_date = nov_date,\n",
-    "    itp_id_list = ALL_ITP_IDS,\n",
-    "    get_df = True\n",
-    ")\n",
-    "\n",
-    "trips_nov.to_parquet(f\"{V1_PATH}trips_{nov_date}.parquet\")\n",
-    "'''"
+    "oct_date = rt_dates.DATES[\"oct2022\"]\n",
+    "GCS_FILE_PATH = \"gs://calitp-analytics-data/data-analyses/gtfs_v1_v2_parity/\""
    ]
   },
   {
@@ -83,60 +67,66 @@
    "outputs": [],
    "source": [
     "daily_feeds = pd.read_parquet(\n",
-    "    f\"{V2_PATH}daily_feeds_orgs_{oct_date}.parquet\")"
+    "    f\"{GCS_FILE_PATH}daily_feeds_orgs_{oct_date}.parquet\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "efdf69eb-8a6f-4197-a6dd-7b1dd8305b48",
+   "id": "ee9cafda-335d-4472-8609-d81f63fb9a08",
    "metadata": {},
    "outputs": [],
    "source": [
-    "v1_id = [\"calitp_itp_id\", \"calitp_url_number\"]\n",
-    "v2_id = [\"feed_key\", \"name\"]\n",
+    "def prep_v2_trip(date: str) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Quick renaming to deal with _x and _y column names.\n",
+    "    This won't happen in the dbt tables.\n",
+    "    \"\"\"\n",
+    "    df = pd.read_parquet(f\"{GCS_FILE_PATH}trips_{date}_v2.parquet\")\n",
+    "    \n",
+    "    # Accidentally left out columns in merge_cols,\n",
+    "    # so now there's _x and _y versions\n",
+    "    df2 = (df.rename(columns = {\n",
+    "                \"feed_key_x\": \"feed_key\",\n",
+    "                \"trip_id_x\": \"trip_id\", \n",
+    "                \"route_id_x\": \"route_id\"})\n",
+    "          )[[\"feed_key\", \"trip_id\", \"route_id\", \n",
+    "             \"shape_id\", \"service_hours\"]]\n",
     "\n",
-    "def import_v1_v2_trips(date: str) -> pd.DataFrame:\n",
-    "    keep_cols = [\n",
-    "        \"trip_id\", \"route_id\", \"shape_id\",\n",
-    "        \"service_hours\"\n",
-    "    ]\n",
-    "    \n",
-    "    df1 = pd.read_parquet(f\"{V1_PATH}trips_{date}.parquet\")\n",
-    "    df1 = df1[v1_id + keep_cols]\n",
-    "    \n",
-    "    df2 = pd.read_parquet(f\"{V2_PATH}trips_{date}.parquet\")\n",
-    "    feed_to_name = pd.read_parquet(\n",
-    "        f\"{V2_PATH}daily_feeds_orgs_{date}.parquet\")\n",
-    "    \n",
-    "    df2 = (df2.rename(columns = {\n",
-    "            \"feed_key_x\": \"feed_key\",\n",
-    "            \"trip_id_x\": \"trip_id\", \n",
-    "            \"route_id_x\": \"route_id\"})\n",
-    "           [[\"feed_key\"] + keep_cols]\n",
-    "          )\n",
-    "    \n",
-    "    exclude_types = [\"Regional Precursor Feed\", \"Combined Regional Feed\"]\n",
-    "    feed_to_name2 = feed_to_name[\n",
-    "        (~feed_to_name.regional_feed_type.isin(exclude_types)) & \n",
-    "        (feed_to_name.is_future == False)\n",
-    "    ].drop_duplicates()\n",
-    "    \n",
-    "    df2 = pd.merge(\n",
-    "        df2,\n",
-    "        feed_to_name2[v2_id + [\"regional_feed_type\"]],\n",
-    "        on = \"feed_key\",\n",
-    "        how = \"outer\",\n",
-    "        validate = \"m:1\"\n",
-    "    )\n",
-    "    \n",
-    "    return df1, df2"
+    "    return df2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "da6ac249-ad4c-46a9-ba80-135ca1597e0c",
+   "id": "8f939e79-9867-4546-8fd5-7eca58aee451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v1_id = [\"calitp_itp_id\", \"calitp_url_number\"]\n",
+    "v2_id = [\"feed_key\"]\n",
+    "\n",
+    "def import_v1_v2_trips(date: str) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Import v1 and v2 data for the same day.\n",
+    "    \"\"\"\n",
+    "    keep_cols = [\n",
+    "        \"trip_id\", \"route_id\", \"shape_id\",\n",
+    "        \"service_hours\"\n",
+    "    ]\n",
+    "    \n",
+    "    df1 = pd.read_parquet(f\"{GCS_FILE_PATH}trips_{date}_v1.parquet\")\n",
+    "    df1 = df1[v1_id + keep_cols]\n",
+    "    \n",
+    "    df2 = prep_v2_trip(date)[v2_id + keep_cols]\n",
+    "\n",
+    "    return df1, df2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5957b362-27a4-45f8-bd5f-f87b95878ed9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,138 +135,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "df1c62e0-1137-40fa-b30a-c262e34e64ca",
+   "execution_count": 6,
+   "id": "fa8dfb0e-242e-4d01-9638-6a45fc1f94cc",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "(113752.53305555556, 124056.98027777777)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# rows in v1 (feed-operator) (212, 2)\n",
+      "# rows in v2 (feed-operator) (187, 1)\n"
+     ]
     }
    ],
    "source": [
-    "oct1.service_hours.sum(), oct2.service_hours.sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "607708b1-267b-448a-9253-22dc875b5a6d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trip_cols = [\"trip_id\", \"route_id\", \"shape_id\"]\n",
-    "\n",
-    "oct_merge = pd.merge(\n",
-    "    oct1.drop_duplicates(subset=trip_cols), \n",
-    "    oct2.drop_duplicates(subset=trip_cols), \n",
-    "    on = [\"trip_id\", \"route_id\", \"shape_id\", \"service_hours\"],\n",
-    "    how = \"outer\",\n",
-    "    validate = \"1:1\",\n",
-    "    indicator = True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1e0f87c2-0b1a-43c4-8176-3d8c584dcf58",
-   "metadata": {},
-   "source": [
-    "## Found in v1 and v2\n",
-    "\n",
-    "Majority is in both, good!\n",
-    "\n",
-    "Need to figure out which feeds to keep in v2 to get at the very small number of missing trips in v1."
+    "print(f\"# rows in v1 (feed-operator) {oct1[v1_id].drop_duplicates().shape}\")\n",
+    "print(f\"# rows in v2 (feed-operator) {oct2[['feed_key']].drop_duplicates().shape}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "9fb6e79e-dec5-49b0-b44f-da836325065e",
+   "id": "55f6ef18-ee5e-4182-9db4-a4f91ac41e87",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "both          112736\n",
-       "right_only     28880\n",
-       "left_only       4252\n",
-       "Name: _merge, dtype: int64"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "oct_merge._merge.value_counts()"
+    "# Use this as a crosswalk to see \n",
+    "# allow m:m merge\n",
+    "oct_merge = pd.merge(\n",
+    "    oct1, \n",
+    "    oct2,\n",
+    "    on = [\"trip_id\", \"route_id\", \"shape_id\", \"service_hours\"],\n",
+    "    how = \"outer\",\n",
+    "    validate = \"m:m\",\n",
+    "    indicator = True\n",
+    ")[v1_id + v2_id + [\"_merge\"]\n",
+    " ].drop_duplicates().reset_index(drop=True)\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3aea33ca-903e-4607-82e4-1f7a49b231ec",
+   "id": "1f4cf657-920b-458f-833e-3a1c828c45b5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "113752.53305555556"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "oct1.drop_duplicates(subset=v1_id + [\"trip_id\"]).service_hours.sum()"
+    "oct_merge2 = pd.merge(\n",
+    "    oct_merge,\n",
+    "    daily_feeds[[\"feed_key\", \"name\", \"regional_feed_type\", \"is_future\"]],\n",
+    "    on = \"feed_key\",\n",
+    "    how = \"outer\",\n",
+    "    validate = \"m:1\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1e5d985e-62f6-4b2f-9ed1-badd1a759432",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "94786.39361111113"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# In reality, url_number is not kept, so see how many hours we actually want\n",
-    "oct1.drop_duplicates(\n",
-    "    subset=[\"calitp_itp_id\", \"trip_id\"]).service_hours.sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d42b555c-82d4-4415-af1c-1d9e2715c521",
+   "id": "4f877e12-3694-41e1-bf69-dc349f804ad3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Beaumont?"
+    "# Instead of a _merge variable holding values,\n",
+    "# change it to dummy variables and aggregate by itp_id\n",
+    "oct_merge2 = pd.merge(\n",
+    "    oct_merge2.drop(columns = \"_merge\"),\n",
+    "    pd.get_dummies(oct_merge2._merge),\n",
+    "    left_index=True,\n",
+    "    right_index=True\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "66d9c4eb-5db1-4aa4-a8ce-979003f74256",
+   "id": "6c2ca189-e515-4bf2-ba21-dad4c6b13320",
    "metadata": {},
    "outputs": [
     {
@@ -300,35 +233,35 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>_merge</th>\n",
-       "      <th>service_hours</th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>both</th>\n",
+       "      <th>right_only</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>left_only</td>\n",
-       "      <td>3097.896667</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>right_only</td>\n",
-       "      <td>21332.336111</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>both</td>\n",
-       "      <td>87973.435278</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "       _merge  service_hours\n",
-       "0   left_only    3097.896667\n",
-       "1  right_only   21332.336111\n",
-       "2        both   87973.435278"
+       "   calitp_itp_id  left_only  both  right_only\n",
+       "0            4.0          0     4           0\n",
+       "1            6.0          0     1           0"
       ]
      },
      "execution_count": 10,
@@ -337,193 +270,293 @@
     }
    ],
    "source": [
-    "oct_merge.groupby('_merge').agg({\"service_hours\": \"sum\"}).reset_index()"
+    "merge_counts = (oct_merge2.groupby(\"calitp_itp_id\")\n",
+    "                .agg({\"left_only\": \"sum\",\n",
+    "                      \"both\": \"sum\",\n",
+    "                      \"right_only\": \"sum\"})\n",
+    "                .reset_index()\n",
+    "               )\n",
+    "\n",
+    "merge_counts.head(2)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9c371648-bb57-493c-b8a9-a2edf1dc6e9c",
+   "id": "f439dd6e-e237-4114-9514-3084bc8e4a8d",
    "metadata": {},
    "source": [
-    "## Issue 1: Metrolink\n",
+    "## Case 1: Both and 1 or 2 feeds\n",
     "\n",
-    "Once we find Metrolink, there's the same number of observations in both v1 and v2.\n",
-    "\n",
-    "As long as the Metrolink fix can be perpetrated in dbt or through `gtfs_utils_v2`, we'll be good."
+    "If 2 feeds, pick regional subfeed"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6432584f-77ac-4978-8ae0-f40d8fa49d24",
+   "id": "3a35141e-5da5-4a58-976a-80a5624a6f3a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "metrolink1 = oct1[oct1.calitp_itp_id==323]\n",
-    "metrolink2 = oct2[(oct2.name.str.contains(\"Metrolink\")) & \n",
-    "                  (oct2.name.notna())]"
+    "def get_id_list(df: pd.DataFrame):\n",
+    "    \"\"\"\n",
+    "    From a subset df, return itp_id as list\n",
+    "    \"\"\"\n",
+    "    return df.calitp_itp_id.tolist()\n",
+    "\n",
+    "def print_regional_feed(df: pd.DataFrame, id_list:list):\n",
+    "    \"\"\"\n",
+    "    Explore how many of the duplicates are due to \n",
+    "    various regional_feed_types. Should these get dropped ahead of time?\n",
+    "    \"\"\"\n",
+    "    subset = df[df.calitp_itp_id.isin(id_list)]\n",
+    "    print(subset.regional_feed_type.value_counts())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3856fc87-2020-4ab7-b7d7-5c93b1da693f",
+   "id": "2b6f0bf5-7cec-4e81-aad7-f2b75ef58d17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def feeds_to_keep(df: pd.DataFrame, id_list: list):\n",
+    "    \"\"\"\n",
+    "    Subset the df to select certain itp_ids and \n",
+    "    also drop regional precursor feeds. \n",
+    "    Keep these for now, and see if the service_hours are the same\n",
+    "    in v1 and v2.\n",
+    "    \"\"\"\n",
+    "    subset = df[(df.calitp_itp_id.isin(id_list)) & \n",
+    "                (df.regional_feed_type != \"Regional Precursor Feed\")\n",
+    "               ]\n",
+    "    return subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a66c954c-1ea1-401c-83f6-be6976208bb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def v1_v2_service_hours(v1_df: pd.DataFrame, \n",
+    "                        v2_df: pd.DataFrame,\n",
+    "                        subset_feeds: pd.DataFrame):\n",
+    "    \"\"\"\n",
+    "    For the subset of feeds to keep, check whether v1 and v2\n",
+    "    service hours are the same.\n",
+    "    \"\"\"\n",
+    "    v1_subset = pd.merge(\n",
+    "        v1_df,\n",
+    "        subset_feeds,\n",
+    "        on = v1_id,\n",
+    "        how = \"inner\"\n",
+    "    )\n",
+    "    \n",
+    "    v2_subset = pd.merge(\n",
+    "        v2_df,\n",
+    "        subset_feeds,\n",
+    "        on = v2_id,\n",
+    "        how = \"inner\"\n",
+    "    )\n",
+    "    \n",
+    "    v1_hours = v1_subset.service_hours.sum().round(3)\n",
+    "    v2_hours = v2_subset.service_hours.sum().round(3)\n",
+    "    \n",
+    "    print(v1_hours, v2_hours)\n",
+    "    \n",
+    "    if v1_hours == v2_hours:\n",
+    "        status = \"EQUAL\"\n",
+    "    else:\n",
+    "        status = \"CHECK ME\"\n",
+    "    \n",
+    "    return status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7042cad3-eef9-4141-92a6-551ad90f5a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# No mixed merges\n",
+    "# It's ok that there are more than 2 observations...looks like\n",
+    "# Regional Precursor Feeds are included\n",
+    "both_ids = merge_counts[(merge_counts.left_only==0) & \n",
+    "                        (merge_counts.right_only==0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "bc30445e-7429-4bc0-af51-217841263922",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "feed key: 55dfff37f64595b6b8ca3fd3e5499d0d\n",
-      "name: Metrolink Schedule\n"
+      "Regional Subfeed           7\n",
+      "Regional Precursor Feed    5\n",
+      "Combined Regional Feed     1\n",
+      "Name: regional_feed_type, dtype: int64\n"
      ]
     }
    ],
    "source": [
-    "print(f\"feed key: {metrolink2.feed_key.iloc[0]}\")\n",
-    "print(f\"name: {metrolink2.name.iloc[0]}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "484afcd3-0b3c-4a4a-a6ab-65b0d9f439a6",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(225.58333333333334, 225.58333333333334)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "metrolink1.service_hours.sum(), metrolink2.service_hours.sum()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47b6fbed-7966-47db-bb84-c27a38c176ea",
-   "metadata": {},
-   "source": [
-    "## Issue 2: Non-Metrolink"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "5fb8f6a6-ea97-4815-9ac2-5c47e0a34369",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "oct_issues = oct_merge[(oct_merge._merge!=\"both\") & \n",
-    "                       (oct_merge.calitp_itp_id != 323) & \n",
-    "                       (oct_merge.name != \"Metrolink Schedule\")\n",
-    "                      ]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "1564ca77-697e-4823-b7d1-2bc1dc229c49",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "right_only    28742\n",
-       "left_only      4114\n",
-       "both              0\n",
-       "Name: _merge, dtype: int64"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "oct_issues._merge.value_counts()"
+    "one_feed = get_id_list(both_ids[both_ids.both==1])\n",
+    "print_regional_feed(oct_merge2, one_feed)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "eab07bb0-4838-4beb-89ea-b1408e9f6d00",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def separate_v1_v2(merged_df):\n",
-    "    \n",
-    "    keep_cols = [\n",
-    "        \"trip_id\", \"route_id\", \"shape_id\",\n",
-    "        \"service_hours\"\n",
-    "    ]\n",
-    "    \n",
-    "    v1 = merged_df[merged_df._merge==\"left_only\"][v1_id + keep_cols]\n",
-    "    \n",
-    "    v2 = merged_df[merged_df._merge==\"right_only\"][v2_id + keep_cols]\n",
-    "    \n",
-    "    return v1, v2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "ccf436ba-4b99-44d4-8fe1-69ca41fb8ea3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "v1, v2 = separate_v1_v2(oct_issues)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "0d679673-763e-4baa-b36c-8d940a55570c",
+   "id": "5528c088-ecc5-4325-b509-0cfa8efec781",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "48054.132 48054.132\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "both          4\n",
-       "left_only     0\n",
-       "right_only    0\n",
-       "Name: _merge, dtype: int64"
+       "'EQUAL'"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pd.merge(\n",
-    "    v1,\n",
-    "    v2,\n",
-    "    on = [\"route_id\", \"service_hours\"],\n",
-    "    how = \"inner\",\n",
-    "    indicator=True\n",
-    ")._merge.value_counts()"
+    "part1 = feeds_to_keep(oct_merge2, one_feed)\n",
+    "v1_v2_service_hours(oct1, oct2, part1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1307ba09-cfa0-4dfb-9085-06d278f1351a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keep_one_feed = oct_merge2[oct_merge2.calitp_itp_id.isin(one_feed)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0ab30086-c6d7-4f58-bcbc-cdbcc4a58baf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regional Precursor Feed    12\n",
+      "Regional Subfeed           11\n",
+      "Combined Regional Feed      1\n",
+      "Name: regional_feed_type, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "two_feeds = get_id_list(both_ids[both_ids.both==2])\n",
+    "print_regional_feed(oct_merge2, two_feeds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ef091ef1-926d-4d1d-a2fa-4c35a8fff75d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "22422.045 22422.045\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'EQUAL'"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "part2 = feeds_to_keep(oct_merge2, two_feeds)\n",
+    "v1_v2_service_hours(oct1, oct2, part2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "02cf925f-900a-45cb-9cd9-b6c6847259a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keep_two_feeds = oct_merge2[oct_merge2.calitp_itp_id.isin(two_feeds)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "935e0d40-742f-4521-916a-e32e367ef173",
+   "metadata": {},
+   "source": [
+    "## Case 2: Both and more than 2 feeds\n",
+    "\n",
+    "* Get rid of `regional_feed_type = \"Regional Precursor Feed\"` because there are instances of more than 2 feeds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "d83861c2-fd63-4bb0-abc7-0400d4f821c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regional Precursor Feed    24\n",
+      "Regional Subfeed           21\n",
+      "Name: regional_feed_type, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "more_than_2_feeds = get_id_list(both_ids[both_ids.both > 2])\n",
+    "print_regional_feed(oct_merge2, more_than_2_feeds)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "205d2ab7-f1e7-4a64-b098-15d498e4a63d",
+   "id": "c7d7f629-9aba-4ada-95e8-f008437a6729",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "31393.084 31393.084\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "both          30\n",
-       "left_only      0\n",
-       "right_only     0\n",
-       "Name: _merge, dtype: int64"
+       "'EQUAL'"
       ]
      },
      "execution_count": 22,
@@ -532,212 +565,1022 @@
     }
    ],
    "source": [
-    "pd.merge(\n",
-    "    v1,\n",
-    "    v2,\n",
-    "    on = [\"route_id\"],\n",
-    "    how = \"inner\",\n",
-    "    indicator=True\n",
-    ")._merge.value_counts()"
+    "part3 = feeds_to_keep(oct_merge2, more_than_2_feeds)\n",
+    "v1_v2_service_hours(oct1, oct2, part3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "886133c8-bb03-4abd-9985-53a633dfa5f4",
+   "metadata": {},
+   "source": [
+    "## Case 3: Mixed merges: operator has left and both merges"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "86c07207-7243-4107-acc2-82d6ce4554f5",
+   "id": "d27535bb-6344-49eb-9c00-396baf8b8995",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "both          8\n",
-       "left_only     0\n",
-       "right_only    0\n",
-       "Name: _merge, dtype: int64"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regional Subfeed           4\n",
+      "Regional Precursor Feed    2\n",
+      "Name: regional_feed_type, dtype: int64\n"
+     ]
     }
    ],
    "source": [
-    "pd.merge(\n",
-    "    v1,\n",
-    "    v2,\n",
-    "    on = [\"shape_id\", \"route_id\"],\n",
-    "    how = \"inner\",\n",
-    "    indicator=True\n",
-    ")._merge.value_counts()"
+    "left_and_both = merge_counts[(merge_counts.left_only > 0) &\n",
+    "                             (merge_counts.both > 0) & \n",
+    "                             (merge_counts.right_only == 0)]\n",
+    "\n",
+    "left_and_both_ids = get_id_list(left_and_both)\n",
+    "print_regional_feed(oct_merge2, left_and_both_ids)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "804b820a-2153-4b15-b7b0-2b33cc03d910",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "v1_agg = geography_utils.aggregate_by_geography(\n",
-    "    v1, \n",
-    "    group_cols = v1_id,\n",
-    "    nunique_cols = [\"shape_id\", \"route_id\", \"trip_id\"],\n",
-    "    sum_cols = [\"service_hours\"],\n",
-    "    rename_cols = True\n",
-    ").sort_values(by = [\"trip_id_nunique\", \"route_id_nunique\", \n",
-    "                    \"service_hours_sum\"], \n",
-    "              ascending=[True, True, True]\n",
-    "             ).reset_index(drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "bf1bb63d-fbd2-4562-9097-a38e761adf9d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "v2_agg = geography_utils.aggregate_by_geography(\n",
-    "    v2,\n",
-    "    group_cols = v2_id,\n",
-    "    nunique_cols = [\"shape_id\", \"route_id\", \"trip_id\"],\n",
-    "    sum_cols = [\"service_hours\"],\n",
-    "    rename_cols = True\n",
-    ").sort_values(by = [\"trip_id_nunique\", \"route_id_nunique\", \n",
-    "                    \"service_hours_sum\"], \n",
-    "              ascending=[True, True, True]\n",
-    "             ).reset_index(drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "id": "0aa1b066-3fd6-4eb2-bf77-103d0cbb5a41",
+   "id": "0c71789a-e290-47dd-9109-b42c488fe024",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "2872.3133333333335"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "v1_agg.service_hours_sum.sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "id": "a073df37-6202-4bfe-aadd-e1ff1242b479",
-   "metadata": {},
-   "outputs": [
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "14.0\n"
+     ]
+    },
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "      <th>name</th>\n",
+       "      <th>regional_feed_type</th>\n",
+       "      <th>is_future</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>right_only</th>\n",
+       "      <th>both</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>14.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>213</th>\n",
+       "      <td>14.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>eb438c167b7f3c3b884f11ba875e345b</td>\n",
+       "      <td>Anaheim Resort Schedule</td>\n",
+       "      <td>None</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "3.75"
+       "     calitp_itp_id  calitp_url_number                          feed_key  \\\n",
+       "22            14.0                0.0                               NaN   \n",
+       "213           14.0                0.0  eb438c167b7f3c3b884f11ba875e345b   \n",
+       "\n",
+       "                        name regional_feed_type is_future  left_only  \\\n",
+       "22                       NaN                NaN       NaN          1   \n",
+       "213  Anaheim Resort Schedule               None     False          0   \n",
+       "\n",
+       "     right_only  both  \n",
+       "22            0     0  \n",
+       "213           0     1  "
       ]
      },
-     "execution_count": 35,
      "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "v2_agg.service_hours_sum.sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "id": "17375e8b-5305-44e5-a358-b68b13a8cac3",
-   "metadata": {},
-   "outputs": [
+     "output_type": "display_data"
+    },
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>213</th>\n",
+       "      <td>14.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>eb438c167b7f3c3b884f11ba875e345b</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "21106.75277777778"
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "213           14.0                0.0  eb438c167b7f3c3b884f11ba875e345b"
       ]
      },
-     "execution_count": 37,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "34.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "      <th>name</th>\n",
+       "      <th>regional_feed_type</th>\n",
+       "      <th>is_future</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>right_only</th>\n",
+       "      <th>both</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>72d31b44f06e4aba7790ea5aa0082c43</td>\n",
+       "      <td>Beaumont Pass Schedule</td>\n",
+       "      <td>None</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key  \\\n",
+       "15            34.0                0.0                               NaN   \n",
+       "139           34.0                0.0  72d31b44f06e4aba7790ea5aa0082c43   \n",
+       "\n",
+       "                       name regional_feed_type is_future  left_only  \\\n",
+       "15                      NaN                NaN       NaN          1   \n",
+       "139  Beaumont Pass Schedule               None     False          0   \n",
+       "\n",
+       "     right_only  both  \n",
+       "15            0     0  \n",
+       "139           0     1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>72d31b44f06e4aba7790ea5aa0082c43</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "139           34.0                0.0  72d31b44f06e4aba7790ea5aa0082c43"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "127.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "      <th>name</th>\n",
+       "      <th>regional_feed_type</th>\n",
+       "      <th>is_future</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>right_only</th>\n",
+       "      <th>both</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>127.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>127.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>126</th>\n",
+       "      <td>127.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>92bd23b390b7c7460a05baffd91684d6</td>\n",
+       "      <td>Golden Gate Bridge Schedule</td>\n",
+       "      <td>Regional Precursor Feed</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key  \\\n",
+       "19           127.0                1.0                               NaN   \n",
+       "20           127.0                2.0                               NaN   \n",
+       "126          127.0                0.0  92bd23b390b7c7460a05baffd91684d6   \n",
+       "\n",
+       "                            name       regional_feed_type is_future  \\\n",
+       "19                           NaN                      NaN       NaN   \n",
+       "20                           NaN                      NaN       NaN   \n",
+       "126  Golden Gate Bridge Schedule  Regional Precursor Feed     False   \n",
+       "\n",
+       "     left_only  right_only  both  \n",
+       "19           1           0     0  \n",
+       "20           1           0     0  \n",
+       "126          0           0     1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [calitp_itp_id, calitp_url_number, feed_key]\n",
+       "Index: []"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "247.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "      <th>name</th>\n",
+       "      <th>regional_feed_type</th>\n",
+       "      <th>is_future</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>right_only</th>\n",
+       "      <th>both</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>e8ccd13b7c2c7ea2a0c3ae92ba2b0c82</td>\n",
+       "      <td>Bay Area 511 Petaluma Schedule</td>\n",
+       "      <td>Regional Subfeed</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>e8ccd13b7c2c7ea2a0c3ae92ba2b0c82</td>\n",
+       "      <td>Bay Area 511 Petaluma Schedule</td>\n",
+       "      <td>Regional Subfeed</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>89</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>ee533bf21b57e229c459ea70bcff7f85</td>\n",
+       "      <td>Petaluma Schedule</td>\n",
+       "      <td>Regional Precursor Feed</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    calitp_itp_id  calitp_url_number                          feed_key  \\\n",
+       "5           247.0                2.0  e8ccd13b7c2c7ea2a0c3ae92ba2b0c82   \n",
+       "6           247.0                1.0  e8ccd13b7c2c7ea2a0c3ae92ba2b0c82   \n",
+       "14          247.0                1.0                               NaN   \n",
+       "89          247.0                0.0  ee533bf21b57e229c459ea70bcff7f85   \n",
+       "\n",
+       "                              name       regional_feed_type is_future  \\\n",
+       "5   Bay Area 511 Petaluma Schedule         Regional Subfeed     False   \n",
+       "6   Bay Area 511 Petaluma Schedule         Regional Subfeed     False   \n",
+       "14                             NaN                      NaN       NaN   \n",
+       "89               Petaluma Schedule  Regional Precursor Feed     False   \n",
+       "\n",
+       "    left_only  right_only  both  \n",
+       "5           0           0     1  \n",
+       "6           0           0     1  \n",
+       "14          1           0     0  \n",
+       "89          0           0     1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>e8ccd13b7c2c7ea2a0c3ae92ba2b0c82</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>e8ccd13b7c2c7ea2a0c3ae92ba2b0c82</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   calitp_itp_id  calitp_url_number                          feed_key\n",
+       "5          247.0                2.0  e8ccd13b7c2c7ea2a0c3ae92ba2b0c82\n",
+       "6          247.0                1.0  e8ccd13b7c2c7ea2a0c3ae92ba2b0c82"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "280.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "      <th>name</th>\n",
+       "      <th>regional_feed_type</th>\n",
+       "      <th>is_future</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>right_only</th>\n",
+       "      <th>both</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>280.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>280.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>131c004dfec39b02438760650ed753fe</td>\n",
+       "      <td>Bay Area 511 San Francisco Bay Ferry Schedule</td>\n",
+       "      <td>Regional Subfeed</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key  \\\n",
+       "18           280.0                0.0                               NaN   \n",
+       "109          280.0                1.0  131c004dfec39b02438760650ed753fe   \n",
+       "\n",
+       "                                              name regional_feed_type  \\\n",
+       "18                                             NaN                NaN   \n",
+       "109  Bay Area 511 San Francisco Bay Ferry Schedule   Regional Subfeed   \n",
+       "\n",
+       "    is_future  left_only  right_only  both  \n",
+       "18        NaN          1           0     0  \n",
+       "109     False          0           0     1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>280.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>131c004dfec39b02438760650ed753fe</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "109          280.0                1.0  131c004dfec39b02438760650ed753fe"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "290.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "      <th>name</th>\n",
+       "      <th>regional_feed_type</th>\n",
+       "      <th>is_future</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>right_only</th>\n",
+       "      <th>both</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>290.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>214</th>\n",
+       "      <td>290.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>050dcfdc6ff44718ff6e326f3d3b9a5a</td>\n",
+       "      <td>Bay Area 511 SamTrans Schedule</td>\n",
+       "      <td>Regional Subfeed</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key  \\\n",
+       "23           290.0                0.0                               NaN   \n",
+       "214          290.0                1.0  050dcfdc6ff44718ff6e326f3d3b9a5a   \n",
+       "\n",
+       "                               name regional_feed_type is_future  left_only  \\\n",
+       "23                              NaN                NaN       NaN          1   \n",
+       "214  Bay Area 511 SamTrans Schedule   Regional Subfeed     False          0   \n",
+       "\n",
+       "     right_only  both  \n",
+       "23            0     0  \n",
+       "214           0     1  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>214</th>\n",
+       "      <td>290.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>050dcfdc6ff44718ff6e326f3d3b9a5a</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "214          290.0                1.0  050dcfdc6ff44718ff6e326f3d3b9a5a"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "geography_utils.aggregate_by_geography(\n",
-    "    v2,\n",
-    "    group_cols = [\"feed_key\"],\n",
-    "    nunique_cols = [\"shape_id\", \"route_id\", \"trip_id\"],\n",
-    "    sum_cols = [\"service_hours\"],\n",
-    "    rename_cols = True\n",
-    ").sort_values(by = [\"trip_id_nunique\", \"route_id_nunique\", \n",
-    "                    \"service_hours_sum\"], \n",
-    "              ascending=[True, True, True]\n",
-    "             ).reset_index(drop=True).service_hours_sum.sum()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "66321125-7062-4ee2-97af-865532aa6e69",
-   "metadata": {},
-   "source": [
-    "Something happens once `name` is included. \n",
+    "left_and_both_keep = pd.DataFrame()\n",
     "\n",
-    "The 21k extra hours drops down to 3??"
+    "for i in left_and_both_ids:\n",
+    "    print(i)\n",
+    "    \n",
+    "    subset = oct_merge2[oct_merge2.calitp_itp_id == i]\n",
+    "    display(subset)\n",
+    "    \n",
+    "    feed_to_keep = subset[(subset.both > 0) & \n",
+    "                          (subset.regional_feed_type != \"Regional Precursor Feed\")\n",
+    "                  ][v1_id + v2_id]\n",
+    "    display(feed_to_keep)\n",
+    "    \n",
+    "    left_and_both_keep = pd.concat([left_and_both_keep, feed_to_keep], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "27612a5a-69de-43d4-afb6-521ccb902cbf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keep_left_and_both = pd.merge(\n",
+    "    oct_merge2[v1_id + v2_id].drop_duplicates(),\n",
+    "    left_and_both_keep,\n",
+    "    on = v1_id + [\"feed_key\"],\n",
+    "    how = \"inner\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "25ccef68-c3f9-49c3-a777-9339f05bd5a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ITP ID: 14.0\n",
+      "3161.147 2909.452\n",
+      "CHECK ME\n",
+      "ITP ID: 34.0\n",
+      "59.75 59.083\n",
+      "CHECK ME\n",
+      "ITP ID: 127.0\n",
+      "0.0 0.0\n",
+      "EQUAL\n",
+      "ITP ID: 247.0\n",
+      "106.028 106.028\n",
+      "EQUAL\n",
+      "ITP ID: 280.0\n",
+      "83.167 83.167\n",
+      "EQUAL\n",
+      "ITP ID: 290.0\n",
+      "1269.783 1269.783\n",
+      "EQUAL\n"
+     ]
+    }
+   ],
+   "source": [
+    "check_me = []\n",
+    "for i in left_and_both_ids:\n",
+    "    print(f\"ITP ID: {i}\")\n",
+    "    status = v1_v2_service_hours(\n",
+    "        oct1, oct2, \n",
+    "        left_and_both_keep[left_and_both_keep.calitp_itp_id==i]\n",
+    "     )\n",
+    "    print(status)\n",
+    "    \n",
+    "    if status == \"CHECK ME\":\n",
+    "        check_me.append(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "a92706de-4236-4d77-bf82-db4735599b9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[14.0, 34.0]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "check_me"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "a5db977f-a0ff-4949-ba27-560bcf31db45",
+   "id": "5b08b431-2cbb-4f5e-bf15-0966cdd96fd5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "v1_unique_feeds  = oct_merge[v1_id + [\"_merge\"]].drop_duplicates()"
+    "def aggregate_v1_v2(itp_id: int, feed_key: str):\n",
+    "    \"\"\"\n",
+    "    Aggregate service hours and count unique shape_id, trip_id,\n",
+    "    and route_id for v1 and v2 for 1 operator.\n",
+    "    \"\"\"\n",
+    "    v1_agg = geography_utils.aggregate_by_geography(\n",
+    "        oct1[oct1.calitp_itp_id == itp_id],\n",
+    "        group_cols = [\"calitp_itp_id\", \"calitp_url_number\"],\n",
+    "        sum_cols = [\"service_hours\"],\n",
+    "        nunique_cols = [\"shape_id\", \"trip_id\", \"route_id\"],\n",
+    "        rename_cols = True\n",
+    "    )\n",
+    "    \n",
+    "    v2_agg = geography_utils.aggregate_by_geography(\n",
+    "        oct2[oct2.feed_key == feed_key],\n",
+    "        group_cols = [\"feed_key\"],\n",
+    "        sum_cols = [\"service_hours\"],\n",
+    "        nunique_cols = [\"shape_id\", \"trip_id\", \"route_id\"],\n",
+    "        rename_cols = True\n",
+    "    )\n",
+    "    \n",
+    "    return v1_agg, v2_agg"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "dd9cba20-733e-40fc-8231-0ac6b61c4be6",
+   "id": "717996da-e125-4351-ab83-391bf13dec63",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "left_only     197\n",
-       "both           14\n",
-       "right_only      0\n",
-       "Name: unmerged, dtype: int64"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "v1_unmerged = pd.merge(\n",
-    "    v1_unique_feeds,\n",
-    "    v1_agg,\n",
-    "    on = v1_id,\n",
-    "    how = \"outer\",\n",
-    "    validate = \"m:1\",\n",
-    "    indicator = \"unmerged\"\n",
-    ")\n",
-    "\n",
-    "v1_unmerged.unmerged.value_counts()"
+    "check_id = 14\n",
+    "check_feed = left_and_both_keep[\n",
+    "    left_and_both_keep.calitp_itp_id==check_id].feed_key.iloc[0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "6fe291ec-9183-4697-8491-522d7014263f",
+   "id": "d040f82e-3a7e-44ae-9037-d3fa86d331f4",
    "metadata": {},
    "outputs": [
     {
@@ -763,205 +1606,46 @@
        "      <th></th>\n",
        "      <th>calitp_itp_id</th>\n",
        "      <th>calitp_url_number</th>\n",
-       "      <th>_merge</th>\n",
        "      <th>service_hours_sum</th>\n",
        "      <th>route_id_nunique</th>\n",
        "      <th>shape_id_nunique</th>\n",
        "      <th>trip_id_nunique</th>\n",
-       "      <th>unmerged</th>\n",
+       "      <th>feed_key</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>247.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>36.597222</td>\n",
-       "      <td>8.0</td>\n",
-       "      <td>23.0</td>\n",
-       "      <td>157.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>247.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>both</td>\n",
-       "      <td>36.597222</td>\n",
-       "      <td>8.0</td>\n",
-       "      <td>23.0</td>\n",
-       "      <td>157.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>34.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>4.416667</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>34.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>both</td>\n",
-       "      <td>4.416667</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50</th>\n",
-       "      <td>367.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>45.004722</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>55</th>\n",
-       "      <td>346.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>147.333333</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>39.0</td>\n",
-       "      <td>137.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>87</th>\n",
-       "      <td>280.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>83.166667</td>\n",
-       "      <td>6.0</td>\n",
-       "      <td>33.0</td>\n",
-       "      <td>141.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>108</th>\n",
-       "      <td>127.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>293.483333</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>21.0</td>\n",
-       "      <td>206.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>126</th>\n",
-       "      <td>127.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>33.000000</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>13.0</td>\n",
-       "      <td>61.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>133</th>\n",
-       "      <td>117.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>39.416667</td>\n",
-       "      <td>7.0</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>40.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>187</th>\n",
+       "      <th>0</th>\n",
        "      <td>14.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>251.694722</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>841.0</td>\n",
-       "      <td>both</td>\n",
+       "      <td>3161.146667</td>\n",
+       "      <td>13</td>\n",
+       "      <td>229</td>\n",
+       "      <td>14231</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>188</th>\n",
-       "      <td>14.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>both</td>\n",
-       "      <td>251.694722</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>841.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>197</th>\n",
-       "      <td>290.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>1269.700000</td>\n",
-       "      <td>70.0</td>\n",
-       "      <td>171.0</td>\n",
-       "      <td>1385.0</td>\n",
-       "      <td>both</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>199</th>\n",
-       "      <td>484.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>left_only</td>\n",
-       "      <td>668.500000</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>73.0</td>\n",
-       "      <td>1077.0</td>\n",
-       "      <td>both</td>\n",
+       "      <th>0</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2909.451944</td>\n",
+       "      <td>12</td>\n",
+       "      <td>227</td>\n",
+       "      <td>13390</td>\n",
+       "      <td>eb438c167b7f3c3b884f11ba875e345b</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "     calitp_itp_id  calitp_url_number     _merge  service_hours_sum  \\\n",
-       "8            247.0                1.0  left_only          36.597222   \n",
-       "9            247.0                1.0       both          36.597222   \n",
-       "19            34.0                0.0  left_only           4.416667   \n",
-       "20            34.0                0.0       both           4.416667   \n",
-       "50           367.0                0.0  left_only          45.004722   \n",
-       "55           346.0                0.0  left_only         147.333333   \n",
-       "87           280.0                0.0  left_only          83.166667   \n",
-       "108          127.0                1.0  left_only         293.483333   \n",
-       "126          127.0                2.0  left_only          33.000000   \n",
-       "133          117.0                0.0  left_only          39.416667   \n",
-       "187           14.0                0.0  left_only         251.694722   \n",
-       "188           14.0                0.0       both         251.694722   \n",
-       "197          290.0                0.0  left_only        1269.700000   \n",
-       "199          484.0                0.0  left_only         668.500000   \n",
+       "   calitp_itp_id  calitp_url_number  service_hours_sum  route_id_nunique  \\\n",
+       "0           14.0                0.0        3161.146667                13   \n",
+       "0            NaN                NaN        2909.451944                12   \n",
        "\n",
-       "     route_id_nunique  shape_id_nunique  trip_id_nunique unmerged  \n",
-       "8                 8.0              23.0            157.0     both  \n",
-       "9                 8.0              23.0            157.0     both  \n",
-       "19                1.0               2.0              4.0     both  \n",
-       "20                1.0               2.0              4.0     both  \n",
-       "50                3.0               4.0             65.0     both  \n",
-       "55               10.0              39.0            137.0     both  \n",
-       "87                6.0              33.0            141.0     both  \n",
-       "108              10.0              21.0            206.0     both  \n",
-       "126               4.0              13.0             61.0     both  \n",
-       "133               7.0              15.0             40.0     both  \n",
-       "187               9.0              30.0            841.0     both  \n",
-       "188               9.0              30.0            841.0     both  \n",
-       "197              70.0             171.0           1385.0     both  \n",
-       "199              30.0              73.0           1077.0     both  "
+       "   shape_id_nunique  trip_id_nunique                          feed_key  \n",
+       "0               229            14231                               NaN  \n",
+       "0               227            13390  eb438c167b7f3c3b884f11ba875e345b  "
       ]
      },
      "execution_count": 30,
@@ -970,31 +1654,330 @@
     }
    ],
    "source": [
-    "v1_unmerged[v1_unmerged.unmerged==\"both\"]"
+    "v1, v2 = aggregate_v1_v2(check_id, check_feed)\n",
+    "pd.concat([v1, v2], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "1b30d3d7-0dc6-4289-9ab3-2d43000dfb75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_id = 34\n",
+    "check_feed = left_and_both_keep[\n",
+    "    left_and_both_keep.calitp_itp_id==check_id].feed_key.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "1512b482-852d-40b9-8de8-6aa3dddda323",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>service_hours_sum</th>\n",
+       "      <th>route_id_nunique</th>\n",
+       "      <th>shape_id_nunique</th>\n",
+       "      <th>trip_id_nunique</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>59.750000</td>\n",
+       "      <td>7</td>\n",
+       "      <td>22</td>\n",
+       "      <td>96</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>59.083333</td>\n",
+       "      <td>7</td>\n",
+       "      <td>21</td>\n",
+       "      <td>96</td>\n",
+       "      <td>72d31b44f06e4aba7790ea5aa0082c43</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   calitp_itp_id  calitp_url_number  service_hours_sum  route_id_nunique  \\\n",
+       "0           34.0                0.0          59.750000                 7   \n",
+       "0            NaN                NaN          59.083333                 7   \n",
+       "\n",
+       "   shape_id_nunique  trip_id_nunique                          feed_key  \n",
+       "0                22               96                               NaN  \n",
+       "0                21               96  72d31b44f06e4aba7790ea5aa0082c43  "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v1, v2 = aggregate_v1_v2(check_id, check_feed)\n",
+    "pd.concat([v1, v2], axis=0)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "36a18c9a-c663-43cf-8b61-5a55aa45e04e",
+   "id": "8ce1a23e-693d-479d-a62b-1ebcd9dd7718",
    "metadata": {},
    "source": [
-    "Try another approach:\n",
+    "After checking these 2 ITP IDs, 14 and 34, it seems like there's some \n",
+    "slight differences in `service_hours` coming from slightly different number of unique `shape_id`, `route_id` and `trip_id`. This could be because in v2, some of the erroneous observations are dealt with.\n",
     "\n",
-    "We always narrow down to operator-trips\n",
+    "These are ok."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b185d1ac-c1a1-4399-afcb-5f1cc13a60f3",
+   "metadata": {},
+   "source": [
+    "## Case 4: Unmerged...either left only in v1 or right only in v2\n",
     "\n",
-    "Need to figure out how to do the same in v2"
+    "None..this might be because we "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "6d5c9b9f-57fe-4df8-809a-2322e76a784e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>left_only</th>\n",
+       "      <th>both</th>\n",
+       "      <th>right_only</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [calitp_itp_id, left_only, both, right_only]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unmerged = merge_counts[(merge_counts.left_only > 0) & \n",
+    "                        (merge_counts.right_only > 0) \n",
+    "                       ]\n",
+    "\n",
+    "unmerged"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a21cae76-45de-4bed-93e0-cc556ded26ab",
+   "metadata": {},
+   "source": [
+    "## Put 4 cases together and get aggregate view of service hours in v1 and v2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "c42ad103-6d91-4cfc-8135-ad5462c107aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_cases_keep_feeds = pd.concat([\n",
+    "    keep_one_feed,\n",
+    "    keep_two_feeds,\n",
+    "    keep_left_and_both,\n",
+    "], axis=0)\n",
+    "\n",
+    "all_cases_keep_feeds = (all_cases_keep_feeds[v1_id + [\"feed_key\"]]\n",
+    "                        .sort_values(\"calitp_itp_id\")\n",
+    "                        .reset_index(drop=True)\n",
+    "                       )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "bfd32861-dc06-4565-9796-e7bc45d113a6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "78941.41055555556 78689.04916666668\n"
+     ]
+    }
+   ],
+   "source": [
+    "final_v1 = pd.merge(\n",
+    "    oct1, \n",
+    "    all_cases_keep_feeds,\n",
+    "    on = v1_id,\n",
+    "    how = \"inner\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "final_v2 = pd.merge(\n",
+    "    oct2, \n",
+    "    all_cases_keep_feeds,\n",
+    "    on = v2_id,\n",
+    "    how = \"inner\"\n",
+    ")\n",
+    "\n",
+    "print(final_v1.service_hours.sum(), final_v2.service_hours.sum())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f42ce9b1-c4ff-4b19-bcb5-b016a494ad44",
+   "metadata": {},
+   "source": [
+    "## Daily Feeds to Organization Name\n",
+    "\n",
+    "* Allow parameters to include certain ones or exclude certain ones.\n",
+    "* By default, drop the precursor feeds. We would have kept unique combos of `itp_id-trip_id`, so multiple feeds would have been combined anyway."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "2562a013-880d-4d84-b346-8daf595eface",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prep_daily_feeds(date: str, \n",
+    "                     include: dict = \"All\", \n",
+    "                     exclude: dict = {\n",
+    "                         \"name\": [\"Bay Area 511 Regional Schedule\"],\n",
+    "                         \"regional_feed_type\": [\"Regional Precursor Feed\"]}\n",
+    "                    ) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Allow dict of feeds to include OR feeds to exclude.\n",
+    "    include: dict \n",
+    "        Takes form \n",
+    "        {\"this_col\": list_of_values_to_include}\n",
+    "    exclude: dict\n",
+    "        Takes form\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    daily_feeds = pd.read_parquet(\n",
+    "        f\"{GCS_FILE_PATH}daily_feeds_orgs_{date}.parquet\")\n",
+    "    \n",
+    "    daily_feeds[\"exclude_me\"] = 0\n",
+    "\n",
+    "    for col, values in exclude.items():\n",
+    "        daily_feeds = daily_feeds.assign(\n",
+    "            exclude_me = daily_feeds.apply(\n",
+    "                lambda x: 1 if x[col] in values \n",
+    "                else x.exclude_me, axis=1)\n",
+    "        )\n",
+    "    \n",
+    "    daily_feeds = (daily_feeds[daily_feeds.exclude_me == 0]\n",
+    "                   .drop(columns = \"exclude_me\")\n",
+    "                  )\n",
+    "    \n",
+    "    if include != \"All\":\n",
+    "        keep = pd.DataFrame()\n",
+    "        \n",
+    "        for col, values in include.items():\n",
+    "            subset = daily_feeds[daily_feeds[col].isin(values)]\n",
+    "            keep = pd.concat([keep, subset], axis=0)\n",
+    "\n",
+    "    \n",
+    "        daily_feeds = keep\n",
+    "    \n",
+    "    daily_feeds = daily_feeds.sort_values(\"name\").reset_index(drop=True)\n",
+    "    \n",
+    "    return daily_feeds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "721ca051-f4c5-4fb8-bea7-65aa541cca0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t1 = prep_daily_feeds(oct_date, include = \"All\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "3c041eb8-6c5b-4385-9863-5285662d5241",
+   "id": "72b2b97d-1644-4dab-8b31-2613f78245dd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "94786.39361111113"
+       "both          158\n",
+       "right_only     35\n",
+       "left_only      17\n",
+       "Name: _merge, dtype: int64"
       ]
      },
      "execution_count": 38,
@@ -1003,20 +1986,29 @@
     }
    ],
    "source": [
-    "oct1.drop_duplicates(subset=[\"calitp_itp_id\", \"trip_id\"]\n",
-    "                    ).service_hours.sum()"
+    "daily_feeds2 = pd.merge(\n",
+    "    all_cases_keep_feeds,\n",
+    "    t1,\n",
+    "    on = v2_id,\n",
+    "    how = \"outer\",\n",
+    "    validate = \"m:1\",\n",
+    "    indicator=True\n",
+    ")\n",
+    "\n",
+    "daily_feeds2._merge.value_counts()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "0fe80d03-408b-4a82-b7a6-fdca4de6aa32",
+   "id": "248bf357-0302-4809-8c36-82819571088d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "123796.93027777778"
+       "Regional Precursor Feed    16\n",
+       "Name: regional_feed_type, dtype: int64"
       ]
      },
      "execution_count": 39,
@@ -1025,14 +2017,695 @@
     }
    ],
    "source": [
-    "oct2.drop_duplicates(subset=[\"name\", \"trip_id\"]\n",
-    "                    ).service_hours.sum()"
+    "left_feeds = daily_feeds2[\n",
+    "    daily_feeds2._merge==\"left_only\"].feed_key.tolist()\n",
+    "\n",
+    "# Make sure these are all precursor feeds\n",
+    "daily_feeds[daily_feeds.feed_key.isin(left_feeds)\n",
+    "           ].regional_feed_type.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "a8203b0e-9e20-49a7-9dcf-9dbec1dee453",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "daily_feeds3 = pd.merge(\n",
+    "    all_cases_keep_feeds,\n",
+    "    t1,\n",
+    "    on = v2_id,\n",
+    "    how = \"inner\",\n",
+    "    validate = \"m:1\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "520d1f44-12f4-432f-90bb-3faa8eb53526",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "service hours across feeds: 75156.05222222222\n",
+      "service hours drop dups by operator-trip: 75103.03833333333\n"
+     ]
+    }
+   ],
+   "source": [
+    "v1_kept_feeds = pd.merge(\n",
+    "    oct1,\n",
+    "    daily_feeds3[v1_id],\n",
+    "    on = v1_id,\n",
+    "    how = \"inner\"\n",
+    ")\n",
+    "\n",
+    "no_drops = v1_kept_feeds.service_hours.sum()\n",
+    "drop_dups = v1_kept_feeds.drop_duplicates(subset=[\"calitp_itp_id\", \"trip_id\"]).service_hours.sum()\n",
+    "\n",
+    "print(f\"service hours across feeds: {no_drops}\")\n",
+    "print(f\"service hours drop dups by operator-trip: {drop_dups}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "33d92afd-87ac-476a-a6a6-1c4c2c29ada8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "service hours across feeds: 74903.69083333334\n",
+      "service hours drop dups by operator-trip: 67446.37638888888\n"
+     ]
+    }
+   ],
+   "source": [
+    "v2_kept_feeds = pd.merge(\n",
+    "    oct2,\n",
+    "    daily_feeds3[v2_id + [\"name\"]],\n",
+    "    on = v2_id,\n",
+    "    how = \"inner\"\n",
+    ")\n",
+    "\n",
+    "no_drops = v2_kept_feeds.service_hours.sum()\n",
+    "drop_dups = v2_kept_feeds.drop_duplicates(subset=[\"name\", \"trip_id\", \"service_hours\"]).service_hours.sum()\n",
+    "\n",
+    "print(f\"service hours across feeds: {no_drops}\")\n",
+    "print(f\"service hours drop dups by operator-trip: {drop_dups}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32bcef8d-b63f-4b05-beb3-5edaac339a9f",
+   "metadata": {},
+   "source": [
+    "## Why is v2 dropping so many more hours compared to v1?\n",
+    "\n",
+    "There were multiple itp_ids in the past, now linked to same feed, and these are ok. We wouldn't have dropped in v1 because we would only look for duplicates within `itp_id-trip_id`, but now that these are tagged as the same feed in v2, it would drop a lot more.\n",
+    "\n",
+    "For ITP ID = 247, which we have 3 feeds to begin with, and we end up keeping 2 feeds, the drop duplicates does handle it correctly because it's a within operator (ITP_ID) duplicate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "252158a5-8bd0-4c3a-bf12-243b9f47ffe0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v2_dups = v2_kept_feeds[v2_kept_feeds.duplicated(\n",
+    "    subset=[\"name\", \"trip_id\", \"service_hours\"])\n",
+    "             ].sort_values([\"feed_key\", \"trip_id\"])\n",
+    "\n",
+    "problem_feeds = v2_dups.feed_key.unique().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "5264f23a-81f5-4c4c-8a59-c2b8c3272a78",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OCTA Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>142.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>05c263e0f0563d3326a15c1b640ad945</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>235.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>05c263e0f0563d3326a15c1b640ad945</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    calitp_itp_id  calitp_url_number                          feed_key\n",
+       "53          142.0                0.0  05c263e0f0563d3326a15c1b640ad945\n",
+       "96          235.0                0.0  05c263e0f0563d3326a15c1b640ad945"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eastern Sierra Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0a165d0fe19fefcb424f577091cf52d0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>78</th>\n",
+       "      <td>190.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0a165d0fe19fefcb424f577091cf52d0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    calitp_itp_id  calitp_url_number                          feed_key\n",
+       "34           99.0                0.0  0a165d0fe19fefcb424f577091cf52d0\n",
+       "78          190.0                0.0  0a165d0fe19fefcb424f577091cf52d0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LADPW Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>64</th>\n",
+       "      <td>171.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>65</th>\n",
+       "      <td>172.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66</th>\n",
+       "      <td>173.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>67</th>\n",
+       "      <td>174.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>68</th>\n",
+       "      <td>176.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>69</th>\n",
+       "      <td>177.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>70</th>\n",
+       "      <td>178.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>71</th>\n",
+       "      <td>179.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>72</th>\n",
+       "      <td>181.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1b548fc017e5c82205e45b89d9fdb42b</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    calitp_itp_id  calitp_url_number                          feed_key\n",
+       "64          171.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "65          172.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "66          173.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "67          174.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "68          176.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "69          177.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "70          178.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "71          179.0                0.0  1b548fc017e5c82205e45b89d9fdb42b\n",
+       "72          181.0                0.0  1b548fc017e5c82205e45b89d9fdb42b"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VCTC GMV Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>94</th>\n",
+       "      <td>231.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>813f7923bf17858360fecc81a53d1640</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>163</th>\n",
+       "      <td>380.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>813f7923bf17858360fecc81a53d1640</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "94           231.0                0.0  813f7923bf17858360fecc81a53d1640\n",
+       "163          380.0                0.0  813f7923bf17858360fecc81a53d1640"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Redding Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>82.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8a19328a3d85a91d3539943af3482669</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>106</th>\n",
+       "      <td>259.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8a19328a3d85a91d3539943af3482669</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "28            82.0                0.0  8a19328a3d85a91d3539943af3482669\n",
+       "106          259.0                0.0  8a19328a3d85a91d3539943af3482669"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tehama Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>141</th>\n",
+       "      <td>329.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8aa4cefe774ac9adb6f1a6e2a5ff3909</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>143</th>\n",
+       "      <td>334.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8aa4cefe774ac9adb6f1a6e2a5ff3909</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "141          329.0                0.0  8aa4cefe774ac9adb6f1a6e2a5ff3909\n",
+       "143          334.0                0.0  8aa4cefe774ac9adb6f1a6e2a5ff3909"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Humboldt Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>18.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>de927a514fa2ef945fa4419e5bdc61c0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>42.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>de927a514fa2ef945fa4419e5bdc61c0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>40</th>\n",
+       "      <td>108.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>de927a514fa2ef945fa4419e5bdc61c0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51</th>\n",
+       "      <td>135.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>de927a514fa2ef945fa4419e5bdc61c0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    calitp_itp_id  calitp_url_number                          feed_key\n",
+       "7            18.0                0.0  de927a514fa2ef945fa4419e5bdc61c0\n",
+       "15           42.0                0.0  de927a514fa2ef945fa4419e5bdc61c0\n",
+       "40          108.0                0.0  de927a514fa2ef945fa4419e5bdc61c0\n",
+       "51          135.0                0.0  de927a514fa2ef945fa4419e5bdc61c0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bay Area 511 Petaluma Schedule\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>calitp_itp_id</th>\n",
+       "      <th>calitp_url_number</th>\n",
+       "      <th>feed_key</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>102</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>e8ccd13b7c2c7ea2a0c3ae92ba2b0c82</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>103</th>\n",
+       "      <td>247.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>e8ccd13b7c2c7ea2a0c3ae92ba2b0c82</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     calitp_itp_id  calitp_url_number                          feed_key\n",
+       "102          247.0                1.0  e8ccd13b7c2c7ea2a0c3ae92ba2b0c82\n",
+       "103          247.0                2.0  e8ccd13b7c2c7ea2a0c3ae92ba2b0c82"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for test_feed in problem_feeds:\n",
+    "    org_name = v2_dups[v2_dups.feed_key==test_feed].name.iloc[0]\n",
+    "    \n",
+    "    subset = all_cases_keep_feeds[all_cases_keep_feeds.feed_key==test_feed]\n",
+    "    \n",
+    "    print(org_name)\n",
+    "    display(subset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "a36c9ca6-9a74-4fd8-b0cd-91597e4a4593",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2    230\n",
+       "Name: calitp_url_number, dtype: int64"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v1_kept_feeds[v1_kept_feeds.calitp_itp_id==247].drop_duplicates(\n",
+    "    subset=[\"calitp_itp_id\", \"trip_id\"]).calitp_url_number.value_counts()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b74e45aa-d14d-404a-ac1b-4922d8717ec3",
+   "id": "73a3208a-d3a4-4abf-a176-a32bc125ae3d",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/gtfs_utils_v2/run-queries.ipynb
+++ b/gtfs_utils_v2/run-queries.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f836a20d-d25c-41b3-908e-b1cf2c25e1d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "os.environ[\"CALITP_BQ_MAX_BYTES\"] = str(200_000_000_000)\n",
+    " \n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "\n",
+    "from dask import delayed, compute\n",
+    "from dask.delayed import Delayed # use this for type hint\n",
+    "from siuba import *\n",
+    "\n",
+    "import gtfs_utils_v2\n",
+    "from shared_utils import geography_utils, rt_dates, utils\n",
+    "\n",
+    "analysis_date = rt_dates.DATES[\"oct2022\"]\n",
+    "\n",
+    "DASK_GCS = \"gs://calitp-analytics-data/data-analyses/dask_test/v2_schedule/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3fa6dc1d-f23b-4047-bdc8-25e363c58d22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'''\n",
+    "daily_feeds_orgs = gtfs_utils_v2.daily_feed_to_organization(\n",
+    "    selected_date = analysis_date,\n",
+    "    get_df = True\n",
+    ")\n",
+    "\n",
+    "daily_feeds_orgs.to_parquet(\"./data/daily_feeds_orgs.parquet\")\n",
+    "'''\n",
+    "\n",
+    "daily_feeds_orgs = pd.read_parquet(\"./data/daily_feeds_orgs.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a45c70d5-68b0-4a34-bca5-4024b3217f9b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['285e72c8fed97bcd0acb05aeda8aa985', 'bbba508561429fb97adb16f47bb4bdb1']\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_operators = [\n",
+    "    \"LA Metro Bus Schedule\",\n",
+    "    \"LA Metro Rail Schedule\"\n",
+    "]\n",
+    "\n",
+    "#daily_feeds_orgs[daily_feeds_orgs.name.isin(test_operators)]\n",
+    "\n",
+    "test_feed_keys = daily_feeds_orgs[\n",
+    "    daily_feeds_orgs.name.isin(test_operators)].feed_key.tolist()\n",
+    "\n",
+    "print(test_feed_keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89bc427c-896b-4c7c-9381-1405fdf64609",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_delayed(\n",
+    "    feed_key: str, analysis_date: str, \n",
+    "    trips: Delayed, route_info: Delayed, route_shapes: Delayed\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Unpack the result from the dask delayed function. \n",
+    "    The delayed object is a tuple, and since we just have 1 object, use \n",
+    "    [0] to grab it.\n",
+    "    \n",
+    "    Export the pd.DataFrame or gpd.GeoDataFrame to GCS.\n",
+    "    \n",
+    "    https://stackoverflow.com/questions/44602766/unpacking-result-of-delayed-function\n",
+    "    \"\"\"\n",
+    "    trips = compute(trips)[0]\n",
+    "    print(\"Computed trips\")\n",
+    "    \n",
+    "    route_info = compute(route_info)[0]\n",
+    "    print(\"Computed route_info\")\n",
+    "\n",
+    "    route_shapes = compute(route_shapes)[0]\n",
+    "    print(\"Computed route_shapes\")\n",
+    "    \n",
+    "    DATA_PATH = \"./v2_data/\"\n",
+    "    \n",
+    "    if not ((trips.empty) and (route_info.empty) and (route_shapes.empty)):\n",
+    "        trips.to_parquet(\n",
+    "            f\"{DATA_PATH}trips_{feed_key}_{analysis_date}.parquet\")\n",
+    "        print(\"Exported trips\")\n",
+    "        \n",
+    "        route_info.to_parquet(\n",
+    "            f\"{DATA_PATH}route_info_{feed_key}_{analysis_date}.parquet\")\n",
+    "        print(\"Exported route_info\")\n",
+    "        \n",
+    "        route_shapes.to_parquet(\n",
+    "            f\"{DATA_PATH}route_shapes_{feed_key}_{analysis_date}.parquet\")\n",
+    "        print(\"Exported route_shapes\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "865cc3e3-c86c-468e-971f-c84368f67425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for feed in test_feed_keys:\n",
+    "    trips = delayed(\n",
+    "        gtfs_utils_v2.get_trips(\n",
+    "            selected_date = analysis_date,\n",
+    "            subset_feeds = [feed],\n",
+    "            get_df = True\n",
+    "        )\n",
+    "    )\n",
+    "    \n",
+    "    route_info = delayed(\n",
+    "        gtfs_utils_v2.get_route_info(\n",
+    "            selected_date = analysis_date,\n",
+    "            subset_feeds = [feed],\n",
+    "            get_df = True\n",
+    "        )\n",
+    "    )\n",
+    "    \n",
+    "    route_shapes = delayed(\n",
+    "        gtfs_utils_v2.get_route_shapes(\n",
+    "            selected_date = analysis_date,\n",
+    "            subset_feeds = [feed],\n",
+    "            get_df = True,\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "    compute_delayed(feed, analysis_date, \n",
+    "                    trips, route_info, route_shapes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb4dfe6a-cc6c-4fe3-924e-2bae7a762e45",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtfs_utils_v2/service_hours_query.ipynb
+++ b/gtfs_utils_v2/service_hours_query.ipynb
@@ -50,7 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analysis_date = rt_dates.DATES[\"oct2022\"]"
+    "analysis_date = rt_dates.DATES[\"oct2022\"]\n",
+    "GCS_FILE_PATH = \"gs://calitp-analytics-data/data-analyses/gtfs_v1_v2_parity/\""
    ]
   },
   {
@@ -206,8 +207,7 @@
     "        selected_date = d,\n",
     "        get_df = True\n",
     "    )\n",
-    "\n",
-    "    daily_feeds.to_parquet(f\"./data/daily_feeds_orgs_{d}.parquet\")"
+    "    daily_feeds.to_parquet(f\"{GCS_FILE_PATH}daily_feeds_orgs_{d}.parquet\")"
    ]
   },
   {
@@ -217,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "daily_feeds = pd.read_parquet(f\"./data/daily_feeds_orgs_{dates[0]}.parquet\")\n",
+    "daily_feeds = pd.read_parquet(f\"{GCS_FILE_PATH}daily_feeds_orgs_{dates[0]}.parquet\")\n",
     "\n",
     "include_feeds = daily_feeds.feed_key.unique().tolist()\n"
    ]
@@ -235,7 +235,7 @@
     "    get_df = True\n",
     ")\n",
     "        \n",
-    "trips.to_parquet(f\"./data/trips_{dates[0]}.parquet\")"
+    "trips.to_parquet(f\"{GCS_FILE_PATH}trips_{dates[0]}_v1.parquet\")"
    ]
   },
   {
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "daily_feeds = pd.read_parquet(f\"./data/daily_feeds_orgs_{dates[1]}.parquet\")\n",
+    "daily_feeds = pd.read_parquet(f\"{GCS_FILE_PATH}daily_feeds_orgs_{dates[1]}.parquet\")\n",
     "\n",
     "include_feeds = daily_feeds.feed_key.unique().tolist()\n",
     "\n",
@@ -255,7 +255,7 @@
     "    get_df = True\n",
     ")\n",
     "        \n",
-    "trips.to_parquet(f\"./data/trips_{dates[1]}.parquet\")"
+    "trips.to_parquet(f\"{GCS_FILE_PATH}trips_{dates[1]}_v2.parquet\")"
    ]
   },
   {

--- a/gtfs_utils_v2/service_hours_query.ipynb
+++ b/gtfs_utils_v2/service_hours_query.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5a70c44-d06e-4175-84d1-ffa48c1fc4fa",
+   "metadata": {},
+   "source": [
+    "# Trips full table v1 vs v2\n",
+    "\n",
+    "Use this to figure out how to do exclusion between v1 and v2. \n",
+    "\n",
+    "Is it simply excluding 511 regional feed?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c794b111-8ce1-413f-94a3-cdc70edd2e23",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "os.environ[\"CALITP_BQ_MAX_BYTES\"] = str(2_000_000_000_000)\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "import sys\n",
+    "\n",
+    "from loguru import logger\n",
+    "from calitp.tables import tbls\n",
+    "from siuba import *\n",
+    "\n",
+    "import gtfs_utils_v2\n",
+    "from shared_utils import rt_dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "123aa69c-1cce-422c-a808-947bb3a0285a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis_date = rt_dates.DATES[\"oct2022\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d67900e5-9c14-4818-aa63-30298e53ebf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dim_gtfs_datasets = (\n",
+    "    tbls.mart_transit_database.dim_gtfs_datasets()\n",
+    "    >> filter(_[\"data\"] == \"GTFS Schedule\")\n",
+    "    >> rename(gtfs_dataset_key = \"key\")\n",
+    "    >> select(_.gtfs_dataset_key, _.name, _.regional_feed_type)\n",
+    "    >> distinct()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3d5630df-5444-4633-a0da-f8fd537de5c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SELECT DISTINCT `mart_transit_database.dim_gtfs_datasets_1`.`key` AS `gtfs_dataset_key`, `mart_transit_database.dim_gtfs_datasets_1`.`name`, `mart_transit_database.dim_gtfs_datasets_1`.`regional_feed_type` \n",
+      "FROM `mart_transit_database.dim_gtfs_datasets` AS `mart_transit_database.dim_gtfs_datasets_1` \n",
+      "WHERE `mart_transit_database.dim_gtfs_datasets_1`.`data` = 'GTFS Schedule'\n",
+      "# Source: lazy query\n",
+      "# DB Conn: Engine(bigquery://cal-itp-data-infra/?maximum_bytes_billed=2000000000000)\n",
+      "# Preview:\n",
+      "    gtfs_dataset_key                    name       regional_feed_type\n",
+      "0  recsBJKl0jkyqfLk4  Thousand Oaks Schedule  Regional Precursor Feed\n",
+      "1  reciKWkJ953NSPTtj        G Trans Schedule                     None\n",
+      "2  reczps9Ejby9P7Njr  SunLine Avail Schedule                     None\n",
+      "3  recM9LZoHwKzjuhPM      La Puente Schedule                     None\n",
+      "4  rec3FmQFpaxdDOpwF        Burbank Schedule                     None\n",
+      "# .. may have more rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dim_gtfs_datasets >> show_query())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d8ac40ed-cf1e-4e84-b886-442e89398d76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fact_feeds = (\n",
+    "    tbls.mart_gtfs.fct_daily_schedule_feeds()\n",
+    "    >> filter((_.date == analysis_date))\n",
+    "    >> inner_join(_, dim_gtfs_datasets, \n",
+    "                  on = \"gtfs_dataset_key\"\n",
+    "                 )\n",
+    ")  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "27051cb2-b9e4-4ee3-90a3-ed44a945f341",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SELECT `anon_1`.`key`, `anon_1`.`date`, `anon_1`.`feed_key`, `anon_1`.`base64_url`, `anon_1`.`gtfs_dataset_key`, `anon_1`.`is_future`, `anon_2`.`regional_feed_type`, `anon_2`.`name` \n",
+      "FROM (SELECT `mart_gtfs.fct_daily_schedule_feeds_1`.`key` AS `key`, `mart_gtfs.fct_daily_schedule_feeds_1`.`date` AS `date`, `mart_gtfs.fct_daily_schedule_feeds_1`.`feed_key` AS `feed_key`, `mart_gtfs.fct_daily_schedule_feeds_1`.`base64_url` AS `base64_url`, `mart_gtfs.fct_daily_schedule_feeds_1`.`gtfs_dataset_key` AS `gtfs_dataset_key`, `mart_gtfs.fct_daily_schedule_feeds_1`.`is_future` AS `is_future` \n",
+      "FROM `mart_gtfs.fct_daily_schedule_feeds` AS `mart_gtfs.fct_daily_schedule_feeds_1` \n",
+      "WHERE `mart_gtfs.fct_daily_schedule_feeds_1`.`date` = '2022-10-12') AS `anon_1` JOIN (SELECT DISTINCT `mart_transit_database.dim_gtfs_datasets_1`.`key` AS `gtfs_dataset_key`, `mart_transit_database.dim_gtfs_datasets_1`.`name` AS `name`, `mart_transit_database.dim_gtfs_datasets_1`.`regional_feed_type` AS `regional_feed_type` \n",
+      "FROM `mart_transit_database.dim_gtfs_datasets` AS `mart_transit_database.dim_gtfs_datasets_1` \n",
+      "WHERE `mart_transit_database.dim_gtfs_datasets_1`.`data` = 'GTFS Schedule') AS `anon_2` ON `anon_1`.`gtfs_dataset_key` = `anon_2`.`gtfs_dataset_key`\n",
+      "# Source: lazy query\n",
+      "# DB Conn: Engine(bigquery://cal-itp-data-infra/?maximum_bytes_billed=2000000000000)\n",
+      "# Preview:\n",
+      "                                key       date  \\\n",
+      "0  a2618a7d74ccf033fd0db40a5ff05b2e 2022-10-12   \n",
+      "1  9248b1774056d768574b2306541b2fe3 2022-10-12   \n",
+      "2  a2e8cc60ae558a8265d03820ed42a53b 2022-10-12   \n",
+      "3  dcd586cd114dabaa793e30e393109a6a 2022-10-12   \n",
+      "4  31bd85c906bd15f1888f291fb32d6827 2022-10-12   \n",
+      "\n",
+      "                           feed_key  \\\n",
+      "0  01fd909003ff5c22a71f28585d04822b   \n",
+      "1  02a365c4cf4b252293fb0503598fd43d   \n",
+      "2  050dcfdc6ff44718ff6e326f3d3b9a5a   \n",
+      "3  05c263e0f0563d3326a15c1b640ad945   \n",
+      "4  06d9698342ca7cb663ebbaf3537ce95d   \n",
+      "\n",
+      "                                          base64_url   gtfs_dataset_key  \\\n",
+      "0  aHR0cDovL2RhdGEudHJpbGxpdW10cmFuc2l0LmNvbS9ndG...  recihmkhgREB2Lvxt   \n",
+      "1  aHR0cDovL3d3dy5nb25jdGQuY29tL2dvb2dsZV90cmFuc2...  recltDJn10nOSilgD   \n",
+      "2  aHR0cDovL2FwaS41MTEub3JnL3RyYW5zaXQvZGF0YWZlZW...  recfkVrxPHPaWOs4J   \n",
+      "3  aHR0cHM6Ly9vY3RhLm5ldC9jdXJyZW50L2dvb2dsZV90cm...  reckk3FzZojulIKYL   \n",
+      "4  aHR0cHM6Ly93d3cuc2RtdHMuY29tL2dvb2dsZV90cmFuc2...  recfZ9iWkptccoONX   \n",
+      "\n",
+      "   is_future regional_feed_type                            name  \n",
+      "0      False               None                Needles Schedule  \n",
+      "1      False               None           North County Schedule  \n",
+      "2      False   Regional Subfeed  Bay Area 511 SamTrans Schedule  \n",
+      "3      False               None                   OCTA Schedule  \n",
+      "4      False               None              San Diego Schedule  \n",
+      "# .. may have more rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(fact_feeds >> show_query())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eafed668-4408-420f-b242-d2bbaba49c68",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['2022-10-12', '2022-11-16']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dates = [\n",
+    "        rt_dates.DATES[\"oct2022\"], \n",
+    "        rt_dates.DATES[\"nov2022\"]\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0054bf9a-a276-4bab-8adb-8e346efe49be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for d in dates:\n",
+    "    \n",
+    "    daily_feeds = gtfs_utils_v2.daily_feed_to_organization(\n",
+    "        selected_date = d,\n",
+    "        get_df = True\n",
+    "    )\n",
+    "\n",
+    "    daily_feeds.to_parquet(f\"./data/daily_feeds_orgs_{d}.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "719e3864-83c5-4590-a306-5abd44ad0f14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "daily_feeds = pd.read_parquet(f\"./data/daily_feeds_orgs_{dates[0]}.parquet\")\n",
+    "\n",
+    "include_feeds = daily_feeds.feed_key.unique().tolist()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1cf59b0f-ec2c-4e98-b3c6-63cf8af8784e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trips = gtfs_utils_v2.get_trips(\n",
+    "    selected_date = dates[0], \n",
+    "    subset_feeds = include_feeds,\n",
+    "    get_df = True\n",
+    ")\n",
+    "        \n",
+    "trips.to_parquet(f\"./data/trips_{dates[0]}.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "00c3eaa9-00cc-4097-a764-e97518362d80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "daily_feeds = pd.read_parquet(f\"./data/daily_feeds_orgs_{dates[1]}.parquet\")\n",
+    "\n",
+    "include_feeds = daily_feeds.feed_key.unique().tolist()\n",
+    "\n",
+    "trips = gtfs_utils_v2.get_trips(\n",
+    "    selected_date = dates[1], \n",
+    "    subset_feeds = include_feeds,\n",
+    "    get_df = True\n",
+    ")\n",
+    "        \n",
+    "trips.to_parquet(f\"./data/trips_{dates[1]}.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72e0afc1-b822-400f-be3e-0bbfc3950c52",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "354d97ef-609a-45b2-a689-b5da5be7858f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### migrate v1 to v2
* compare v1 `trips` to v2 `trips` 
* do aggregate service hours generally match up? Once we get rid of the fact that there are multiple feeds present, if we try to keep the unique `operator-trip_id` combination, how well do hours stack up?
* There are still differences between v1 and v2, with v2 having much fewer hours, but those differences are due to the fact that there were multiple `itp_ids` that were storing same info, and if we dropped those, we'd have much similar aggregate service. These now move to the same `feed_key-name`, allowing the duplicates to be dropped.
*  First iteration of a function to help keep all operators on a given day is put into `gtfs_utils_v2`...just remove precursor feeds and Bay Area MTC 511 by default 
* #564 

### `gtfs_utils_v2`
* Have the ability to filter on the feeds we want for a day or exclude feeds on a day, with columns other than `feed_key`