### PR TITLE
Add geo

### DIFF
--- a/project_prioritization/_portfolio_utils.py
+++ b/project_prioritization/_portfolio_utils.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import _utils 
 
 # Geography
 from shared_utils import geography_utils
@@ -145,7 +146,7 @@ def summarize_by_project_names(df, col_wanted: str):
         lambda x: format_currency(x, currency="USD", locale="en_US")
     )
     # Clean up column names, remove snakecase
-    df = clean_up_columns(df)
+    df = _utils.clean_up_columns(df)
 
     return df
 
@@ -228,6 +229,6 @@ def summarize_districts(df, col_wanted: str):
     df = df.reset_index(drop=True)
 
     # Clean up column names, remove snakecase
-    df =  clean_up_columns(df)
+    df =  _utils.clean_up_columns(df)
 
     return df

--- a/project_prioritization/_utils.py
+++ b/project_prioritization/_utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-
+import _portfolio_utils 
 # Geography
 from shared_utils import geography_utils
 import geopandas as gpd
@@ -182,7 +182,7 @@ def tableau_district_map(df, col_wanted):
     df: original dataframe to summarize
     col_wanted: to column to groupby
     """
-    df_districts = summarize_districts(df, col_wanted)
+    df_districts = _portfolio_utils.summarize_districts(df, col_wanted)
 
     # Reverse the dictionary with district names because
     # final DF has the full names like 04-Bay Area and I only need 4

--- a/project_prioritization/_utils.py
+++ b/project_prioritization/_utils.py
@@ -15,26 +15,24 @@ from calitp.storage import get_fs
 fs = get_fs()
 import os
 
-def simplify_project_names(df, column_wanted: str):
-    """
-    Simplify project names for string matching.
-    """
+# Function to clean agency/organization names
+def organization_cleaning(df, column_wanted: str):
     df[column_wanted] = (
         df[column_wanted]
         .str.strip()
-        .str.lower()
+        .str.split(",")
+        .str[0]
         .str.replace("/", "")
-        .str.replace("-", "")
-        .str.replace("!", "")
-        .str.replace("&", "")
-        .str.replace("#", "")
-        .str.replace("(", "")
-        .str.replace(")", "")
-        .str.replace(":", "")
-        .str.replace("the", "")
+        .str.split("(")
+        .str[0]
+        .str.split("/")
+        .str[0]
+        .str.title()
+        .str.replace("Trasit", "Transit")
         .str.strip()  # strip again after getting rid of certain things
     )
     return df
+
 
 # Natalie's function
 def align_funding_numbers(df, list_of_cols):

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -180,8 +180,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_1639/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
-      "/tmp/ipykernel_1639/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+      "/tmp/ipykernel_1801/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
+      "/tmp/ipykernel_1801/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
      ]
     }
    ],
@@ -381,8 +381,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_1639/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
-      "/tmp/ipykernel_1639/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+      "/tmp/ipykernel_1801/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
+      "/tmp/ipykernel_1801/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
      ]
     }
    ],
@@ -469,7 +469,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_1639/3707436155.py:1: UserWarning: GeoSeries.notna() previously returned False for both missing (None) and empty geometries. Now, it only returns False for missing values. Since the calling GeoSeries contains empty geometries, the result has changed compared to previous versions of GeoPandas.\n",
+      "/tmp/ipykernel_1801/3707436155.py:1: UserWarning: GeoSeries.notna() previously returned False for both missing (None) and empty geometries. Now, it only returns False for missing values. Since the calling GeoSeries contains empty geometries, the result has changed compared to previous versions of GeoPandas.\n",
       "Given a GeoSeries 's', you can use '~s.is_empty & s.notna()' to get back the old behaviour.\n",
       "\n",
       "To further ignore this warning, you can do: \n",
@@ -764,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 57,
    "id": "c03ada7e-43f2-4f22-9ff2-d6ad9704337f",
    "metadata": {
     "scrolled": true,
@@ -777,7 +777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 53,
    "id": "2eec244d-6141-4655-898d-d10e23cca51d",
    "metadata": {
     "scrolled": true,
@@ -785,12 +785,12 @@
    },
    "outputs": [],
    "source": [
-    "#nine_sample_projects[['project_name','lead_agency','full_county_name','project_description']].sort_values(['full_county_name','project_name'])"
+    "# nine_sample_projects[['project_name','lead_agency','full_county_name','project_description']].sort_values(['full_county_name','project_name'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 58,
    "id": "bc283dad-5081-4d09-b160-006c9992472a",
    "metadata": {},
    "outputs": [],
@@ -801,17 +801,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "id": "2e3dad1e-5626-49a9-aff0-746fb54858e9",
+   "execution_count": 67,
+   "id": "3d20cf2c-ed33-4e69-90ea-f4e29b5911f5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "non_shopp_projects_in_sb1 = sb1_geo2[sb1_geo2[\"projecttitle\"].isin(non_shopp_projects_sb1_list)].reset_index(drop = True)"
+    "test = sb1_geo2[sb1_geo2[\"projecttitle\"].isin(non_shopp_projects_sb1_list)].reset_index(drop = True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 72,
+   "id": "a0ebf374-ea77-4a93-b8eb-c40bab0f3f1d",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# test[['geometry','projecttitle']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "2e3dad1e-5626-49a9-aff0-746fb54858e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_shopp_projects_in_sb1 = tcep_sccp2[tcep_sccp2[\"projecttitle\"].isin(non_shopp_projects_sb1_list)].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
    "id": "3586edee-5451-481b-b3b1-2713acae7dc7",
    "metadata": {},
    "outputs": [],
@@ -824,7 +847,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 61,
+   "id": "08269d32-1146-4680-970e-b1a93c02c7d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(non_shopp_projects_in_sb1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
    "id": "5d02f7da-fb30-4fe6-a62c-f73e2efd872e",
    "metadata": {},
    "outputs": [],
@@ -840,12 +884,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 64,
+   "id": "d6cf4ff9-e128-41e2-9b0b-2ad5d810022c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(nine_sample_projects_geo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "a22c7ff3-a633-4582-b464-1a3d41f43fde",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "geopandas.geodataframe.GeoDataFrame"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(nine_sample_projects_geo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "660faea4-9c6d-4041-b131-8f3905342a8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# nine_sample_projects_geo[['project_name','projecttitle','project_description','projectdescription', 'full_county_name']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
    "id": "b1ffa7f6-a4d1-4ffb-986d-5f9681dc2f00",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# _utils.geojson_gcs_export(nine_sample_projects_geo,_utils.GCS_FILE_PATH, 'nine_sample_projects_geom')"
+    " _utils.geojson_gcs_export(nine_sample_projects_geo,_utils.GCS_FILE_PATH, 'nine_sample_projects_geom')"
    ]
   },
   {
@@ -862,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "57760f7c-453e-4d1e-9055-911fdc5dd74b",
    "metadata": {},
    "outputs": [],

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -10,20 +10,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 1,
    "id": "22b768e0-0316-4684-a4b2-683dcd82a323",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "import _utils\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import geopandas as gpd\n",
     "from calitp.sql import to_snakecase"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 2,
+   "id": "c375e3ed-515c-4762-a8aa-2c448a5433f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fsspec\n",
+    "from calitp import *\n",
+    "from calitp.storage import get_fs\n",
+    "fs = get_fs()\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a4ba3617-394e-4277-ab7f-0103120dcd3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_geopandas as dg\n",
+    "import pyogrio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
    "metadata": {},
    "outputs": [],
@@ -43,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 5,
    "id": "6b483a64-786d-4d9c-96e8-0bfe429ffd2a",
    "metadata": {},
    "outputs": [],
@@ -54,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 6,
    "id": "aa0c6362-1f89-4112-a55f-6928841266ce",
    "metadata": {},
    "outputs": [],
@@ -81,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 7,
    "id": "a63dc3e3-2485-4331-b370-c6fdf2c57952",
    "metadata": {},
    "outputs": [],
@@ -90,16 +125,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "06967d23-860f-4d11-a4ed-18675a5070e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.district = df.district.map(\"{:02}\".format)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "b69c71eb-66fc-4e92-9d53-554ef18f190d",
+   "id": "9080657d-b4de-453c-9663-55bb5e004915",
    "metadata": {},
    "source": [
-    "### SB1"
+    "### SB1 CSV"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 9,
    "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
    "metadata": {},
    "outputs": [],
@@ -110,115 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
-   "id": "1aa20f7d-3acf-463b-b9a4-ad0426c59978",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>project_id</th>\n",
-       "      <th>project_name</th>\n",
-       "      <th>implementing_agency</th>\n",
-       "      <th>sb1_program</th>\n",
-       "      <th>federal_program</th>\n",
-       "      <th>fiscal_year</th>\n",
-       "      <th>project_description</th>\n",
-       "      <th>total_cost</th>\n",
-       "      <th>sb1_funds</th>\n",
-       "      <th>is_sb1?</th>\n",
-       "      <th>federal_funds</th>\n",
-       "      <th>is_federal?</th>\n",
-       "      <th>project_status</th>\n",
-       "      <th>assembly_districts</th>\n",
-       "      <th>senate_districts</th>\n",
-       "      <th>congressional_districts</th>\n",
-       "      <th>counties</th>\n",
-       "      <th>cities</th>\n",
-       "      <th>caltrans_districts</th>\n",
-       "      <th>on_shs?</th>\n",
-       "      <th>date_updated</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>4098</th>\n",
-       "      <td>'0418000347</td>\n",
-       "      <td>Roadside</td>\n",
-       "      <td>Caltrans</td>\n",
-       "      <td>State Hwy Operations &amp; Protection Program Minor A</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>'18/19</td>\n",
-       "      <td>In Napa, on Routes 121 and 128.  Replace trees after fire.</td>\n",
-       "      <td>778700.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>In Progress</td>\n",
-       "      <td>04</td>\n",
-       "      <td>03</td>\n",
-       "      <td>05</td>\n",
-       "      <td>Napa</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>04</td>\n",
-       "      <td>Y</td>\n",
-       "      <td>10/08/2021</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       project_id project_name implementing_agency  \\\n",
-       "4098  '0418000347     Roadside            Caltrans   \n",
-       "\n",
-       "                                            sb1_program federal_program  \\\n",
-       "4098  State Hwy Operations & Protection Program Minor A             NaN   \n",
-       "\n",
-       "     fiscal_year                                         project_description  \\\n",
-       "4098      '18/19  In Napa, on Routes 121 and 128.  Replace trees after fire.   \n",
-       "\n",
-       "      total_cost  sb1_funds is_sb1?  federal_funds is_federal? project_status  \\\n",
-       "4098    778700.0        0.0       N            NaN         NaN    In Progress   \n",
-       "\n",
-       "     assembly_districts senate_districts congressional_districts counties  \\\n",
-       "4098                 04               03                      05     Napa   \n",
-       "\n",
-       "     cities caltrans_districts on_shs? date_updated  \n",
-       "4098    NaN                 04       Y   10/08/2021  "
-      ]
-     },
-     "execution_count": 70,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sb1.sample()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 10,
    "id": "11af211e-6647-49b7-b818-d3bc5209ab43",
    "metadata": {},
    "outputs": [],
@@ -245,7 +182,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 11,
+   "id": "1c970a13-2b8a-4c24-afca-7f2f8fbe229d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_2 = sb1[sb1_subset]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "0b6f73ab-706d-4c31-8fae-fe830a3fc260",
    "metadata": {},
    "outputs": [
@@ -270,7 +217,7 @@
        "Name: sb1_program, dtype: int64"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -281,52 +228,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "id": "1c970a13-2b8a-4c24-afca-7f2f8fbe229d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sb1_2 = sb1[sb1_subset]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 64,
-   "id": "9d7d179d-cdf5-4254-a076-0e8175c3fbfb",
+   "execution_count": 13,
+   "id": "ad12e624-e1cd-4e0f-a98e-c533490fc3d4",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Completed      4838\n",
-       "Planned        2517\n",
-       "In Progress    2277\n",
-       "Name: project_status, dtype: int64"
+       "(9632, 16)"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Filter out completed projects\n",
-    "sb1.project_status.value_counts()"
+    "sb1_2.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
-   "id": "557537af-c710-453c-8ea1-4f3552c89881",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sb1_2 = sb1_2.loc[sb1_2.project_status != \"Completed\"].reset_index(drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 14,
    "id": "f3a9fb1a-9cbf-45a9-a0a6-cc96dbb16b09",
    "metadata": {},
    "outputs": [],
@@ -337,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 15,
    "id": "7510fd40-c15e-42ba-a4f1-68031c2e6b3e",
    "metadata": {},
    "outputs": [],
@@ -347,194 +270,355 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "69f2f3b4-c1d0-4d4b-87c5-d2158e115dcc",
+   "metadata": {},
+   "source": [
+    "#### Merge on Project Names"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 16,
    "id": "76e719a2-21fa-4b8f-bce4-100d612e3484",
    "metadata": {
     "scrolled": true,
     "tags": []
    },
+   "outputs": [],
+   "source": [
+    "# Lower case and clean project names\n",
+    "for i in [sb1_2, df]:\n",
+    "    i['project_name'] = i['project_name'].str.lower().str.strip().str.split(\"20\").str[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b4deeadc-c568-466e-9325-b8e491f5e51f",
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ppno</th>\n",
-       "      <th>project_name</th>\n",
-       "      <th>lead_agency</th>\n",
-       "      <th>previous_caltrans_nominations</th>\n",
-       "      <th>full_county_name</th>\n",
-       "      <th>district</th>\n",
-       "      <th>project_description</th>\n",
-       "      <th>current_phase</th>\n",
-       "      <th>primary_mode</th>\n",
-       "      <th>urban_rural</th>\n",
-       "      <th>total_project_cost__$1,000</th>\n",
-       "      <th>total_unfunded_need__$1,000</th>\n",
-       "      <th>notes</th>\n",
-       "      <th>shs_capacity_increase_detail</th>\n",
-       "      <th>current_phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>345</th>\n",
-       "      <td>None</td>\n",
-       "      <td>La River Bikeway - Segment 8</td>\n",
-       "      <td>La Metro</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Los Angeles</td>\n",
-       "      <td>7</td>\n",
-       "      <td>This project will construct at least 4.65 miles of high-quality bicycle infrastructure and pedestrian enhancements along the LA River and through the east San Fernando Valley, providing a safe and continuous active transportation network that will expand non-auto commute options increase access to high-quality transit lines and employment hubs, and improve access to recreation for LA residents and visitors. This project will include 3.2 miles of Class I bike, path greenway, and pedestrian path (as feasible), along the LA river between Whitsett Ave to Lankershim Blvd, which will also include five (5) at grade crossings at, and four (4) at grade crossings located at Whitsett Ave, Laurel Canyon Blvd, and Tujunga Ave, as well as two (2) bridges located at Radford Ave/over the Tujunga Wash as and a pedestrian bridge over the LA River. Class IV bike path on Whitsett, Radford, and Vineland will be constructed and approximately 0.45 miles of Class III bike path on Laurel Grove leading to the River will be constructed. This project will also try to upgrade to the maximum extent feasible the Vineland Ave corridor from Whipple to San Fernando Road, which stretches approximately 5 miles. These upgrades include putting in bollards along buffer areas and painting conflict zones. Other scope includes lighting, bioswales, retaining walls (as needed), and other pedestrian amenities, such as bike racks, benches, trash cans, and pet waste stations, and pedestrian enhancements.</td>\n",
-       "      <td>UNKNOWN</td>\n",
-       "      <td>Bike/Pedestrian</td>\n",
-       "      <td>Urban</td>\n",
-       "      <td>34108.0</td>\n",
-       "      <td>23409.0</td>\n",
-       "      <td>Partner agency = Implementing Agency</td>\n",
-       "      <td>None</td>\n",
-       "      <td>UNKNOWN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "     ppno                  project_name lead_agency  \\\n",
-       "345  None  La River Bikeway - Segment 8    La Metro   \n",
-       "\n",
-       "    previous_caltrans_nominations full_county_name  district  \\\n",
-       "345                          None      Los Angeles         7   \n",
-       "\n",
-       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            project_description  \\\n",
-       "345  This project will construct at least 4.65 miles of high-quality bicycle infrastructure and pedestrian enhancements along the LA River and through the east San Fernando Valley, providing a safe and continuous active transportation network that will expand non-auto commute options increase access to high-quality transit lines and employment hubs, and improve access to recreation for LA residents and visitors. This project will include 3.2 miles of Class I bike, path greenway, and pedestrian path (as feasible), along the LA river between Whitsett Ave to Lankershim Blvd, which will also include five (5) at grade crossings at, and four (4) at grade crossings located at Whitsett Ave, Laurel Canyon Blvd, and Tujunga Ave, as well as two (2) bridges located at Radford Ave/over the Tujunga Wash as and a pedestrian bridge over the LA River. Class IV bike path on Whitsett, Radford, and Vineland will be constructed and approximately 0.45 miles of Class III bike path on Laurel Grove leading to the River will be constructed. This project will also try to upgrade to the maximum extent feasible the Vineland Ave corridor from Whipple to San Fernando Road, which stretches approximately 5 miles. These upgrades include putting in bollards along buffer areas and painting conflict zones. Other scope includes lighting, bioswales, retaining walls (as needed), and other pedestrian amenities, such as bike racks, benches, trash cans, and pet waste stations, and pedestrian enhancements.   \n",
-       "\n",
-       "    current_phase     primary_mode urban_rural  total_project_cost__$1,000  \\\n",
-       "345       UNKNOWN  Bike/Pedestrian       Urban                     34108.0   \n",
-       "\n",
-       "     total_unfunded_need__$1,000                                 notes  \\\n",
-       "345                      23409.0  Partner agency = Implementing Agency   \n",
-       "\n",
-       "    shs_capacity_increase_detail current_phase  \n",
-       "345                         None       UNKNOWN  "
+       "_merge    \n",
+       "right_only    9563\n",
+       "left_only      840\n",
+       "both            69\n",
+       "dtype: int64"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.sample()"
+    "# 67 without accounting for districts\n",
+    "pd.merge(df, sb1_2, how=\"outer\", on=[\"project_name\"], indicator=True)[[\"_merge\"]].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 20,
    "id": "ccede347-cbfe-4ee3-9346-71b8f538258f",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>project_name</th>\n",
-       "      <th>implementing_agency</th>\n",
-       "      <th>sb1_program</th>\n",
-       "      <th>fiscal_year</th>\n",
-       "      <th>project_description</th>\n",
-       "      <th>total_cost</th>\n",
-       "      <th>sb1_funds</th>\n",
-       "      <th>is_sb1?</th>\n",
-       "      <th>project_status</th>\n",
-       "      <th>assembly_districts</th>\n",
-       "      <th>senate_districts</th>\n",
-       "      <th>congressional_districts</th>\n",
-       "      <th>counties</th>\n",
-       "      <th>cities</th>\n",
-       "      <th>caltrans_districts</th>\n",
-       "      <th>on_shs?</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>922</th>\n",
-       "      <td>Drainage - HM251</td>\n",
-       "      <td>Caltrans</td>\n",
-       "      <td>Highway Maintenance</td>\n",
-       "      <td>'21/22</td>\n",
-       "      <td>Repair/Replace Culverts</td>\n",
-       "      <td>333.0</td>\n",
-       "      <td>333.0</td>\n",
-       "      <td>Y</td>\n",
-       "      <td>In Progress</td>\n",
-       "      <td>28</td>\n",
-       "      <td>13, 15</td>\n",
-       "      <td>18</td>\n",
-       "      <td>Santa Clara</td>\n",
-       "      <td>Saratoga</td>\n",
-       "      <td>04</td>\n",
-       "      <td>N</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "         project_name implementing_agency          sb1_program fiscal_year  \\\n",
-       "922  Drainage - HM251            Caltrans  Highway Maintenance      '21/22   \n",
-       "\n",
-       "         project_description  total_cost  sb1_funds is_sb1? project_status  \\\n",
-       "922  Repair/Replace Culverts       333.0      333.0       Y    In Progress   \n",
-       "\n",
-       "    assembly_districts senate_districts congressional_districts     counties  \\\n",
-       "922                 28           13, 15                      18  Santa Clara   \n",
-       "\n",
-       "       cities caltrans_districts on_shs?  \n",
-       "922  Saratoga                 04       N  "
+       "_merge    \n",
+       "right_only    9569\n",
+       "left_only      845\n",
+       "both            63\n",
+       "dtype: int64"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "sb1_2.sample()"
+    "# 62 matches\n",
+    "pd.merge(df, sb1_2, how=\"outer\", left_on=[\"project_name\",\"district\"], right_on = [\"project_name\", \"caltrans_districts\"], indicator=True)[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "fbdc6b9d-9f9b-41cc-965b-6602a7ceb15f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_title_m = pd.merge(df, sb1_2, how=\"left\", left_on=[\"project_name\",\"district\"], right_on = [\"project_name\", \"caltrans_districts\"], indicator=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "3366c8f6-0ddf-4b57-8f01-0a7d9101d8d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preview =['project_name','district','caltrans_districts', 'counties','full_county_name','project_description_x','project_description_y', \"previous_caltrans_nominations\",\n",
+    "                \"sb1_program\", \"total_project_cost__$1,000\", \"total_cost\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "e3e4e316-b22f-4278-8c41-6bd048104212",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# project_title_m.loc[project_title_m._merge == 'both'][preview]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3522a920-706f-4475-9b23-0f2759eef3ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Active Transportation Program                52\n",
+       "Local Partnership Program - Formulaic         3\n",
+       "Local Partnership Program - Competitive       2\n",
+       "Trade Corridor Enhancement Program            2\n",
+       "Solutions for Congested Corridors Program     2\n",
+       "State Transportation Improvement Program      2\n",
+       "Name: sb1_program, dtype: int64"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "project_title_m.sb1_program.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bd3b888-c935-4029-81ca-e8cc5d3eedb5",
+   "metadata": {},
+   "source": [
+    "### Tircp\n",
+    "* None of the projects from TIRCP are mapping, even though the names appear the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "182020ac-5310-48a9-96d5-0227b89f6231",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sb1_tircp = sb1_2.loc[sb1_2.sb1_program == \"Transit and Intercity Rail Capital Program\"].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "81191fad-bd8a-4d7b-b75b-bcf7c542fc71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sb1_tircp[['project_name','caltrans_districts','counties']].sort_values('project_name').head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "38542d47-6129-4bac-bb97-d6ee4e158d06",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tircp_sb = sb1_2.loc[sb1_2.sb1_program.str.contains('Transit and Intercity')].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "80ca7f9b-043b-4f18-a79a-3e5d69161af4",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# tircp_sb[['project_name']].sort_values(by = 'project_name')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "417df614-c9e4-4b8e-9ffa-b4f21889e974",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# tircp_shopp[['project_name']].sort_values(by = 'project_name')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "25c0f244-c284-4de8-a8d9-872be7c74c0d",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tircp_shopp = df.loc[df.previous_caltrans_nominations.str.contains('TIRCP')].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "4f74adae-6714-4e3b-b288-911be3d67c27",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "right_only    95\n",
+       "left_only     93\n",
+       "both           1\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# why are there no matches??\n",
+    "pd.merge(tircp_shopp, tircp_sb, how=\"outer\", on=[\"project_name\"], indicator=True)[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b69c71eb-66fc-4e92-9d53-554ef18f190d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### SB1 Geojson\n",
+    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer\n",
+    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/query\n",
+    "* https://medium.com/@thomas.deboer/how-to-download-from-an-arcgis-rest-server-using-python-df900db3e364"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "ddd3fc5f-e17f-45a4-96d1-9151ff066edf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import urllib.parse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "a7e8656d-12dc-4ab1-9996-b7ac5dcc8ce4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = r\"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/query\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "37e6f914-1cc7-4515-bb23-930331fe0955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#params = {\n",
+    "#    'geometry': '-118.21637221791077, 34.094916196179504',\n",
+    "#    'geometryType': 'esriGeometryPoint',\n",
+    "#    'returnGeometry': 'true', \n",
+    "#    'f': 'pjson'\n",
+    "# }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "bacfe953-b85b-4cf0-b07c-6a918817e8df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# url_final = url + urllib.parse.urlencode(params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "9b118605-a8bf-477c-b070-3ad76211ce8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# response = requests.get(url=url_final)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "5286b27a-87be-4c90-a4ac-7bca4d018790",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data = response.text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "id": "933b3718-e5ab-4da8-b671-cace2f32b1a4",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# test = gpd.read_file(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "id": "6b1090ff-25b8-48cb-a70d-cb0fdfd0ab86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer?f=json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "id": "5e0ce5fb-389d-4a9c-acb2-183ceaf72a72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer/tilemap/0/0/0/8/8?f=json"
    ]
   }
  ],

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -25,9 +25,9 @@
    ],
    "source": [
     "import _utils\n",
+    "import geopandas as gpd\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import geopandas as gpd\n",
     "from calitp.sql import to_snakecase"
    ]
   },
@@ -41,55 +41,35 @@
     "import fsspec\n",
     "from calitp import *\n",
     "from calitp.storage import get_fs\n",
+    "\n",
     "fs = get_fs()\n",
     "import os"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "a4ba3617-394e-4277-ab7f-0103120dcd3c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import dask_geopandas as dg\n",
-    "import pyogrio"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pd.options.display.max_columns = 200\n",
-    "pd.set_option(\"display.max_rows\", None)\n",
-    "pd.set_option(\"display.max_colwidth\", None)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "76e4f5c3-7968-49e6-97d3-a1d165e50af3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Non SHOPP-ATP-TIRCP"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 59,
    "id": "6b483a64-786d-4d9c-96e8-0bfe429ffd2a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Read in 10 Year non SHOPP with ATP and TIRCP\n",
-    "df = to_snakecase(pd.read_excel(f\"{_utils.GCS_FILE_PATH}cleaned_data_atp_tircp.xlsx\"))"
+    "nonshopp = to_snakecase(pd.read_excel(f\"{_utils.GCS_FILE_PATH}cleaned_data_atp_tircp.xlsx\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 60,
    "id": "aa0c6362-1f89-4112-a55f-6928841266ce",
    "metadata": {},
    "outputs": [],
@@ -116,22 +96,666 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 62,
    "id": "a63dc3e3-2485-4331-b370-c6fdf2c57952",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df[non_shopp_subset]"
+    "nonshopp = nonshopp[non_shopp_subset]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "06967d23-860f-4d11-a4ed-18675a5070e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nonshopp.district = nonshopp.district.map(\"{:02}\".format)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "2258812c-fed6-4b48-84f7-10367a9b8839",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nonshopp.project_name = nonshopp.project_name.str.lower().str.strip().str.split(\"20\").str[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ba81d8f-2aaa-4138-be99-ed6687892a8a",
+   "metadata": {},
+   "source": [
+    "### Sb1 Geo\n",
+    "* Not every dataset has project names..."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "06967d23-860f-4d11-a4ed-18675a5070e6",
+   "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.district = df.district.map(\"{:02}\".format)"
+    "pd.options.display.max_columns = 200\n",
+    "pd.set_option(\"display.max_rows\", None)\n",
+    "pd.set_option(\"display.max_colwidth\", None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9f4ed958-a976-4c2b-8def-63a575f74d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_sb1_files():\n",
+    "\n",
+    "    sb1_gcs_path = f\"{_utils.GCS_FILE_PATH}SB1_geojsons\"\n",
+    "\n",
+    "    # Create a list of all the files in my folder\n",
+    "    files = fs.ls(sb1_gcs_path)\n",
+    "\n",
+    "    # Lower case\n",
+    "    files = [i for i in files if \".geojson\" in i]\n",
+    "\n",
+    "    # For now, delete out any Pt geometries\n",
+    "    # So the df isn't extremely large\n",
+    "    # files= [ x for x in files if \"Pt\" not in x ]\n",
+    "    # files= [ x for x in files if \"pt\" not in x ]\n",
+    "\n",
+    "    # String to add to read the files\n",
+    "    my_string = \"gs://\"\n",
+    "    files = [my_string + i for i in files]\n",
+    "\n",
+    "    return files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f2d48c49-7b67-472f-a3a5-d4f6e11e3352",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_files = get_sb1_files()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "40027b1a-07ec-45d1-be50-386900e1f72d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "22"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sb1_files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2e049563-3660-4bcf-8dcf-9ca5f55fb9af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with get_fs().open(\"gs://calitp-analytics-data/data-analyses/project_prioritization/SB1_geojsons/SB1_RCA_Projects_032022_Transit_and_Intercity_Rail_Capital_Program.geojson\") as f:\n",
+    "    tircp = to_snakecase(gpd.read_file(f))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0956687a-ec80-4b83-951d-54cd4af8864f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with get_fs().open(sb1_files[0]) as f:\n",
+    "    atp = to_snakecase(gpd.read_file(f))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "affd5c72-1f1a-4048-b93e-9dc47764e63a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_gdf = pd.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b16b7b3d-abbb-4f44-81c2-e50868f9a305",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for i in sb1_files:\n",
+    "    with get_fs().open(i) as f:\n",
+    "        df = to_snakecase(gpd.read_file(f))\n",
+    "    full_gdf = pd.concat([full_gdf, df], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "474ab647-776f-4341-80f0-46d8cd874b0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "|SHOPP|    2741\n",
+       "|HM|       1163\n",
+       "|LSR|       509\n",
+       "|ATP|       321\n",
+       "|SHOPA|     165\n",
+       "|SGR|       161\n",
+       "|STIP|      126\n",
+       "|TIRCP|      96\n",
+       "|LPP-F|      68\n",
+       "|TCEP|       63\n",
+       "|LPP-C|      57\n",
+       "|STA|        49\n",
+       "|SCCP|       40\n",
+       "|FM|         12\n",
+       "|SRA|        11\n",
+       "Name: programcodes, dtype: int64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_gdf.programcodes.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "9fcb5510-3b08-4ffc-b5db-ff584c49f407",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5582, 38)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "948200e3-eb60-4f0b-8d4d-bf0a65caf65d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_gdf[\"project_title2\"] = (\n",
+    "    full_gdf[\"programcodes\"]\n",
+    "    + \" \"\n",
+    "    + full_gdf[\"agencies\"]\n",
+    "    + \" \"\n",
+    "    + full_gdf[\"countynames\"]\n",
+    "    + \" \"\n",
+    "    + full_gdf[\"fiscalyears\"]\n",
+    "    + \" \"\n",
+    "    + full_gdf[\"totalcost\"].astype(str)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "114d0f9e-00bc-43e9-9698-55918bcb4cb2",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "full_gdf.projecttitle = full_gdf.projecttitle.fillna(full_gdf.project_title2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "9b7b1538-2ad7-4a82-9519-d581d616153e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop duplicates...since opened all ln/pt file?\n",
+    "full_gdf2 = (\n",
+    "    full_gdf.drop_duplicates(\n",
+    "        subset=[\n",
+    "            \"agencies\",\n",
+    "            \"programcodes\",\n",
+    "            \"sb1funds\",\n",
+    "            \"projectid\",\n",
+    "            \"projecttitle\",\n",
+    "            \"totalcost\",\n",
+    "        ]\n",
+    "    )\n",
+    ").reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "8e96fc92-c2ed-455a-bef6-c3889e4e3bb3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "|SHOPP|    2741\n",
+       "|HM|        913\n",
+       "|LSR|       509\n",
+       "|ATP|       321\n",
+       "|SHOPA|     164\n",
+       "|SGR|       161\n",
+       "|STIP|      126\n",
+       "|TIRCP|      96\n",
+       "|LPP-F|      68\n",
+       "|TCEP|       60\n",
+       "|LPP-C|      57\n",
+       "|STA|        49\n",
+       "|SCCP|       40\n",
+       "|FM|         12\n",
+       "|SRA|        11\n",
+       "Name: programcodes, dtype: int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_gdf2.programcodes.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "1b5ae135-7dd9-43f3-a063-36c415b4de5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset = [\n",
+    "    \"projectid\",\n",
+    "    \"agencyids\",\n",
+    "    \"agencies\",\n",
+    "    \"programcodes\",\n",
+    "    \"fiscalyears\",\n",
+    "    \"projectstatuses\",\n",
+    "    \"sb1funds\",\n",
+    "    \"iijafunds\",\n",
+    "    \"totalcost\",\n",
+    "    \"assemblydistricts\",\n",
+    "    \"senatedistricts\",\n",
+    "    \"congressionaldistricts\",\n",
+    "    \"countynames\",\n",
+    "    \"citynames\",\n",
+    "    \"ct_districts\",\n",
+    "    \"issb1codes\",\n",
+    "    \"isiijacode\",\n",
+    "    \"isonshscodes\",\n",
+    "    \"geometry\",\n",
+    "    \"projecttitle\",\n",
+    "    \"projectdescription\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "09b254a3-ae7d-4de3-8238-afaa0d35c6e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fill in NA\n",
+    "full_gdf2 = full_gdf2.fillna(\n",
+    "    full_gdf.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "ad31dbbc-592b-4082-b64d-bd5f411ad553",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_gdf2 = full_gdf2[subset]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "0257f8fa-b724-48c3-a171-57a403ad754b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((5328, 21), 1565)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_gdf2.shape, full_gdf2.projecttitle.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "98b60f3e-8875-4cc2-807a-98266ac56bbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Align funding\n",
+    "full_gdf2 = _utils.align_funding_numbers(\n",
+    "    full_gdf2,\n",
+    "    [\n",
+    "        \"totalcost\",\n",
+    "        \"sb1funds\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "bf24ac71-79a4-417f-906b-9ca4824b499f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lower case and clean project names\n",
+    "full_gdf2.projecttitle = (\n",
+    "    full_gdf2.projecttitle.str.lower().str.strip().str.split(\"20\").str[0]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "921e3b0a-eec5-471e-aeff-9a04dd1d5a6e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_2293/1072677451.py:3: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get rid of |\n",
+    "for i in ['programcodes','issb1codes','projecttitle','isiijacode', 'isonshscodes']:\n",
+    "    full_gdf2[i] = full_gdf2[i].str.replace(\"|\", \"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41757458-fdcb-4b34-8bd6-b2e6995230b6",
+   "metadata": {},
+   "source": [
+    "#### Low hanging fruit, TIRCP & ATP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "563d4da0-7985-429a-9a88-a2d7929fe765",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['ATP', 'FM', 'LPP-C', 'LPP-F', 'LSR', 'SCCP', 'SHOPP', 'SHOPA',\n",
+       "       'HM', 'SRA', 'STA', 'STIP', 'SGR', 'TCEP', 'TIRCP'], dtype=object)"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_gdf2.programcodes.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "3479af91-30bc-494a-82d7-cbbe1045841f",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tircp_atp = full_gdf2.loc[full_gdf2.programcodes.str.contains(\"TIRCP|ATP\")].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "ad603d43-2605-4df0-b671-2870222af678",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tircp_atp_nonshopp = nonshopp.loc[\n",
+    "    nonshopp.previous_caltrans_nominations.str.contains(\"TIRCP|ATP\")\n",
+    "].reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52d2dcca-c3ad-4c60-bb64-713eeeb70f5b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Try to merge CSV project ids with Geojson\n",
+    "* CSV version has cleaner project names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "5a61b35c-5e67-4ea4-b1b0-da721486fdc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_project_id(df, project_id_col:str):\n",
+    "    df[project_id_col] = (df[project_id_col].str.replace(\"'\",\"\")\n",
+    "                          .str.lower()\n",
+    "                          .str.strip()\n",
+    "                         )\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in SB1\n",
+    "sb1_project_id = to_snakecase(pd.read_csv(f\"{_utils.GCS_FILE_PATH}RebuildingCA_map_Data.csv\"))[['project_id','project_name']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "b8413685-db5a-43c8-81a4-46e7f98175c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_2293/2537473179.py:2: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
+     ]
+    }
+   ],
+   "source": [
+    "sb1_project_id = clean_project_id(sb1_project_id, \"project_id\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "76b3ea1c-9750-4f68-9659-96de5f83bbc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_gdf2 = clean_project_id(full_gdf2, \"projectid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "52ae80b3-b737-45cc-901c-6dbd8334204a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4050, 9544, 9632)"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_gdf2.projectid.nunique(), sb1_project_id.project_id.nunique(), len(sb1_project_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "307fd968-aec1-4e26-a2b3-88c80c5a1ab4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "left_only     5595\n",
+       "both          4174\n",
+       "right_only    1321\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(sb1_project_id, full_gdf2, how=\"outer\",left_on=[\"project_id\"], right_on=['projectid'], indicator=True)[\n",
+    "    [\"_merge\"]\n",
+    "].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "c05a86f1-6c69-484e-b6bd-5d3324742824",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_m = pd.merge(full_gdf2, sb1_project_id, how=\"left\",left_on=[\"projectid\"], right_on=['project_id']) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "e4b1d2d3-7b68-460b-a2eb-dd5f6e59c381",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_m.project_name = sb1_m.project_name.fillna(sb1_m.projecttitle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb97717c-265b-4564-8a7a-dc99f0168119",
+   "metadata": {},
+   "source": [
+    "### Merge 1 with Non SHOPP\n",
+    "* Didn't work on project names :( "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "92fc5d14-d99c-470f-9bc5-d903d7b212db",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "right_only    5495\n",
+       "left_only      905\n",
+       "both             0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(nonshopp, sb1_m, how=\"outer\", on = ['project_name'], indicator=True)[\n",
+    "    [\"_merge\"]\n",
+    "].value_counts()"
    ]
   },
   {
@@ -144,18 +768,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
+   "execution_count": null,
+   "id": "805ac0f5-36dc-40bd-b7b5-582baadc339a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Read in SB1\n",
-    "sb1 = to_snakecase(pd.read_csv(f\"{_utils.GCS_FILE_PATH}RebuildingCA_map_Data.csv\"))"
+    "sb1.shape, sb1.project_name.nunique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
+   "id": "34a06b31-dd37-48a2-83d6-06abd8d4b615",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Titles are not necessarily specifically named.\n",
+    "# Tends to be very general\n",
+    "# sb1.project_name.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "11af211e-6647-49b7-b818-d3bc5209ab43",
    "metadata": {},
    "outputs": [],
@@ -182,7 +817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "1c970a13-2b8a-4c24-afca-7f2f8fbe229d",
    "metadata": {},
    "outputs": [],
@@ -192,64 +827,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "0b6f73ab-706d-4c31-8fae-fe830a3fc260",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Local Streets and Roads                              3345\n",
-       "State Hwy Operations & Protection Program Major      2771\n",
-       "Highway Maintenance                                  1002\n",
-       "Active Transportation Program                         923\n",
-       "State of Good Repair                                  536\n",
-       "State Transit Assistance                              196\n",
-       "State Transportation Improvement Program              188\n",
-       "State Hwy Operations & Protection Program Minor A     169\n",
-       "Local Partnership Program - Formulaic                 135\n",
-       "Transit and Intercity Rail Capital Program             96\n",
-       "Trade Corridor Enhancement Program                     66\n",
-       "Local Partnership Program - Competitive                62\n",
-       "State Rail Assistance                                  53\n",
-       "Field Maintenance                                      48\n",
-       "Solutions for Congested Corridors Program              42\n",
-       "Name: sb1_program, dtype: int64"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sb1.sb1_program.value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ad12e624-e1cd-4e0f-a98e-c533490fc3d4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(9632, 16)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sb1_2.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "f3a9fb1a-9cbf-45a9-a0a6-cc96dbb16b09",
    "metadata": {},
    "outputs": [],
@@ -260,13 +858,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "7510fd40-c15e-42ba-a4f1-68031c2e6b3e",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Align funding\n",
-    "sb1_2 = _utils.align_funding_numbers(sb1_2, [\"total_cost\", \"sb1_funds\",])"
+    "sb1_2 = _utils.align_funding_numbers(\n",
+    "    sb1_2,\n",
+    "    [\n",
+    "        \"total_cost\",\n",
+    "        \"sb1_funds\",\n",
+    "    ],\n",
+    ")"
    ]
   },
   {
@@ -279,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "76e719a2-21fa-4b8f-bce4-100d612e3484",
    "metadata": {
     "scrolled": true,
@@ -289,85 +893,82 @@
    "source": [
     "# Lower case and clean project names\n",
     "for i in [sb1_2, df]:\n",
-    "    i['project_name'] = i['project_name'].str.lower().str.strip().str.split(\"20\").str[0]"
+    "    i[\"project_name\"] = i[\"project_name\"].str.lower().str.strip().str.split(\"20\").str[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "b4deeadc-c568-466e-9325-b8e491f5e51f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_merge    \n",
-       "right_only    9563\n",
-       "left_only      840\n",
-       "both            69\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 67 without accounting for districts\n",
-    "pd.merge(df, sb1_2, how=\"outer\", on=[\"project_name\"], indicator=True)[[\"_merge\"]].value_counts()"
+    "pd.merge(df, sb1_2, how=\"outer\", on=[\"project_name\"], indicator=True)[\n",
+    "    [\"_merge\"]\n",
+    "].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "ccede347-cbfe-4ee3-9346-71b8f538258f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_merge    \n",
-       "right_only    9569\n",
-       "left_only      845\n",
-       "both            63\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 62 matches\n",
-    "pd.merge(df, sb1_2, how=\"outer\", left_on=[\"project_name\",\"district\"], right_on = [\"project_name\", \"caltrans_districts\"], indicator=True)[[\"_merge\"]].value_counts()"
+    "pd.merge(\n",
+    "    df,\n",
+    "    sb1_2,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"project_name\", \"district\"],\n",
+    "    right_on=[\"project_name\", \"caltrans_districts\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "fbdc6b9d-9f9b-41cc-965b-6602a7ceb15f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "project_title_m = pd.merge(df, sb1_2, how=\"left\", left_on=[\"project_name\",\"district\"], right_on = [\"project_name\", \"caltrans_districts\"], indicator=True)"
+    "project_title_m = pd.merge(\n",
+    "    df,\n",
+    "    sb1_2,\n",
+    "    how=\"left\",\n",
+    "    left_on=[\"project_name\", \"district\"],\n",
+    "    right_on=[\"project_name\", \"caltrans_districts\"],\n",
+    "    indicator=True,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "3366c8f6-0ddf-4b57-8f01-0a7d9101d8d2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "preview =['project_name','district','caltrans_districts', 'counties','full_county_name','project_description_x','project_description_y', \"previous_caltrans_nominations\",\n",
-    "                \"sb1_program\", \"total_project_cost__$1,000\", \"total_cost\"]"
+    "preview = [\n",
+    "    \"project_name\",\n",
+    "    \"district\",\n",
+    "    \"caltrans_districts\",\n",
+    "    \"counties\",\n",
+    "    \"full_county_name\",\n",
+    "    \"project_description_x\",\n",
+    "    \"project_description_y\",\n",
+    "    \"previous_caltrans_nominations\",\n",
+    "    \"sb1_program\",\n",
+    "    \"total_project_cost__$1,000\",\n",
+    "    \"total_cost\",\n",
+    "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "e3e4e316-b22f-4278-8c41-6bd048104212",
    "metadata": {},
    "outputs": [],
@@ -380,26 +981,22 @@
    "execution_count": null,
    "id": "3522a920-706f-4475-9b23-0f2759eef3ba",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Active Transportation Program                52\n",
-       "Local Partnership Program - Formulaic         3\n",
-       "Local Partnership Program - Competitive       2\n",
-       "Trade Corridor Enhancement Program            2\n",
-       "Solutions for Congested Corridors Program     2\n",
-       "State Transportation Improvement Program      2\n",
-       "Name: sb1_program, dtype: int64"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "project_title_m.sb1_program.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40591042-e292-424c-9a08-cc0fc7148ae1",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sb1_csv = project_title_m.project_name.unique().tolist()"
    ]
   },
   {
@@ -413,7 +1010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "182020ac-5310-48a9-96d5-0227b89f6231",
    "metadata": {},
    "outputs": [],
@@ -423,7 +1020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "81191fad-bd8a-4d7b-b75b-bcf7c542fc71",
    "metadata": {},
    "outputs": [],
@@ -433,20 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "38542d47-6129-4bac-bb97-d6ee4e158d06",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "tircp_sb = sb1_2.loc[sb1_2.sb1_program.str.contains('Transit and Intercity')].reset_index(drop = True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "80ca7f9b-043b-4f18-a79a-3e5d69161af4",
    "metadata": {
     "scrolled": true,
@@ -459,7 +1043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "417df614-c9e4-4b8e-9ffa-b4f21889e974",
    "metadata": {
     "scrolled": true,
@@ -472,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "25c0f244-c284-4de8-a8d9-872be7c74c0d",
    "metadata": {
     "scrolled": true,
@@ -480,62 +1064,39 @@
    },
    "outputs": [],
    "source": [
-    "tircp_shopp = df.loc[df.previous_caltrans_nominations.str.contains('TIRCP')].reset_index(drop = True)"
+    "tircp_shopp = df.loc[\n",
+    "    df.previous_caltrans_nominations.str.contains(\"TIRCP\")\n",
+    "].reset_index(drop=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "4f74adae-6714-4e3b-b288-911be3d67c27",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_merge    \n",
-       "right_only    95\n",
-       "left_only     93\n",
-       "both           1\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# why are there no matches??\n",
-    "pd.merge(tircp_shopp, tircp_sb, how=\"outer\", on=[\"project_name\"], indicator=True)[[\"_merge\"]].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b69c71eb-66fc-4e92-9d53-554ef18f190d",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### SB1 Geojson\n",
-    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer\n",
-    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/query\n",
-    "* https://medium.com/@thomas.deboer/how-to-download-from-an-arcgis-rest-server-using-python-df900db3e364"
+    "pd.merge(tircp_shopp, tircp_sb, how=\"outer\", on=[\"project_name\"], indicator=True)[\n",
+    "    [\"_merge\"]\n",
+    "].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "id": "ddd3fc5f-e17f-45a4-96d1-9151ff066edf",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests\n",
-    "import urllib.parse"
+    "import urllib.parse\n",
+    "\n",
+    "import requests"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "id": "a7e8656d-12dc-4ab1-9996-b7ac5dcc8ce4",
    "metadata": {},
    "outputs": [],
@@ -545,22 +1106,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "id": "37e6f914-1cc7-4515-bb23-930331fe0955",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#params = {\n",
+    "# params = {\n",
     "#    'geometry': '-118.21637221791077, 34.094916196179504',\n",
     "#    'geometryType': 'esriGeometryPoint',\n",
-    "#    'returnGeometry': 'true', \n",
+    "#    'returnGeometry': 'true',\n",
     "#    'f': 'pjson'\n",
     "# }"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "id": "bacfe953-b85b-4cf0-b07c-6a918817e8df",
    "metadata": {},
    "outputs": [],
@@ -570,7 +1131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "id": "9b118605-a8bf-477c-b070-3ad76211ce8d",
    "metadata": {},
    "outputs": [],
@@ -580,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "id": "5286b27a-87be-4c90-a4ac-7bca4d018790",
    "metadata": {},
    "outputs": [],
@@ -590,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "id": "933b3718-e5ab-4da8-b671-cace2f32b1a4",
    "metadata": {
     "scrolled": true,
@@ -603,7 +1164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "id": "6b1090ff-25b8-48cb-a70d-cb0fdfd0ab86",
    "metadata": {},
    "outputs": [],
@@ -613,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "id": "5e0ce5fb-389d-4a9c-acb2-183ceaf72a72",
    "metadata": {},
    "outputs": [],

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -34,6 +34,25 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "736a052e-ea23-4b87-bdf9-43d5b396c9e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning\n"
+     ]
+    }
+   ],
+   "source": [
+    "import fuzzywuzzy\n",
+    "from fuzzywuzzy import process"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "c375e3ed-515c-4762-a8aa-2c448a5433f9",
    "metadata": {},
    "outputs": [],
@@ -48,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
    "metadata": {},
    "outputs": [],
@@ -60,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "237a5df4-60b9-4b73-858e-0468dad85d15",
    "metadata": {},
    "outputs": [],
@@ -108,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "6b483a64-786d-4d9c-96e8-0bfe429ffd2a",
    "metadata": {},
    "outputs": [],
@@ -121,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "aa0c6362-1f89-4112-a55f-6928841266ce",
    "metadata": {},
    "outputs": [],
@@ -151,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a63dc3e3-2485-4331-b370-c6fdf2c57952",
    "metadata": {},
    "outputs": [],
@@ -161,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "06967d23-860f-4d11-a4ed-18675a5070e6",
    "metadata": {},
    "outputs": [],
@@ -172,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "388aab8a-a885-4cd2-98b2-7dd6e5b24b82",
    "metadata": {},
    "outputs": [
@@ -180,8 +199,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_1801/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
-      "/tmp/ipykernel_1801/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+      "/tmp/ipykernel_2784/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
+      "/tmp/ipykernel_2784/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
      ]
     }
    ],
@@ -201,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "3e217738-36f1-4c7e-939d-dda2c86dc95d",
    "metadata": {},
    "outputs": [],
@@ -221,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "8834ce41-93b4-4978-a1bf-d4595dad14a6",
    "metadata": {},
    "outputs": [],
@@ -231,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "8b7deddf-30b5-4071-8a9c-2bd91c9cdc25",
    "metadata": {},
    "outputs": [],
@@ -252,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "86fcc2e9-e7d2-413e-bf0f-a133f9e1d628",
    "metadata": {},
    "outputs": [],
@@ -275,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "d001144d-7528-43d7-8b60-32d925ccf080",
    "metadata": {
     "scrolled": true,
@@ -288,11 +307,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da7daae5-7482-4535-aa72-08a3145b757e",
+   "id": "fdb18805-5114-4180-ab25-911c37435f42",
    "metadata": {},
    "source": [
     "### Sb1 Geo\n",
     "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "569fabbe-78eb-4f85-a8ec-4ff5aaf74c8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subset to preview SB1 vs Nonshopp. Nonshopp is on the left, sb1 on the right\n",
+    "preview_cols =  ['project_name','projecttitle','project_description','projectdescription', 'full_county_name', 'countynames']"
    ]
   },
   {
@@ -307,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "66078fe9-1813-4114-8cd3-f202d767d42f",
    "metadata": {},
    "outputs": [],
@@ -318,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "1d4ea347-27e9-46e0-896b-d46d31cb583c",
    "metadata": {},
    "outputs": [],
@@ -333,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "8871efb7-866e-4eba-8de0-47aba5974e09",
    "metadata": {},
    "outputs": [],
@@ -343,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "bf8f1b02-f703-487f-b0af-6b3b5aa494f0",
    "metadata": {},
    "outputs": [
@@ -362,7 +392,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -373,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "2f810e79-6227-4c12-940d-3b8f92f7e1fd",
    "metadata": {},
    "outputs": [
@@ -381,8 +411,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_1801/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
-      "/tmp/ipykernel_1801/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+      "/tmp/ipykernel_2784/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
+      "/tmp/ipykernel_2784/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
      ]
     }
    ],
@@ -393,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "52ac67ea-44e6-43d4-b5d5-c2f345554418",
    "metadata": {},
    "outputs": [],
@@ -403,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "d7bec9fb-c72f-4644-91c8-b8d019843a70",
    "metadata": {},
    "outputs": [
@@ -428,7 +458,7 @@
        "Name: programcodes, dtype: int64"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -439,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "3a14fd39-d217-42dc-9d8d-b8a1b1f7b559",
    "metadata": {},
    "outputs": [
@@ -449,7 +479,7 @@
        "True"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -461,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "f51de107-8fb6-4d05-86a6-6111753452c6",
    "metadata": {},
    "outputs": [
@@ -469,7 +499,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_1801/3707436155.py:1: UserWarning: GeoSeries.notna() previously returned False for both missing (None) and empty geometries. Now, it only returns False for missing values. Since the calling GeoSeries contains empty geometries, the result has changed compared to previous versions of GeoPandas.\n",
+      "/tmp/ipykernel_2784/3707436155.py:1: UserWarning: GeoSeries.notna() previously returned False for both missing (None) and empty geometries. Now, it only returns False for missing values. Since the calling GeoSeries contains empty geometries, the result has changed compared to previous versions of GeoPandas.\n",
       "Given a GeoSeries 's', you can use '~s.is_empty & s.notna()' to get back the old behaviour.\n",
       "\n",
       "To further ignore this warning, you can do: \n",
@@ -482,7 +512,7 @@
        "True"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "3a14399a-65f7-4c4a-8dff-770a5a8428c0",
    "metadata": {},
    "outputs": [
@@ -503,7 +533,7 @@
        "5581"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -514,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "225588db-cf65-4420-91f5-529f94f04e0f",
    "metadata": {
     "scrolled": true,
@@ -528,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "52e55d21-d807-4bf8-ac14-6e0d7c1b624f",
    "metadata": {},
    "outputs": [],
@@ -538,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "cd71460f-35f5-46ae-a93a-5191bdde60f7",
    "metadata": {},
    "outputs": [
@@ -548,7 +578,7 @@
        "True"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "9f70a4a8-8b23-4bd8-b362-2d27c7e642e1",
    "metadata": {},
    "outputs": [
@@ -574,7 +604,7 @@
        "Name: projecttitle, dtype: int64"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -585,7 +615,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
+   "id": "adde595b-1aeb-467f-a6f7-a0fb2b41db63",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5581, 38)"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_geo2.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
    "id": "a8e5a8eb-23bb-4741-a674-06d3448b1431",
    "metadata": {},
    "outputs": [],
@@ -595,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "id": "a4f51702-caca-4c01-b7d6-23de04012ead",
    "metadata": {},
    "outputs": [],
@@ -608,12 +659,12 @@
    "id": "a91b5261-4f89-439a-b82e-7877b7707551",
    "metadata": {},
    "source": [
-    "#### Compare with 9 Sample Projects"
+    "### Compare with 9 Sample Projects"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "id": "7fbba442-b295-4a9b-b94d-68dc41c0131f",
    "metadata": {},
    "outputs": [],
@@ -624,7 +675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "id": "729a5f9b-34ce-4802-8195-2319a38bc857",
    "metadata": {},
    "outputs": [],
@@ -635,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "id": "9002f8e2-75d1-4b3a-a7b6-b01efa548b5c",
    "metadata": {},
    "outputs": [],
@@ -646,7 +697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "id": "cb74fc0e-5ed1-4a40-acd7-84aa24a72733",
    "metadata": {},
    "outputs": [
@@ -656,7 +707,7 @@
        "(37, 38)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -667,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "id": "3fef812f-a54c-403e-992b-6bb51dcebdd7",
    "metadata": {},
    "outputs": [
@@ -679,7 +730,7 @@
        "Name: programcodes, dtype: int64"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -690,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "id": "d9ed4ea2-9e66-4ddd-b1b6-1c65d7ceaf97",
    "metadata": {},
    "outputs": [
@@ -704,7 +755,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -722,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "id": "a7475dba-a1dc-414c-8f13-c94d34003069",
    "metadata": {},
    "outputs": [
@@ -736,7 +787,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -764,7 +815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 41,
    "id": "c03ada7e-43f2-4f22-9ff2-d6ad9704337f",
    "metadata": {
     "scrolled": true,
@@ -777,7 +828,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 42,
    "id": "2eec244d-6141-4655-898d-d10e23cca51d",
    "metadata": {
     "scrolled": true,
@@ -790,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 43,
    "id": "bc283dad-5081-4d09-b160-006c9992472a",
    "metadata": {},
    "outputs": [],
@@ -801,30 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
-   "id": "3d20cf2c-ed33-4e69-90ea-f4e29b5911f5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test = sb1_geo2[sb1_geo2[\"projecttitle\"].isin(non_shopp_projects_sb1_list)].reset_index(drop = True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 72,
-   "id": "a0ebf374-ea77-4a93-b8eb-c40bab0f3f1d",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# test[['geometry','projecttitle']]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 44,
    "id": "2e3dad1e-5626-49a9-aff0-746fb54858e9",
    "metadata": {},
    "outputs": [],
@@ -834,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 45,
    "id": "3586edee-5451-481b-b3b1-2713acae7dc7",
    "metadata": {},
    "outputs": [],
@@ -847,7 +875,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 46,
+   "id": "3be58107-c5b9-48b6-bfdd-571247169e81",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>agencies</th>\n",
+       "      <th>programcodes</th>\n",
+       "      <th>countynames</th>\n",
+       "      <th>projecttitle</th>\n",
+       "      <th>projectdescription</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Caltrans</td>\n",
+       "      <td>SCCP</td>\n",
+       "      <td>Santa Cruz</td>\n",
+       "      <td>watsonvillesanta cruz multimodal corridor program wscmcp cycle 3 project contract 1  sr 1 freedom to state park aux lanes bus on shoulders and coastal rail trail segment 12</td>\n",
+       "      <td>near capitola and aptos state route 1 from state park drive to bayporter interchanges  construct auxiliary lanes between interchanges  includes reconstruction of the capitola avenue overcrossing to accommodate new lanes on state route 1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>None</td>\n",
+       "      <td>TCEP</td>\n",
+       "      <td>San Bernardino</td>\n",
+       "      <td>us 395 freight mobility and safety project</td>\n",
+       "      <td>on us 395 between sr 18 and chamberlaine way in the city of adelanto widen this section of us 395 from two to four lanes proposed improvements also include operational improvements such as adding turn lanes and signal improvements at intersections</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   agencies programcodes     countynames  \\\n",
+       "0  Caltrans         SCCP      Santa Cruz   \n",
+       "1      None         TCEP  San Bernardino   \n",
+       "\n",
+       "                                                                                                                                                                   projecttitle  \\\n",
+       "0  watsonvillesanta cruz multimodal corridor program wscmcp cycle 3 project contract 1  sr 1 freedom to state park aux lanes bus on shoulders and coastal rail trail segment 12   \n",
+       "1                                                                                                                                    us 395 freight mobility and safety project   \n",
+       "\n",
+       "                                                                                                                                                                                                                                        projectdescription  \n",
+       "0             near capitola and aptos state route 1 from state park drive to bayporter interchanges  construct auxiliary lanes between interchanges  includes reconstruction of the capitola avenue overcrossing to accommodate new lanes on state route 1  \n",
+       "1  on us 395 between sr 18 and chamberlaine way in the city of adelanto widen this section of us 395 from two to four lanes proposed improvements also include operational improvements such as adding turn lanes and signal improvements at intersections  "
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "non_shopp_projects_in_sb1[['agencies','programcodes', 'countynames','projecttitle','projectdescription']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
    "id": "08269d32-1146-4680-970e-b1a93c02c7d6",
    "metadata": {},
    "outputs": [
@@ -857,7 +963,7 @@
        "2"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -868,7 +974,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 48,
    "id": "5d02f7da-fb30-4fe6-a62c-f73e2efd872e",
    "metadata": {},
    "outputs": [],
@@ -884,7 +990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 49,
    "id": "d6cf4ff9-e128-41e2-9b0b-2ad5d810022c",
    "metadata": {},
    "outputs": [
@@ -894,7 +1000,7 @@
        "9"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -905,7 +1011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 50,
    "id": "a22c7ff3-a633-4582-b464-1a3d41f43fde",
    "metadata": {},
    "outputs": [
@@ -915,7 +1021,7 @@
        "geopandas.geodataframe.GeoDataFrame"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -926,7 +1032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 51,
    "id": "660faea4-9c6d-4041-b131-8f3905342a8a",
    "metadata": {},
    "outputs": [],
@@ -936,12 +1042,644 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 52,
    "id": "b1ffa7f6-a4d1-4ffb-986d-5f9681dc2f00",
    "metadata": {},
    "outputs": [],
    "source": [
-    " _utils.geojson_gcs_export(nine_sample_projects_geo,_utils.GCS_FILE_PATH, 'nine_sample_projects_geom')"
+    "#  _utils.geojson_gcs_export(nine_sample_projects_geo,_utils.GCS_FILE_PATH, 'nine_sample_projects_geom')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88d14b0f-ae25-42db-9130-3617662e7da7",
+   "metadata": {},
+   "source": [
+    "### Compare with ALL Projects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c3c71db-b030-44a5-a4e0-868648820924",
+   "metadata": {},
+   "source": [
+    "#### Fuzzy Matches"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b269ba27-10b3-47d9-9146-e6ad9defc30a",
+   "metadata": {},
+   "source": [
+    "##### Try with Project Titles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "b50375e7-147a-49b6-b8dc-f7a4cf26458e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Replace all rows in agency column with a min ratio with  \"string_to_match value\"\n",
+    "def replace_matches_in_column(df, column, new_col_name, string_to_match, min_ratio):\n",
+    "    # Get a list of unique strings\n",
+    "    strings = df[column].unique()\n",
+    "\n",
+    "    # Get the top 10 closest matches to our input string\n",
+    "    matches = fuzzywuzzy.process.extract(\n",
+    "        string_to_match, strings, limit=10, scorer=fuzzywuzzy.fuzz.token_sort_ratio\n",
+    "    )\n",
+    "\n",
+    "    # Only get matches with a  min ratio\n",
+    "    close_matches = [matches[0] for matches in matches if matches[1] > min_ratio]\n",
+    "\n",
+    "    # Get the rows of all the close matches in our dataframe\n",
+    "    rows_with_matches = df[column].isin(close_matches)\n",
+    "\n",
+    "    # replace all rows with close matches with the input matches\n",
+    "    df.loc[rows_with_matches, new_col_name] = string_to_match"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "e9858197-0dc1-4ea3-846e-8773a954ba15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nonshopp_projects = nonshopp.project_name.unique().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "321d9525-dfda-44b8-a4b2-8bef515893dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "901"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(nonshopp_projects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "44b972d1-376b-4cd7-8623-8d5de2c45e5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete project titles that are none\n",
+    "sb1_w_projectnames = sb1_geo2.loc[sb1_geo2.projecttitle != \"None\"].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "a29521cf-3c8c-426a-8f5e-b5dc48bc3028",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4260"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sb1_w_projectnames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "275b8922-5412-4a5b-8e94-d5c2cb0b9b27",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "291"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_w_projectnames.projecttitle.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "873f5b33-90d9-4cdd-a512-63cfd7af4120",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in nonshopp_projects:\n",
+    "    replace_matches_in_column(\n",
+    "        sb1_w_projectnames\n",
+    "        , \"projecttitle\", \"project_title_fuzzy_match\", i,90 \n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "7e0dc785-b0f5-4f99-953a-0e5637e8f30b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuzzy_match_results = sb1_w_projectnames.loc[sb1_w_projectnames.project_title_fuzzy_match.notnull()].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "424c79fd-ef66-44f6-bb89-71bf6e875f69",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>projecttitle</th>\n",
+       "      <th>project_title_fuzzy_match</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>caldwell interchange</td>\n",
+       "      <td>caldwell interchange</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>etiwanda avenue grade separation</td>\n",
+       "      <td>etiwanda ave grade separation</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>eurekaarcata corridor improvement</td>\n",
+       "      <td>eurekaarcata corridor improvement</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>excelsior expressway</td>\n",
+       "      <td>excelsior expressway ii</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>i680sr4 interchange improvements  phases 1 2 a</td>\n",
+       "      <td>i680sr4 interchange improvements  phases 1 2 a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>interstate 680 southbound express lane from state route 84 to alcosta blvd</td>\n",
+       "      <td>interstate 680 southbound express lane from state route 84 to alcosta blvd</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>interstate 680 southbound express lane from state route 84 to alcosta blvdtoll system</td>\n",
+       "      <td>interstate 680 southbound express lane from state route 84 to alcosta blvd</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>livingston widening northbound</td>\n",
+       "      <td>livingston widening  southbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>north county corridor project  phase 1 from claribel road to clause road</td>\n",
+       "      <td>north county corridor phase 1 from claribel road to claus road</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>redding to anderson six lane  phase 1  2</td>\n",
+       "      <td>redding to anderson six lane  phase 1 and 2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>redlands passenger rail project</td>\n",
+       "      <td>redlands passenger rail project</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>route 46 expressway segment 4c</td>\n",
+       "      <td>route 46 expressway segment 4b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>solano 80 managed lanes</td>\n",
+       "      <td>solano 80 managed lanes</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>state route 1  state park to bayporter auxiliary lanes</td>\n",
+       "      <td>state route 1  state park to bayporter auxiliary lanes</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                             projecttitle  \\\n",
+       "1                                                                    caldwell interchange   \n",
+       "10                                                       etiwanda avenue grade separation   \n",
+       "15                                                      eurekaarcata corridor improvement   \n",
+       "18                                                                   excelsior expressway   \n",
+       "13                                         i680sr4 interchange improvements  phases 1 2 a   \n",
+       "5              interstate 680 southbound express lane from state route 84 to alcosta blvd   \n",
+       "4   interstate 680 southbound express lane from state route 84 to alcosta blvdtoll system   \n",
+       "19                                                         livingston widening northbound   \n",
+       "14               north county corridor project  phase 1 from claribel road to clause road   \n",
+       "16                                               redding to anderson six lane  phase 1  2   \n",
+       "7                                                         redlands passenger rail project   \n",
+       "8                                                          route 46 expressway segment 4c   \n",
+       "12                                                                solano 80 managed lanes   \n",
+       "6                                  state route 1  state park to bayporter auxiliary lanes   \n",
+       "\n",
+       "                                                     project_title_fuzzy_match  \n",
+       "1                                                         caldwell interchange  \n",
+       "10                                               etiwanda ave grade separation  \n",
+       "15                                           eurekaarcata corridor improvement  \n",
+       "18                                                     excelsior expressway ii  \n",
+       "13                              i680sr4 interchange improvements  phases 1 2 a  \n",
+       "5   interstate 680 southbound express lane from state route 84 to alcosta blvd  \n",
+       "4   interstate 680 southbound express lane from state route 84 to alcosta blvd  \n",
+       "19                                             livingston widening  southbound  \n",
+       "14              north county corridor phase 1 from claribel road to claus road  \n",
+       "16                                 redding to anderson six lane  phase 1 and 2  \n",
+       "7                                              redlands passenger rail project  \n",
+       "8                                               route 46 expressway segment 4b  \n",
+       "12                                                     solano 80 managed lanes  \n",
+       "6                       state route 1  state park to bayporter auxiliary lanes  "
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fuzzy_match_results[['projecttitle','project_title_fuzzy_match']].sort_values('projecttitle').drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "ef8e50d6-105b-4b92-8319-a526dd7f4634",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outer_m_project_titles = pd.merge(\n",
+    "    fuzzy_match_results,\n",
+    "    nonshopp,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"project_title_fuzzy_match\"],\n",
+    "    right_on=[\"project_name\"],\n",
+    "    indicator=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "1c0b4c0d-e7aa-43a9-bc72-3c594c68d8c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "geopandas.geodataframe.GeoDataFrame"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(outer_m_project_titles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "be3e1cd9-2bc3-4fb3-825e-07100dd50d15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# outer_m_project_titles.loc[outer_m_project_titles._merge == 'both'][preview_cols]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5aa4e30b-4a42-4d2a-8134-9e7ef6c8efc9",
+   "metadata": {},
+   "source": [
+    "##### Try with project description since titles are very vague."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "7d999b4e-4865-4bf6-98fb-bcf8cacf820d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def replace_matches_set_ratio(df, column, new_col_name, string_to_match, min_ratio):\n",
+    "    # Get a list of unique strings\n",
+    "    strings = df[column].unique()\n",
+    "\n",
+    "    # Get the top 10 closest matches to our input string\n",
+    "    matches = fuzzywuzzy.process.extract(\n",
+    "        string_to_match, strings, limit=10, scorer=fuzzywuzzy.fuzz.token_set_ratio\n",
+    "    )\n",
+    "\n",
+    "    # Only get matches with a  min ratio\n",
+    "    close_matches = [matches[0] for matches in matches if matches[1] > min_ratio]\n",
+    "\n",
+    "    # Get the rows of all the close matches in our dataframe\n",
+    "    rows_with_matches = df[column].isin(close_matches)\n",
+    "\n",
+    "    # replace all rows with close matches with the input matches\n",
+    "    df.loc[rows_with_matches, new_col_name] = string_to_match"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "dd72498d-f734-4a74-87f0-0f9cfb14476c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Only include project descriptions that are \n",
+    "# more than 10 strings long\n",
+    "sb1_geo2[\"project_str_count\"] = sb1_geo2['projectdescription'].str.count('\\w+')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "4aefc612-ebac-4e64-a9c9-a8aa21269ba0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3638"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sb1_geo2.loc[sb1_geo2.project_str_count > 10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "34283c34-ceba-4fc7-bfd0-9f5c57f2a743",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3501"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_geo2.loc[sb1_geo2.project_str_count > 10]['projectdescription'].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "d4138105-6ed4-40ba-9b78-f537f7ec4efa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_w_projectdesc = sb1_geo2.loc[sb1_geo2.project_str_count > 10].head(500)[\"projectdescription\"].unique().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "d37f4b7a-cbef-470c-9308-f0052250e858",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "476"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sb1_w_projectdesc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "c0457ff4-e6ec-41c1-aefe-bb386e73a36b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in sb1_w_projectdesc:\n",
+    "    replace_matches_set_ratio(\n",
+    "        nonshopp\n",
+    "        , \"project_description\", \"project_desc_fuzzy_match\", i, 95\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "36c2446b-f22f-4ae2-8e30-17733af6b473",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>project_description</th>\n",
+       "      <th>project_desc_fuzzy_match</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>pavement preservation</td>\n",
+       "      <td>this project will perform preservation activities on approximately 32 lane miles of pavement on route 90 in orange county</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>on route 101 in marin county in and near city of novato from just south of the franklin avenue overhead to 03 miles south of the marinsonoma county line  the project will widen route 101 to construct a southbound hov lane from 03 miles south of the marinsonoma county line to just south of the franklin avenue overhead 60 miles and a northbound hov lane from 17 miles north of the atherton avenue overcrossing to 03 miles south of the marinsonoma county line 35 miles the project includes roadway and bridge widening for hov lanes and standard shoulders the project will also upgrade the horizontal and vertical roadway alignment for a 70 mph design speed modify the redwood landfill interchange ramps to conform with the new alignment and restripe a frontage road redwood boulevard for class ii bike lanes in novato\\n\\nconstruct 16 miles of mainline shoulder 9130 lf culverts 076 miles of bikeped facilities 95 miles of hothov mainline widen 4 shoulders modify 4 ramps and provide corrects to 10 curve and vertical alignments install 3 traffic monitoring detection stations 2 changeable message signs 1 extinguishable message signs 6 freeway ramp meters and 3 close circuit television cameras</td>\n",
+       "      <td>on route 101 in marin county in and near city of novato from just south of the franklin avenue overhead to 03 miles south of the marinsonoma county line  the project will widen route 101 to construct a southbound hov lane from 03 miles south of the marinsonoma county line to just south of the franklin avenue overhead 60 miles and a northbound hov lane from 17 miles north of the atherton avenue overcrossing to 03 miles south of the marinsonoma county line 35 miles the project includes roadway and bridge widening for hov lanes and standard shoulders the project will also upgrade the horizontal and vertical roadway alignment for a 70 mph design speed modify the redwood landfill interchange ramps to conform with the new alignment and restripe a frontage road redwood boulevard for class ii bike lanes in novato</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>on state route 68 from josselyn canyon road to spreckels blvd operational improvements replaces signalized intersections with roundabouts to achieve smooth traffic flow provide active transportation facilities at intersections and achieve transit benefits achieving these improvements on the existing corridor will preempt need for previouslyconsidered bypass alignment</td>\n",
+       "      <td>on state route 68 from josselyn canyon road to spreckels blvd operational improvements</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>in monterey county at castroville boulevard from post mile r16 to 14  build a new interchange at castroville boulevard and highway 156</td>\n",
+       "      <td>in monterey county at castroville boulevard from post mile r16 to 14  build a new interchange at castroville boulevard and highway 156</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>reconstruct interchange</td>\n",
+       "      <td>on route 99 in tulare county between 03 miles south of the avenue 280 caldwell avenue overcrossing to 04 miles north of the avenue 280 overcrossing  reconstruct interchange</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>reconstruct interchange</td>\n",
+       "      <td>on route 99 in tulare county between 03 miles south of the avenue 280 caldwell avenue overcrossing to 04 miles north of the avenue 280 overcrossing  reconstruct interchange</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>turnbull canyon road</td>\n",
+       "      <td>in the city of industry and unincorporated los angeles county along the alameda corridoreast trade corridor at turnbull canyon road replace atgrade crossing with a new grade separated undercrossing add sidewalks and bike lanes</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>realign intersection</td>\n",
+       "      <td>in stockton on the northern limits of the navy drive bridge at the san joaquin river to the port of stockton west complex entrance construct a grade separated crossing four lane overcrossing over the fyffe avenue rail line realign mccloy avenue south of its current location to form a stopcontrolled intersection</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>the north county corridor project phase 2 of 4</td>\n",
+       "      <td>the north county corridor project consists of 4 separate phases of construction totaling 18 miles in length the scope of this project is for phase 1 the corridor will be a high capacity bypass around the cities of modesto riverbank and oakdale as shown in exhibit 1 the phase 1 project will be an ultimate 6lane divided expressway beginning at the intersection of claribel road  oakdale road extending eastward to the intersection of claribel road  claus road it will be access controlled with a 4070median with grade separations over roselle avenue terminal avenue and the burlington northern santa fe railroad tracks this new alignment will build a westeast expressway that will improve regional network circulation connecting from the western end of downtown modesto to the eastward end joining sr120 east of the city of oakdale segments 1 to 4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>roadway grade separation</td>\n",
+       "      <td>in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>roadway grade separation</td>\n",
+       "      <td>in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>roadway grade separation</td>\n",
+       "      <td>in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>roadway grade separation</td>\n",
+       "      <td>in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          project_description  \\\n",
+       "0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       pavement preservation   \n",
+       "1   on route 101 in marin county in and near city of novato from just south of the franklin avenue overhead to 03 miles south of the marinsonoma county line  the project will widen route 101 to construct a southbound hov lane from 03 miles south of the marinsonoma county line to just south of the franklin avenue overhead 60 miles and a northbound hov lane from 17 miles north of the atherton avenue overcrossing to 03 miles south of the marinsonoma county line 35 miles the project includes roadway and bridge widening for hov lanes and standard shoulders the project will also upgrade the horizontal and vertical roadway alignment for a 70 mph design speed modify the redwood landfill interchange ramps to conform with the new alignment and restripe a frontage road redwood boulevard for class ii bike lanes in novato\\n\\nconstruct 16 miles of mainline shoulder 9130 lf culverts 076 miles of bikeped facilities 95 miles of hothov mainline widen 4 shoulders modify 4 ramps and provide corrects to 10 curve and vertical alignments install 3 traffic monitoring detection stations 2 changeable message signs 1 extinguishable message signs 6 freeway ramp meters and 3 close circuit television cameras   \n",
+       "2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           on state route 68 from josselyn canyon road to spreckels blvd operational improvements replaces signalized intersections with roundabouts to achieve smooth traffic flow provide active transportation facilities at intersections and achieve transit benefits achieving these improvements on the existing corridor will preempt need for previouslyconsidered bypass alignment   \n",
+       "3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      in monterey county at castroville boulevard from post mile r16 to 14  build a new interchange at castroville boulevard and highway 156   \n",
+       "4                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     reconstruct interchange   \n",
+       "5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     reconstruct interchange   \n",
+       "6                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        turnbull canyon road   \n",
+       "7                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        realign intersection   \n",
+       "8                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              the north county corridor project phase 2 of 4   \n",
+       "9                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    roadway grade separation   \n",
+       "10                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   roadway grade separation   \n",
+       "11                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   roadway grade separation   \n",
+       "12                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   roadway grade separation   \n",
+       "\n",
+       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           project_desc_fuzzy_match  \n",
+       "0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         this project will perform preservation activities on approximately 32 lane miles of pavement on route 90 in orange county  \n",
+       "1                                  on route 101 in marin county in and near city of novato from just south of the franklin avenue overhead to 03 miles south of the marinsonoma county line  the project will widen route 101 to construct a southbound hov lane from 03 miles south of the marinsonoma county line to just south of the franklin avenue overhead 60 miles and a northbound hov lane from 17 miles north of the atherton avenue overcrossing to 03 miles south of the marinsonoma county line 35 miles the project includes roadway and bridge widening for hov lanes and standard shoulders the project will also upgrade the horizontal and vertical roadway alignment for a 70 mph design speed modify the redwood landfill interchange ramps to conform with the new alignment and restripe a frontage road redwood boulevard for class ii bike lanes in novato  \n",
+       "2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            on state route 68 from josselyn canyon road to spreckels blvd operational improvements  \n",
+       "3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            in monterey county at castroville boulevard from post mile r16 to 14  build a new interchange at castroville boulevard and highway 156  \n",
+       "4                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      on route 99 in tulare county between 03 miles south of the avenue 280 caldwell avenue overcrossing to 04 miles north of the avenue 280 overcrossing  reconstruct interchange  \n",
+       "5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      on route 99 in tulare county between 03 miles south of the avenue 280 caldwell avenue overcrossing to 04 miles north of the avenue 280 overcrossing  reconstruct interchange  \n",
+       "6                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                in the city of industry and unincorporated los angeles county along the alameda corridoreast trade corridor at turnbull canyon road replace atgrade crossing with a new grade separated undercrossing add sidewalks and bike lanes  \n",
+       "7                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          in stockton on the northern limits of the navy drive bridge at the san joaquin river to the port of stockton west complex entrance construct a grade separated crossing four lane overcrossing over the fyffe avenue rail line realign mccloy avenue south of its current location to form a stopcontrolled intersection  \n",
+       "8   the north county corridor project consists of 4 separate phases of construction totaling 18 miles in length the scope of this project is for phase 1 the corridor will be a high capacity bypass around the cities of modesto riverbank and oakdale as shown in exhibit 1 the phase 1 project will be an ultimate 6lane divided expressway beginning at the intersection of claribel road  oakdale road extending eastward to the intersection of claribel road  claus road it will be access controlled with a 4070median with grade separations over roselle avenue terminal avenue and the burlington northern santa fe railroad tracks this new alignment will build a westeast expressway that will improve regional network circulation connecting from the western end of downtown modesto to the eastward end joining sr120 east of the city of oakdale segments 1 to 4  \n",
+       "9                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path  \n",
+       "10                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path  \n",
+       "11                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path  \n",
+       "12                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   in elk grove at lent ranch parkway to interstate 5  construct a 2 lane roadway modification of the i5hood franklin interchange and grade separation at the uprr tracks class 2 bike lanes class 1 path and signalized intersections  the project will design and acquire rightofway for 2 lanes that excludes the class 1 path  "
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nonshopp.loc[nonshopp.project_desc_fuzzy_match.notnull()].reset_index(drop = True)[['project_description','project_desc_fuzzy_match']]"
    ]
   },
   {
@@ -951,7 +1689,7 @@
     "tags": []
    },
    "source": [
-    "#### Step 2: Read in all projects\n",
+    "### Read in all projects\n",
     "* Compare with CSV.\n",
     "* Clean it up."
    ]
@@ -1077,7 +1815,7 @@
    "id": "59a4eef7-4b8b-40bd-af1a-f15f81a077ba",
    "metadata": {},
    "source": [
-    "#### Step 3: Figure out why the rows differ between `sb1_all_projects` and `sb1_geo2`"
+    "### Figure out why the rows differ between `sb1_all_projects` and `sb1_geo2`"
    ]
   },
   {

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -10,10 +10,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "22b768e0-0316-4684-a4b2-683dcd82a323",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "import _utils\n",
     "import geopandas as gpd\n",
@@ -24,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "c375e3ed-515c-4762-a8aa-2c448a5433f9",
    "metadata": {},
    "outputs": [],
@@ -39,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
    "metadata": {},
    "outputs": [],
@@ -61,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "6b483a64-786d-4d9c-96e8-0bfe429ffd2a",
    "metadata": {},
    "outputs": [],
@@ -74,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "aa0c6362-1f89-4112-a55f-6928841266ce",
    "metadata": {},
    "outputs": [],
@@ -95,7 +104,6 @@
     "    \"urban_rural\",\n",
     "    \"total_project_cost__$1,000\",\n",
     "    \"total_unfunded_need__$1,000\",\n",
-    "    \"notes\",\n",
     "    \"shs_capacity_increase_detail\",\n",
     "    \"current_phase\",\n",
     "]"
@@ -103,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "a63dc3e3-2485-4331-b370-c6fdf2c57952",
    "metadata": {},
    "outputs": [],
@@ -113,7 +121,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
+   "id": "831b6492-b46d-4b82-b11a-87d25b87bcdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lower case and clean project names\n",
+    "nonshopp.project_name = (\n",
+    "    nonshopp.project_name.str.lower().str.strip().str.split(\"20\").str[0]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "06967d23-860f-4d11-a4ed-18675a5070e6",
    "metadata": {},
    "outputs": [],
@@ -136,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "57760f7c-453e-4d1e-9055-911fdc5dd74b",
    "metadata": {},
    "outputs": [],
@@ -146,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
    "metadata": {},
    "outputs": [],
@@ -157,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "98ad0ce0-1ec1-4686-b088-51f1d5d4ea72",
    "metadata": {},
    "outputs": [],
@@ -167,7 +188,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
+   "id": "cd7b978f-e0fe-4cf9-9cfa-fe0993b78e27",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((9632, 37), 5453)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_all_projects.shape, sb1_all_projects.projecttitle.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "1c2e3f9f-55fc-4d4d-a6a4-931da4a68d84",
    "metadata": {},
    "outputs": [],
@@ -178,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "24de4776-90e4-4862-9224-fe1fedf4ef60",
    "metadata": {},
    "outputs": [],
@@ -191,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "3961c1b6-eb36-44ba-8a78-aca089cd2035",
    "metadata": {},
    "outputs": [],
@@ -201,39 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1b5ae135-7dd9-43f3-a063-36c415b4de5d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "subset = [\n",
-    "    \"projectid\",\n",
-    "    \"agencyids\",\n",
-    "    \"agencies\",\n",
-    "    \"programcodes\",\n",
-    "    \"fiscalyears\",\n",
-    "    \"projectstatuses\",\n",
-    "    \"sb1funds\",\n",
-    "    \"iijafunds\",\n",
-    "    \"totalcost\",\n",
-    "    \"assemblydistricts\",\n",
-    "    \"senatedistricts\",\n",
-    "    \"congressionaldistricts\",\n",
-    "    \"countynames\",\n",
-    "    \"citynames\",\n",
-    "    \"ct_districts\",\n",
-    "    \"issb1codes\",\n",
-    "    \"isiijacode\",\n",
-    "    \"isonshscodes\",\n",
-    "    \"geometry\",\n",
-    "    \"projecttitle\",\n",
-    "    \"projectdescription\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "98b60f3e-8875-4cc2-807a-98266ac56bbb",
    "metadata": {},
    "outputs": [],
@@ -250,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "bf24ac71-79a4-417f-906b-9ca4824b499f",
    "metadata": {},
    "outputs": [],
@@ -263,19 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "921e3b0a-eec5-471e-aeff-9a04dd1d5a6e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get rid of |\n",
-    "for i in [\"programcodes\", \"issb1code\", \"projecttitle\", \"isiijacode\", \"isonshscode\"]:\n",
-    "    sb1_all_projects[i] = sb1_all_projects[i].str.replace(\"|\", \"\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "a87ebb9b-4ca9-45d0-9e58-01a13ab873ef",
    "metadata": {},
    "outputs": [],
@@ -286,10 +284,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "563d4da0-7985-429a-9a88-a2d7929fe765",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'full_gdf2' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[19], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mfull_gdf2\u001b[49m\u001b[38;5;241m.\u001b[39mprogramcodes\u001b[38;5;241m.\u001b[39munique()\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'full_gdf2' is not defined"
+     ]
+    }
+   ],
    "source": [
     "full_gdf2.programcodes.unique()"
    ]
@@ -326,25 +336,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5a61b35c-5e67-4ea4-b1b0-da721486fdc5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def clean_project_id(df, project_id_col: str):\n",
-    "    df[project_id_col] = df[project_id_col].str.replace(\"'\", \"\").str.lower().str.strip()\n",
-    "    return df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "b1616bcb-efe6-451c-9310-7ca2629dcb37",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Fill in NA\n",
-    "# sb1_2 = sb1_2.fillna(sb1_2.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
+    "sb1_all_projects = sb1_all_projects.fillna(sb1_all_projects.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
    ]
   },
   {
@@ -352,58 +350,97 @@
    "id": "1ea8e6ea-1ab7-42f4-be6d-d0de4d4a4113",
    "metadata": {},
    "source": [
-    "#### Step 2: Read in files with geometry "
+    "#### Step 2: Read in files with geometry \n",
+    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "120f70b4-586f-4e63-a178-0f68ae97bf41",
+   "execution_count": 21,
+   "id": "66078fe9-1813-4114-8cd3-f202d767d42f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Stopped at Trade Corridor Enhancement Program Pt for testing\n",
-    "url_list = [\n",
-    "    \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/1/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\",\n",
-    "    \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/2/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\",\n",
-    "    \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/3/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\",\n",
-    "]"
+    "url_pt1 = \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/\"\n",
+    "url_pt2 = \"/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
+   "id": "1d4ea347-27e9-46e0-896b-d46d31cb583c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rest_server():\n",
+    "    full_gdf = pd.DataFrame()\n",
+    "    for i in [*range(0,22)]:\n",
+    "        df = to_snakecase(gpd.read_file(f\"{url_pt1}{i}{url_pt2}\"))\n",
+    "        full_gdf = pd.concat([full_gdf, df], axis=0)\n",
+    "    return full_gdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "id": "8871efb7-866e-4eba-8de0-47aba5974e09",
    "metadata": {},
    "outputs": [],
    "source": [
-    "full_gdf = pd.DataFrame()"
+    "sb1_geo = rest_server()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "90737e33-59b9-4ad1-bf45-1e933b4cc099",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAGdCAYAAADkAUNdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAA9hAAAPYQGoP6dpAACJk0lEQVR4nO2deVxU5f7HP2dmmBn2HUFFQEERERFTwTURXLC0rFtpLpWZVnbbfveqmalpqS1Xu9eyMrPU1FZTE3dNUVFUQEFEFEGUfZF9GZg5vz+GGWdglnNmzgwz8LxfL1/F8JxznoPyOc/5Pt/v50vRNE2DQCAQCFYJr6MnQCAQCATDISJOIBAIVgwRcQKBQLBiiIgTCASCFUNEnEAgEKwYIuIEAoFgxRARJxAIBCuGiDiBQCBYMYKOnkBbZDIZCgoK4OjoCIqiOno6BAKBYBQ0TaOmpgbdu3cHj8f9utniRLygoAC+vr4dPQ0CgUDglHv37qFnz56cn9fiRNzR0RGA/IadnJw6eDYEAoFgHNXV1fD19VVqG9dYnIgrQihOTk5ExAkEQqfBVOFhsrFJIBAIVgwRcQKBQLBiiIgTCASCFUNEnEAgEKwYIuIEAoFgxRARJxAIBCuGiDiBQCBYMUTECQQCwYohIk4gEAhWjFEivm7dOlAUhbfeegsAUFFRgTfeeAP9+vWDra0tevXqhX/+85+oqqriYq6dDqmMRmJ2Ofal5iMxuxxSGd2pr0sgELjH4LL7S5cu4ZtvvkFYWJjys4KCAhQUFOCzzz5DSEgI7t69i4ULF6KgoAC//fYbJxPmEqmMRlJOBUpqGuHlKMawADfweeZxTjycXohVBzJQWNWo/MzHWYwVj4dgUqgP6/NJWmTYkZiLuxX18HOzw+wofwgF7Z/Rmq7rYmuDF0f6Y1F0kNnun0AgcANF0zTrZVhtbS0iIiLw1VdfYc2aNQgPD8fGjRs1jv31118xa9Ys1NXVQSDQ/8yorq6Gs7MzqqqqWHunNEik+Dg+A7nl9fB3t8N7cSGwFfI1juVaRNlwOL0Qr+5MRtsfvEI+N8+KYDWHtfEZ2JKQA9UFNY8C5o8OwNK4EL3XVeBiZ4N10wea/P4JhK6EMZrGBIPCKa+//jqmTJmCmJgYvWMVE2ci4MYwf/sl9P/gMHZcyEPCrTLsuJCH/h8cxvztl9qNPZxeiIU7k9UEHACKqhrx6s5kHE4vNNk8pTIaqw5kaBRSxWerDmQwDnGsjc/AN2fUBRwAZDTwzZkcvLL9EvLK63VeV0FlfbPJ759AIHALaxHfs2cPkpOTsXbtWr1jy8rKsHr1arzyyitaxzQ1NaG6ulrtD1vmb7+EYxklGr93LKNETcilMhpLfk/TOFafiHIRS07KqWj38Gg7h8KqRiTlVOg9l6RFhm8TcnSOOZpRgplbLuBMVqnO66pen81DhEAgdCyslsf37t3Dm2++iWPHjkEsFuscW11djSlTpiAkJAQrV67UOm7t2rVYtWoVm2mo0SCRahVwBccySnA6swSj+nrizT0pqGxo1jpWVUSj+rgrP9cUfnGzF2J4gBv6eNojqrcHIvu4640pl9ToF1Km4348nwsmwTCJVIaLOeWMrgtovn8CgWCZsBLxK1euoKSkBBEREcrPpFIpzpw5g02bNqGpqQl8Ph81NTWYNGkSHB0dsXfvXtjY2Gg959KlS/HOO+8ov1YYqDPl4/gMRuPm/nAJzrYCVDW0MBqvKqLaYskVdRIcSi8CAGw6lc0opuzlqPvhx2bcpVxmwhzu64yxfb3w9ek7jMYDzB82BAKhY2El4uPHj0damnoo4sUXX0RwcDAWL14MPp+P6upqTJw4ESKRCPv379e7YheJRBCJROxn3kpueT3jsUwFHHgookxiyQoq65uxcGcy5o30R0yIt8Zsl2EBbvBxFusMbfg4yzNl9GEnZPbXZycUMLquKkwfNgQCoWNhJeKOjo4IDQ1V+8ze3h7u7u4IDQ1FdXU1JkyYgPr6euzcuVMtxu3p6Qk+X3OmiDH4u9sh4Ra353SxtVGKqL4Ytia2nsvF1nO58HEWY9nkYAwNcMe7v6ZCRgO2NnwM7OGk85xTB/kwSvV7KqIn/kwtYDSOz6Ow4vEQLNyZrHe8o0iAoqoGJGaXmzXtkkAgsIfTlJHk5GRcvHgRABAYGKj2vZycHPj7+3N5OQDAe3Eh2HEhj9NzvjjSXylcRdWGhxUKqxqxaE9qu8+dxLp/7PuvFuLfk/rrFc8RgR6wE/JRL5FqHWMv5GNEoAcAYFKoD76eFYElf6Shsl77vkBNUwve/uUqAPOlXRIIBMMwKE/clLDNqRy65hhKayWcXd9BJMDVFRPA51GIv1aAxX9cQ02jdpFkg7u9ELZCPu4/aNA79u2YILwZ01fvOEW6pDa+1pBzLpXR2HTyNrady9G5yQsYnrtOIBDkWGSeuKVQUSvhVMAB4JOnwsDnUVgbn4HXdqVwJuDPDfVF0nvj0a+bA6PxG47fYpSvrVhdd3NU31fwdhJpFHAA4PMovBkThCvLY7F7fiQ2PBsON3vNm880SNohgWDJWFy3ezY89+15Ts+3YEwA4sJ8EH+tEN+c0Z1/zZaoPu6Q0sCJzFLGx6w6kIHYEG+9YZVJoT6IDfFmbSHA51GI6uOOxOxyVNTpXpGTtEMCwTKxahEvqTFsFe5iZ6MWE3azt8GaaaGIC+sOqYzG+/vSuZqiEi9HMf71ayqrY9oKpy5/FIUgGwLTuL8x+wMEAsE0WLWIezkK9cZ0VXEQ8fHZPwbpXLUm5VSgoo67EA0FwNtZjCF+rnh+ywXWxyvytTX5o3wUfwPzRgUgOribUSZeFbVNnI3rSFMxAqErYtUivueVEYhYc4zx+NVPPCzE0bZqZVPksiyuP6oampFdWoND6cWgALV8coV0rXg8BFfuPoCM8Zkf4uUoVvqjtEVGA1sScrBFpfTekGwSN3shJ+M60lSMQOiqWPXGppuDEB4O2qtB2+LtpL+AhWmRi5u9DV4aFYD/m9gPm2c9gq9nRcDbWf1Yb2exMquDbQUkBbkAhvu6qIm0Pgwx8fJ2tjV6nKKqtSNMxQiEroxVr8QB4PL7EzBw5WG9WSRMqyCZVjaumRaqFibQt7loSAXkisdDsOvi3XYOhbqgIX8AMN0UBYyvItXnzMh2PgQCgTlWvRJXkLZyEmZH9tL6fQpyQWQiIIrKRl3Is1i6azw2qo87poX3QFQbM6xhAW5wtmX2zHSxs8FbMX0RG+KNuxXMbQUUsHFCVMx7xeMh0PXT0fXzY+rMOPSjY3jqq3NYfygTs7dexNHrRYzmRyAQtNMpRByQx7u/mjm4Xb6zSECxLlSZOMAbj4f5wIavLlru9kJ8NTNCrdECU/g8CqunheofCLkHy4bjWRi1/iTqm5j7vbSFTQhnUqgPNs+KgI9z+zcGigKcbbXHw5lep6KuGVfyKrH5dDYSbpXh2v2HbftomkZ6fhUadFSfEgiE9lh9OEWVuLDumBjqg6ScCuxNvodfruSjuYVGUDdHVue5XlANdwcRmqU0ds+P5CzTYmp4DwgFvHabfwIehRYNMZPCqkb8lpzfbsOUKWxDOJpCQr9duYffk/Px6k9X8HRET0T2dsew3m5wEtsoM1FuFdcaMDtgb+p9/N/EfgCAB/XNqGpohq2Qj/+euIUFY3tDJODea4dA6Gx0KhEHHoY0ovq4Iy2/GgVVjThyvQivPRqo/+BWJFIZfjifC0B7FouhtBVKDwcR3v0lFUXV2tP32Aq4Iq2RyR5AW9rmmw/ydcbFnArcf9CA787m4LuzOeDzKPR0sUV5nQS1Rrwp5D9oRFV9M5ztbCCjaeV8MwqqGfmkEwiETijiqhx4YxQEfPYRI9UslkNphZg8kNv0OFWhTMwu1yngbFFNa+RiE9FOKMBfb4zC6axSXLhTjsTscuSW1xsUq9fESz8k4ffXRsLD4aFtwEujAmBjwN8bgdAV6dQiLpPRmPvjRdwuqcVn/whXs5fVFSLp7mILR5EANU0t2HTqNucirgrb1MP3JgfjfmUD/Nzs0M1RhI8OZaqFZrxNkJftYifEtPAemBbeA1IZjai1J1BSw82Dp0DDhqghbxAEQlel04r44fRC/Ou3a6hplL/uz9hyAS528k1P1ZJ7bcUoo/t6ID6tCMUmLjVnG7c+lVmC3QuilF9PDutu1gpJ+bX0C3g3JxGKGbxhdNewkUogEJjTKd9ZFYUnCgFXUFnf3M5Hu20xiqIZskIG/d3tTTpXRY42UxJzKhB/7WEjCF1pjaaA6ZvD2zFBjMZ9/8IwY6ZDIHR5Op2Is2mnBqh3uI+/VohR609ixpYLOJgmz2FOL6gyabUhk7z0trzzy9V2trCKh8++1HwkZpebzDaW6ZuDn7sD/Nx1V4L6udvC2Y55xS2BQGiP1TeFaEtidjlmGGA0pQ1zNUX4KzVfYxcgbTwW5oNNM+UNq83pWSKV0Ri1/qTe6s6zi6PB51EY++lJ3C1v3wTDz90Wp/8VzencCARLhDSFYAnXXdpVV+qmbIrwWHgPTBnozXj8wWuFkLTIzO5ZwudRmDpI94NBtUfo6X9F4+oHEzC458N/vKumDiACTiBwRKcTcVN0aWdbxs6ExmZpuxzr/86IgNiG2V8JDWDpH9ewcv91rZ4lpujII5XR+PnyfZ1j9l8tVLums50NfnttlPLeknJMF+4hELoanU7Ew31dIOSbZnOPq1X+qcwSPLX5PEJXHEFWcY3ycz6Pwn/+Ec74PL8n5+vNMef64bPp5G2dTZY1XfNwunyvobFZbsZ7MK0Io9afJM6GBAIHdCoRX/1XBkI+OAyJtGM39fRBg8b1gmoAwMIdV9S+FxfmAz83ZtawTDHm4aO6YXrudhk2nbrF6prEopZAMC2dJk986qYEXLtfrXOMq50NaEDvSrItxpSxayI6uBumR/TAH8n5ENm09wcZGeSBuxfvcXItwPCHT/y1Qry/L92gTkdejmJiUUsgmIFOsRJf/Ve6XgGnAJxfMh5X3o/Fk+HtbWR1HQdwV8auoKk1tNDHs30eeh8PB8bncbO30Wohq2gsYcjDZ218Bl7blWyQgIsFPAwLcGNsUctluIdA6GpYvYhLWmTYevau3nE0gF0X74LPo9DdhXm4QrU7D1f8fbMEh1rDCE8P6dnu+zOH+zE6j4+zGGta7W3bCrkxD5/4awUa28ExxVEsAJ9HMQ7jcJ1RRCB0Jaw+nPLjeeZiozBtcmFYYDImyB3bXhzO6Qqcpmks25sOGQ30cLFFZG91l8TD6YVYuT+D0bkUeeCbeVS7PHFNHipMmhhLZTTe35duxB0CpbUSrI3PwKP9ujEan1vGjZkWgdAVsXoRv5T7gPFYPzc7AIAHwxjxlbuVhkxJJzIayK9sgKudDX58aSjEKjHxw+mFWLgzWe857EV8fP6PQUqB1tcaTnFuJgVBSTkVqKhjt2egiW/P5OCtmH7wdhLpzaDZcykPi6IDSVycQDAAqxdxeyHzxgGzo/wBMGuYDAB1Eiku3CnHyEAPQ6amER4FfPJ0GKYO6g6R4GE0Syqj8e4vV3UeK+BR2DrnEYzq69lO8Nr6gKuiyBBpu8GoyBBRDRdxFdqgAey8kIsZw3phw3HdGS2KuDjX3u0EQlfA6mPi0yPax5Q1MSm0G4StojkswA32Imbin5hdbvDcNEFRFJ4I74Fvz9zBdwl3lJ+fv12GOj2tyVpkNHg8itWKVV+GCAAs25uOxmb5tbkslrqU+wD+HswMxEhcnEAwDKsX8RGBHoxW44fTi/HM1+eRcLMUADAmiNnqOru0Rv8glsz4NhEbjmXhRGaJ8rP/nWSWf/1Hsu5qybYwyRApr5Mg7osEVDU0s3ZV1IW9kM/4oWCKSlsCoStg9SLO51H4/JlBjMYm5T7A7G1J6PtePPp2Y2ZEc+52OSQtMmOmqFYw89TX53AlrxI0gH6tvT+lMhpXVZoG60LXal2TkyHTFa5QwINTa1bJisd1d76PC2Xm8TI9oqfyoWCKNEgCgdAJYuKAfGNvwzPhePuXVEbjpQC+OMFs5Vvd2ILItcfx8ZMDDUoz1LShCMhj4x881h+AfLXcxPBBMcTPhfF1fJzFeG5oL0bnXf5YCChKLrWTQn2weVZEu/O52dtgzbRQTAz1wemVR3Q+UOyEPIwI9FA+FF7VsGFrqhx8AqEr0SlEHAAOXss32bkr6pqxcGcyvmaZL65tQxGQZ6kcu1GCSaE+rOLBdU3thVPXxuXG41lwsbNBVX2zxnkoqlHbpjrqy3j5/JlBOjNpnn3EVzlW8VB47adkqPpemaKVHIHQ1bD6cAogry48nllq8uv836/XGIdW9DWnUJScS2U0q3jw1rM5SgdAqYzGuVtlWPJ7mk4nwwaJVGeTDG0rYV1dgyaF+uDrWRHtMn1sbXgI8nJAQJuq00mhPnhicA8A8iybH18chrOLo4mAEwhGYvUr8bXxGUZVF7KhtqkFEauP4jOVHG1tnL9dxrjkfFiAG9zshYxK3OskUmw6eQv9vB01hmk0oS1UI+BR+OwfYQYLqabV+pt7UnCrpBb9vB3bjX9jXCD2JuejRUbjvb1pOPLWGDiIrf6fIIHQoVj1SlzSIjNawN+O6atzE68ttU1SLNTgvqe6qfj6T5cx+/skRucrqWkEn0cpy+eZ8O2ZO1iowRlQFyIBD4vGBWLr3Eew/LH+cBAJ0CKjcd7IFMq2q3UZTSPY2xF+GnqTBng64Pnh8hh9fmUDRq0/idvF3Gf/EAhdCateBu1IzDXq+G6OQiyKDkQ/bwe8t5edW5+q+562zUsmKEIpcWE+eDzdGweuFek9Rl8+uSZ+eHGYWjGNm70Qb/98FdfuVzEqx2fKmicGYkxfD9gJNf/TWvPkQHg5ifGfY1mobGjGlP+dxYE3RqFvt/YrdwKBoB+rFnGFF4qhNElpHMsowqRQH0QHd8Pg1Uc1bhxqQhEKOX69EFvP6zfg0kTb1LqNz0XgaMZhxpkqTNBmo6sQzaziGjyy5ige1D/sMmRMf85JbdIPNT0g/jk+CEHdHPDaT8loapHhxW1J+Owf4Zw8RAiEroZVi7jCC8VQquqb1crOXxndW2+JuCrGNmRW7UUJAMcyijgXcEDzxmWIjxNsbXhoaJapCTggf0C1Lcc3BF1+LZNDffCff8jTQvMrG9V+lqZq8kwgdEasOiau8EIxlLZNkBdFBzF2OOSCb8/kKGPrUhmNxb9f4/T8umx0P46/gYZm7Q8MY/tzMunoYyvU/M+PdP0hEJhj1SL++dFMo8+hmiXC51FYN30go41OLt72aQDL96VDKqNxIbscVQ0teo8B5FklunCxtcFPLw/XmMInldHYeCwLWxL0bwgb2rCBiV/Lyv3XtVrutn24EggE7VitiEtaZIyEiCmKghtFYYq2FTnV+ufN8UGcXLe0RoKotSew5xLzuHqLFmFTzG3dUwMxsrVaUpXD6YUYue4ENjKsVgWA//v1Kjb/nY0qFi3tmPi1FFU3oaiadP0hEIzFakV8R2IuuFykqRbcTAr1wZX3Y/F2TBBcbNXFXBGiYOrOx4SSmiZGWSkKfJzFeDc2CN5OIo1z0xQ+ib8m9yrX5+3dlvzKBqw/nIknN5/D7ZJaRsdw6UhI3A0JBN1Y7camsZkpChTZG0P8XJGYXa6WIfFmTF8sig7SmH7HpUUtBeisqGzLP6MDMWO4H14bp3lubTNCymua8M+fU1jPi0cB4b4uKKxqxJ3SOjz55Tnsf2MUAvQ8wLh0JCTuhgSCbqxWxI3NTFFAA4jo5YxhHx1HZcPDkIFqhoSmZgXDAtzQzVGI4hr2jYQVKB4gf74+AsM/Psn4uBOZJZgx3E9jIwhjctbbsmnGYMSFdUdJdSPmb7+Mq/ersHDHFeyaPxzuDiKtxymcC4uqGrX6tXRzEgGgUFytfYym1EgCgaCO1YZTZkf5g2K5uajtZg+mFasJOKA/Q+KTwzdQUqtbwH1dxXC31x5bB+Tpf92cmDduBoBTmSWY+30S/korUPtcW0aIIcwf7Y+4sO4AAC8nMb6Z/Qg8HUW4WVyDD/Zf13ksn0dh2eRgrW8XNICVUwdg5dQQANw2eSYQuhpWuxIXCnh4eVQAq81NNhnYNB6aVCkqMxXo82uxE/Lxn2ce+qtoWh0b4+AnpYHTWaU4nVWKdwVXYcPnoYeLLW6V1LAKy2hj/ugALJsSovaZt7MY388diqlfnsXBa4XwccrAuxP6wVZDQ4618Rn4loEdgjbLW+JuSCAwh6Jp2qJyuKqrq+Hs7Iyqqio4Oelv3PDiDxdxKrPMpHPaPT9SGbZokEgR8sFhvWL5+dNh6O5qpzVO3bYqMTW3Ek98fc6Ed6EfN3sh1kwLRVyYdvH89EgmvjyVDQDo42mP7+YOVYuRMzUk83EW4+ziaPB5FCrrJQj/8BgAYMucRxAd7EVW4IROA1tNY4vVrsQVbHthOEatO4H7labLYlBkSBxOL8S/frvGaLX77m/ywh03exs8Gd4DMSHeOsvJw/1dWM3J3cEG/b2dUVbbhJyyOqMrPd+OCcKi6CC94vmvicEY4ueKxb+nIbu0DlP+m4C10wciOtgLIgGf0QockKcPLtp1BXOiApQ59z7OYsSGdDPqPgiErobVr8QBeTNjY0vgdfHKmN6I6OWitcEDU5iUk/svOcj4fKpvCMb8DFxsBVj3FDNLWsUbxa2SGvx4PhfZpXXK79kL+QaZcznbClDV0ILRQR7YMW846+MJBEvG1Ctxq93YVGVYgFu75gRc8u2ZO1obL7CBSTl57ropeHygJ8PzNSj/X18vS11UNbQwKnM/nF6IUetPYsaWC/hg33Vkl9bB1oYPz9ZMFUMEXHF9AKQ6k0AwgE4h4nwepcx0MBVts1cMgWk5eXgvD0bnU7XOVfSyBNpne7CZl6RFhnO3y/DZkZv47Egmzt0qg1RGa818aWyWorS2CZG9XcE38l9Ten4VEXICgSWdQsSBh+3CRALubsnFzgZ7XxvBWU46wKyc3E1HDraucYpsj25tKjl9nMV6bQIU84pYfQzPf3cRm07dxqZT2Xh+60UMWX0US/7Q3gIOAC7ceQAnsXHmYdWNLaTMnkBgSacRcUAuYhkfTsI/x/UxelUIAOumD8TgXq5Y91SY8Sdrw+2SGuSU1aJZ2n5DkmloyNtJjF8u3cOavzJQ2BpamRTqg7OLozGunyc2PjsIu+dH4uziaAR4MHsQ1Ta1N+GqbGhBJQPvlJEaiqLYQsrsCQR2WH12Slv4PArvTAzGm7H98OaeFPx1jb2dadsNSH0ViIawfN/DgpnpET0wa7gfzmeXoZe7HaYM7A4fZ7HOoh1FQ4k/U/Lx8+V7KKxqxBfPhUPA56GmsQWu9kKM69cNzq1GXi52Qo5mrp3YAd7o4WprVMs8UmZPILCj04m4Aj6PwqaZEXASX8OupHuMjnlppD9iNaQCKuLNr+5MZu1zogkeBTXzrj+S8/FHcr7y67T7VcrrabtWSU2jvCvRQG+0yGg0tkhRUtOE7i62cLUX4j/PhKuNHx3kqffBYCxejmJMi5N3tGcr5KTMnkAwjE4VTtHEvQcN+ge1cii9SGsutyLe7O2svlJ0EAlgp6FqURMKq9ivno/A9VUTceSt0XgvLhjBKp3heRSwJSEHf98sbedSqIpUBizcmYymZik+f2YQvpwZge4u2sv3+TwKUweZrgJStdXc0rgQZK2ZjOH+royOJWX2BILhdIo8cV0s/zMNOy7kMR6vmnutCU2VlwCUn3k4iAAaOJFZjD9TC9QySLTlictkNKobm7EvNR8rtDRK0IatgEL6h5P1ip9URmPU+pMmW4l/rcUCV9Iiw47EXOSW1wOgUVLdiCMZJWpjSDs2QmeGVGwayXtxIaxEXN/GmibnQADtPhsZ5IFlU0IYdZHn8Si42Akxd0QATmSWIO1+FWqbWtAs1f98bWihcf5WGUb3051brq9RgzHMG+mvVYCFAh7mje6t9tl3CXew5uANAMAT4d3xweMD4GZv+pg9gdAZ6fThFFshH7EhXozHezBM72OCQvCnhfdAVB93RqGC7S8NR8oHEzA8gHmmx+8p9/WOOZ7BvOkEW8YEMitOUvDy6N6YNyoAAPBnagEiPz6BN/ekIJth0wkCgfCQTi/iALBlzlCE92T2GiNpNqzqkGtsbZj/1aTkVer8vlRGY29qvs4xxvDi9kv44vgt7EvNR2J2OaOCnfen9MeqqQPg6SiCRCrDvtQCxPznNOb/eAlV9YZ7tBMIXQ2jRHzdunWgKApvvfWW8rPGxka8/vrrcHd3h4ODA5566ikUFxcbO0+jcWBYiLL1HHd9O41hAgsjqLsV9Vgbrz2WnpRTgYo6/XnePAr434zB+Onl4Vg0LhCLxvXBlIHeeo+T0cCG41l4c08qZmy5gFHrT+ot4acoCnNH+OPSshgcWDQKvT3sQQM4dqMEYz49heMZHf9vhkCwBgwW8UuXLuGbb75BWJh6Iczbb7+NAwcO4Ndff8Xp06dRUFCA6dOnGz1RY6liWDbPdJyp6enGrofnt2dyINHiZMi0gGZOlB/iBvqAR1EI6uYAGz4PB9PYh2GYeMSoMrCnM46+NQZPDu4BAY9CVUMLXt5+GceIkBMIejFIxGtra/H8889jy5YtcHV9mEZWVVWFrVu34j//+Q+io6MxZMgQbNu2DefPn8eFC6ZzGWRCWE9nTseZmmEBbqw2+2gAW89ma/we0wIaVzuR0uDqzT2p2HD8FuPrt50LoN8jRhWBgIcNz4bj6opYPD2kJwDg/369ivsPuOmlSiB0VgwS8ddffx1TpkxBTEyM2udXrlxBc3Oz2ufBwcHo1asXEhMTjZupkbw/ZQCn40wNn0dhzbRQVsesP5ylMazCxOHQxc4GG49ncZbBwsQjRhP2Iht8/ORADPOXO1N+d+YOJ/MhEDorrEV8z549SE5Oxtq1a9t9r6ioCEKhEC4uLmqfd+vWDUVFml/Lm5qaUF1drfbHFAgFPL3mWCIBD0IODbSMZWKoN+wZFhIp+OZMTjsh1+VwqPq1KQoGDPFCEQp4WDi2N24W1+CHxLvYnpjL/cQIhE4CK8W6d+8e3nzzTfz0008Qi7nxuFi7di2cnZ2Vf3x9fTk5b1uScir0dr9papHhwp1yk1zfEJJyKgzy6N6S0D4+PinUB189P7idw6G3sxhvxwQxMrgyhNwyw8Ih0f274d0JfQEAK/Zfx1enbhObWgJBA6yKfa5cuYKSkhJEREQoP5NKpThz5gw2bdqEI0eOQCKRoLKyUm01XlxcDG9vzVkOS5cuxTvvvKP8urq62iRCznRF+PKPlzBloA/sRAL4udlhdpR/h63ODXX0k9HAjsTcdkU2wT7OOPnuo7h6v0qtAOmvawVcTFcjG49noZ+3A+tqzMPphfjpwl0AAE0Dnxy5ie2JuVg5dQCp7CQQVGAl4uPHj0daWpraZy+++CKCg4OxePFi+Pr6wsbGBidOnMBTTz0FALh58yby8vIQFRWl8ZwikQgiEXcFNtpgurnX0CzDbypmVGsO3sArYwKwNM60TSc0YYyj392K9itgRUNj1epSqYxGWU2TwdfRBw1gyR9pcBTZILL1urqqWOslLdhy5o7GTdWi6ia8ujMZm7WU+BMIXRFWIu7o6IjQUPXNNnt7e7i7uys/nzdvHt555x24ubnByckJb7zxBqKiohAZGcndrA1AsbnHduOOxkNHPnML+bAANziKBahpbO/xrY/kuw/wyvbLGOrvirkjAiAU8NAgkeLj+AzkltfD390OQ3u5Yu2RmyZ1NgSAyvpmPL/1IlxabXFVQzdtfVMSskp1ZsXQkGe9xIZ4E7MsAgEcGGA9+uijCA8Px8aNGwHIi33effdd7N69G01NTZg4cSK++uorreGUtpjSLOZweiEW7kw26FgKwM01k80eWjlwtQBv7E4x6hwUgF7utrhbztzRUfVYAFgUHYic0hr8lcZt7rbi/IrV9eAPj+IBg/i8PqMyAsFSMLUBVqd3MWzL6gPXsfVcrkHHxvT3RHcXO7PHyudvv4RjbZz/zEXblfLUTQm4dp/7DCKxDQ8RvVxxIbscuref5Wx4ZhCejOjJ+TwIBK4h3e45JiaE2RuBJo7fKMX2xLtYffAG+r5/CJM2nuFwZtp5qoPEavmU/ji7OFot/rx/0WiEMfShYUNjswznGQo4oN4kmkDoynQ5Eeeyc0xmUY1OzxIukMpoLPkjTf9AE+DhKNIYd96/aDTSV05EbH8v9PN2xKBWUTdnhJppM2kCobPT6f3E28LnUfB0FKK0hpuV3JaEHLw7Idio0IqmRhMK8dx08pbJcrj1oSs7xkEswJa5Q5VfH04vxKoDGSbfJFXAtJk0gdDZ6XIiDgA9XGw5E3FtOdlM0SR+3k5izBjWC73cbPFtQseUnfuw7Hc5KdQHsSHeuHCnHK//lIxKExqJsZ0bgdCZ6ZIivmXOIxj60QkAQLC3I2L6d0N2aQ0OpRuWeaEpJ5sJh9MLNTZDLqpuxIbjWQadkyvY9LtUTV30c7PFrOG9sOlvzWZc5p4bgdDZ6ZIi7ukohljAQ2OLDMXVjfi/if0AyEV15f4MFFWzCwn01NGgWBtSGY1VBzJM4ldiLG/HBOktplGEgD6Kz0B6/sNslQQdx9iL+Khvkhp8z652Nlg7fSAp9CEQVOiSIg4AYiEfjS0ytXjzpFAfRAd3Q+Ta44yaKCgwRJRM2fPSGHycxVgUHaRzjKHx77omKexs+KhvlkJswwOfohh5w0wb1B3PDPVFZG9mLe4IhK5ElxXxpmZ5MltbAb5y9wErAQeA/Er2RTSG+qKYGl2hCqmMxqaTtwz2GQcAO6FcxJ8b2guDe7ngnV+u6jS2crWzwX+eDSfiTSBooUuKeINECjshDw2t/TT/SrmPxwbLc7ENEVc/NzvWxxjji2IqnMV8raGKw+mFWLHvOoqN8Fl5L64/HER89HCxxdh+XqBpGh/su66zm9La6QOJgBMIOuhyIq6p+nHRz1exL60QW+YMZS2uPAqYHeXPeh4KL5eiqkaLiYtXNUpRVd8MZzv1fqTG2BWo0s1JhGnhPZRfy2jgy5kRqG6Q4MO/bqjtRbStFCUQCJrpUiKuq3z9WEYJ5m+/hK9nPcJKXOePDjAoR1zRqOHVncmgYJqGDIbw0g9J+P21kcqvuSw2avuA5PMojAryAABMDPXB+ewy3KuoR4CHQzt3QwKBoJkuU7HZIJHq9R85llECSYtM2QWHCYN6uhg8p0mhPtg8KwLezpYTWilos1l5Ibvc6GIjCvpzu3++dA8fHbyBHRfyMCzADedvleGtPSl4ZftlfHs6W2sTaAKhq9NlVuIr96czHrf+6UF4K6Yvo1ztRbtScCvUx+BVo6JIRlGxmVtWh91JeSiqNp3Hty66t3mg/HQx16jzKX4qmjZMGyRSrDlwHedzytEipXHvQQPsbHjo81682rijGcX4+FAm5o/2xzIL6YFKIFgKXUbEj2YwK+Q5mlGM9QB6uTHL/ZYB+DujGONDDTfW4vMoNVvVRdFBSMqpwP2KOvzrd/P6pnz/wjDl/x9OL0S8gQVQChxEfAR42GFn4l2k5lXC1V6Iivom/HLpvkbL2fpm7SvuLQm54FFUhzToIBAslS4j4lIZs9dxxTg2Lnlv/ZqCtNDJBs1LE0pR7+OOIxlFOH6jlLNz68LP3Va5qakoRmKDgEdhRB83zBvZG9sv5OJEZilqmqS4ll8DADibbXz/Ui68agiEzkSX+U3wZOh65+kgQkreA3xzhnnZeE2TzGQx23mj+pjkvG3xc7fF6X9FK782pBhJKqNx5lY5lu1Lw4lM0zx4FF41BAJBTpcR8Uf8XRmNG+TrjANXC1HC0iDrexMZVZm6KMjPzRZXP5igJuCGXleRYXP/gWnnbKhXDYHQGekyIi4U8BmNsxfZ4M2YQNgLmY1XsO7ITczffsmQqemEad66ocl4c6L84SBuH1WzxGIkBfVN7HuOEgidlS4j4oN9ma3E+RQFZ1shrn84CV/NHMzqGscySvD05nPYm3wfW87cwSeHMvHWnhR8cjgT526X6Swv18awADdlg2FdqJ65t6cdbnw4CWIGcePVB29g1PqTOJxeqPb5g7omWGqa9m/J+e3mSyB0VbpMj83E7HLM2HJB7zg3extcWharTIdbc+A6vjOwJ2dbXOxssI6lC1/8tQK8viuFdTFQWE8nvPZooEar27Yoio0+fjIUsSHeuHK3gtFxHQUFwNtZjLOLo0lBEMHiIT02OWJYgBvc7IV6x1XUNSMpp0L59fuPD0BMfy9O5lBZ34yFO5MZryIPpxfiNQMEHACu3a/GqEBPxITon7vi/O/tTcfwj49jye/XLFbAAfl8C6sa1f6eCISuSpcRcT6PwhPh3RmNbbup993coZg/2p+zuaw6kKE3tGJIil9bZm5J1Ful2pZuTmJUNlhHzNlSnSAJBHPSZUQcAGIZdrp//890vLgtSS1tcNmUAbDXH5pmBJNVJBd+49dUmjUwpYeL5W5otsWSN18JBHPRpURc4Ryoj5rGFpy6WYoZWxLVPmdpM66Ts7dLsS81H4nZ5cpVuVRGIzG7HPtS83HutnkKfNoy2USugW52Nhjfz5OTczHxYiEQugpdpmITeOgcyNRW9crdSrz7Syo+eXoQ5/HXL089LCbycRbjsTAf/J6cz6pS1BQ8PcQX353N4dQiN6a/F76bOxSJ2eU4cdO4h5MuLxYCoSvSZbJTVPnieBar7jRCAc/qXPR83US4V8HeRMtRzMfMYb3w7ZkcTkT8v88MwtQIecMNqYzGqPUnjXpAiPg8DPJ1xhvRQRgR6EGEnGDxkOwUE+DvYc9oHNWqD9Ym4ABA0zx4OejPxmlLTaMU357JwStjAmDHsuBJFR9nMb6eFaEUcODhmxBgeHFSk1SGpNwHmP19EsJWHiH54oQuT5cUcaYbYk4i6/3xFFQ2YExfw2LQNIA/U/IhZljl2pYhvVxwdnG0xnx4bR7qjmL216qTSFmlbBIInZEuGU5RvNbryv5wtxeivIPj01xAUfJVrwHFogaTvnKixlJ+VaQyWumh7uUoRnxaIXZcuGvQ9XxI4Q/BgjG1pnWpjU0FfB4FoUD3LzzVSfSApuUr62F+Lki6W2ny64X1dNIr4EB7D/WMgiqDr6lI2VQ9H4HQVbDeeIER1Da24G55g84xZbXWvwpXxRwC3tvDDvsXjTbo2NlR/kZ5tZy7XWqQNw2BYO10SRF/++cURuMEPMM34LoaQj6FNU8MNPx4AQ/zRwcYfPymU9kajbwIhM5OlxTxvAe6V+EKWmTyUAQRcv1IpDSe33oRNY3MKqJUC5sUBU9L40KwYIzhQl5U1YhXyUYnoYvRJWPivVxtcbOohvF4Y1/S+RRwdcVElNQ0Ivrz00aezXKhaWDLmTtYFB2k1j5N0iLDjsRc3K2oh5+bHbycxPg4/obaxrKPsxgrHg/B0rgQuNuL8PGhTPbXh/yBu+pABmJDvMlGJ6FL0CVFfMOzgxG68gjr42x4FJoNiLtKaeDq/UqMbC1O4Tp2GxvsiWMmaofGlv+evI3/nryNFyL9sPKJUKyNz8CWhBy92TGKVfTmWRG4x/BNSROqDodko5PQFeiSIu4gFqC3px3ulLJr82WIgCtIzC7HyEAP9PGwR1ZJrd7xdkI+6iVSRue+cq8So4M8kHCrzOD5cc0PF+5i16U8SKTMfmaKUUwtEfRBHA4JXYUuGRMHgGNvPwqBAa/bkQHMOgS1Ry5TG2eEMxpdL5FiykBmrosVdc2wszG8utJUMBVwU0AcDgldhS4r4nwehU0s268BgJOtEF/NjGDUYEKVqN4eAIAQH2cMY9i0ecIAb8yN8mM09khGMav5dGb4FIjDIaHL0GVFHJCXgH89K4KRPa2C+qYWTAz1xqVlMdg9PxIbng2HiEEvy9sl1cosjJGBzMrhvRzFrFq5EeRIaev0uyEQDKFLlt23RSqjsTXhDuOMCEUmhUJgD6cXMo7ldnMUorZJijo98W5vJxHOLRkPAHotAgjtmR3ZC6uNyFsnELiCuBiaAT6PwrzRvWHP0LWvsKoRC3cmI/5aAYCHK3pvJ5HeY4trJHoFHABmDOsFPo9SOv9RIPnqbLh890FHT4FAMAtExFvh8yh8/swgVscs2p2CA1cfCvm5JeOVIRYHkXEbjcduPIxxa3P+I2jHUdQlE68IXRASTmnD4fRCrNyfgaJq5uGLBWMCsDQuRPn1uVtleH7rRaPnMqK3G+xEAtCg4SiywZPhPZB8rxJbEu4wTj/saBxFAtRJWtTyxHkUMHeEP7adyzXZdW98OAm2RvihEwhcQVwMzcykUB/Ehnhjw7EsbDp1m9Ex35zJQXJeJf4ZHYThvd3x65V7nMzl/B31lnB/phZwcl5zYWvDQ9qqie0qNmdH+WNHYq7JrhvgbkcEnNBlICKuAT6PwshAD8YiDgCXWrvNEOS42fKRvGISALm51QsjA5T+4YfSCvDD+RyTXXtKWHeTnZtAsDSIiGthWIAbfJzFJCvEQCoapJi//RK2zBmK+GsFWPZnOh7UMzPHMhZSbk/oSpCNTS2o9oMkqNPb3ZbRuGMZJVi9Px2v7Uoxm4C72tkgsjcRcULXgYi4DiaF+uCrmYM7TZcfrrijp6GGKlvPG9ZyzVDWTh9I3AsJXQoi4nqIC+uO/z7HvjyfwBwuJNfbSYS3Y4LQ1CJTVsYyxcIStAgEVpCYOAMeH9Qd6fmV+OaM6TbjujKPh3lj/7Ui1sctn9IfHo4i5JbVY3dSHjYcv6X8noutDV4cGYBF0YE6V+YtUhn2XLqHCSHd4OkoAkVeuwhWBlmJM2RpXAi+mjkYLrbkucc1BVVNBh3n4yyGSMDDxuNZ7fL6KxuaseF4FoasOYbD6YWgaVrjinv/1QK8/2c6hn18glVtAIFgKZBiH5ZIZTTe3J2Cv9JICzCueCK8u8E58CIBD00szK6eGdITlQ3NWDC2D67kVuDTozfRLKUxrq8nvnthKImnEziHeKdYGHwehU3PRyCil3NHT6XTMC28O2z4hoknGwEHgOzSWhzNKMZTm8/j40OZaG71PD+VVYqBK4+Q/pwEq4OIuIH8unAkbMhPz2hc7WzwcfxDMTUlC8f2ga1Q+19avUSKhaTRMsHKIDJkIHwehUXRQR09DauHBnCrtV2drQ0P3RzZNdtgQ5CnPc7drtA7bsW+dM77oBIIpoLs0hnBouggbDufi0ozFbJ0JnycxaAAFLRWxPo4i3Hq3bGwEfCV5fllNU1YffAGZ9dMvV8JJtJcXCMhjZYJVgNZiRsBn0dh3XTSeIANT0X4YPmU/jj9r3FKS4PRQR5IXDoeYqEAfB6FqD7umBbeAy+MDNDZdYkC4GJnozfPnAJaz8M87k4aLROsBSLiRqJoCOFiZ9PRU7EKfk8uxOqDNxC+6qhyVRzRy0XjWD6Pgp2WjQeFHK+bPhCbdfz8FeNWPB4Cf3c7xvMkjZYJ1gIRcQ6YFOqDK+/H4vVxfTp6KlZDffNDP/TYEG+NY+K+OIPssnqN3/N2FmPzrAhMCvVR/vzfjgmCi62N1nGzo/zBJIPQWcwnjZYJVgOJiXMEn0dhVKAnvjyV3dFTsSrc7G3Q36d97uzEjadxs6hW+XW4rzMWT+qPkppGeDmKMSzATS2nm8+j8GZMXyyKDlLG1NuOEwp4mD86QG/lbVWjFMcyikiTaoJVQEScQxT2tUVVjYw20AhARV0zHllzDJ88MRDRod7g8yjM2XpRTcD/91w4Hg/vweh8ipi6NpbGhUBGA1sSdAv5qgMZiA3xJsU/BIuHVThl8+bNCAsLg5OTE5ycnBAVFYVDhw4pv19UVITZs2fD29sb9vb2iIiIwO+//875pC2Vzm5fOzpQszhSbf7Llgf1zZi/Kxl93otH4HvxOHOrTPm9bS8+wljAmRId3E3vmMKqRiTl6E9HJBA6GlYi3rNnT6xbtw5XrlzB5cuXER0djWnTpuH69esAgDlz5uDmzZvYv38/0tLSMH36dDzzzDNISUkxyeQtEUVTY2MbJVsifb0c8PIof7jbq+dyezuL8dXMwdj58nA4iY277xaV/Oy5UX4Y10+/4LKFaebJsYwiSGU0ErPLsS81n7U7IoFgDoz2TnFzc8Onn36KefPmwcHBAZs3b8bs2bOV33d3d8f69evx8ssvMzqfpXunMOWTwzfw1d93OnoanHPxvfEorm5EbWMLSmub4OUoxoM6CVYfzOC0C9LZf49DTzfm2SRsSMwux4wtF/SOs+FTcLcXoqj6oUGXj7MYKx4PIfFyAmMs1jtFKpViz549qKurQ1RUFABgxIgR+Pnnn1FRUQGZTIY9e/agsbERjz76qNbzNDU1obq6Wu1PZ2BkH8+OnoJJ+OjAdfh72GNEoAemhfdAVYMEr+9K5ryN3b0HzBtPsGVYgBsjN8pmKa0m4ABQVNWIV0lpPsGCYC3iaWlpcHBwgEgkwsKFC7F3716EhMjjwL/88guam5vh7u4OkUiEBQsWYO/evQgMDNR6vrVr18LZ2Vn5x9fX1/C7sSAi+7h3ypDK/rQi2AvlAnjudhmW/5lukk1cUxbb8HkU+nZzNOhYxb2uOpBBQisEi4C1iPfr1w+pqam4ePEiXn31VcydOxcZGRkAgOXLl6OyshLHjx/H5cuX8c477+CZZ55BWlqa1vMtXboUVVVVyj/37t0z/G4sCD6PwidPhXX0NExC4HvxCF1xBM9/dxGltRKTXENTsQ2X8WljirNokI1PguVgdEw8JiYGffr0wb///W8EBgYiPT0dAwYMUPt+YGAgvv76a0bn6ywxcQUfHbyOLQm5HT0Nq8KWD6SvjlNL7zucXohVB9Tj7sbEp7ecuYOP4o3zZfniuXBM05A5k1dej/rmFgR7W/+/X4LxWGxMXIFMJkNTUxPq6+WVdTye+in5fD5kMnaez52JZVMGYP7ogI6eRocyzN+F1fhP/xHeTsBf3dk+7m5MfHruCH+jG2BreluoamjGc98mYuaWi7hZVGPcBQgEBrAS8aVLl+LMmTPIzc1FWloali5dir///hvPP/88goODERgYiAULFiApKQnZ2dn4/PPPcezYMTzxxBMmmr51sGxKCL6aGQGRoOsVjtgJ+Ui9X8V4vA2fwoWcCkhaZKiok6CyXoIV+65rjLsbE58WCnh4xcCHq8JQS1Np/rnbZSioaoRIwIMr8dMhmAFWFZslJSWYM2cOCgsL4ezsjLCwMBw5cgSxsbEAgPj4eCxZsgSPP/44amtrERgYiB9//BFxcXEmmbw1ERfmg/zKBqNf4a0NVzsb5Fcy36RsltLYeTEPOy/mMRqvGp9max07uJcrAHbNr1UNtTRVc1bUSRDV2x1Twnzg5URMtAimh/TYNCOSFhmClx9CV0lqoAD8vCASV+9VwdtZhD9TCnAptwLVjS1aj7ET8lEvkWr9vja0xae1IZXRGLX+JOvUSG8nEVZOHUDyxAmMMbWmEe8UM8LUgKmzQANIu1+F+WN6AwDiBnbHhTvl2HnhLs5klaJORaxt+BReHdsb70wIRm1jC47fKEZRVQOaZTQ+P5ql91psrWOTcioMym3//JlwjAz0YH0cgWAqiIibmaVx8pz6riLkvyffx7zRvTVml6jSIqXxv5PZCOnujEmhPnhisHxVLZXR2HUxT6fgaotP68LQPPSy2ib9gwgEM0L8xDuApXEhyFozGUN8nTt6KiYno7AG87df0phdooq2TUo+j0JoD92voKE9nFi7DRra9CG3rM6g4wgEU0FW4h2EUMBDSA9nXLnHPHPDWjmWUcJonGKT8kJ2Ofp3d4KjWACaBo7rOf5YRgkkLTIIBczXJIbaBu84fwd2QgHuPaiHn5sdZkf5s7ougcA1RMQ7EKll7SlbDKdvleDny/cQ0t0Jt4trGInsjsRczBvdm/E1FLbBr+5MBgUwFvKyeqlahtFH8Tcwf3SAMkxGIJgbIuIdCN/YapNOyret+wXVjc04n13O6Ji7FZrbuOlCYRusK1avDxn9cH+jrZBLZbTWLkMEAlcQEe9ApF24klUTFOTe5AO6O+H4jRL8fbOU8bG+robZ1k4K9UFsiDciPz5ulA/MloQcvDshWBlaMdQmgAg/gS1ExDsIqYzGb1fyO3oaFseKx0PQy80ex28wi6MrCDbQlRCQh1ZeHBmAT47cNPgcMvphSEdhE9A2RKOwCVA0bm7LtnN38J9jt1CjkkdP/MsJ+iA7Mh1EUk4FJFLzxsRtbXjYNvcR/DRvuN6MD3Pjo9KVPqS7E84vicbA7syFuayuySiHw5dZxNO1kVteB6mMxqoDGaxtAn5OysOqAzfUBBwg/uUE/ZCVeAdhSr9sTVAANjwbjnH95e3O/goajdrGFjyy5igaW0z3MNFXgWkn5GPLnEcQ2dtdLWzg4SBCWgFzA6nVB2+gou5hOITtClYo4GHBGOMKsQoqG/UWEWmyCZDKaGw8cUvreAqkcTNBO2Ql3kEYmqdsKF/ObP8K7yAWYONzg012TXd7G70l9PUSKXgU1U6cdiTmsrqWqoADcqFku4JdGheCBWMC0FYnme4/P9rPi/HDWXUcG+EnENpCRLyDUOQpm4uNx29qDDFMCvXB17MijGqSYCyahM+QbBNNsHU4XBoXgszVk7F8Sn/MifLD8in9cXP1ZCwYo9vxcMGYAMyO8sPxjCJG11F9iBsi/ASCAhJO6SBU85TNERnPKqlDyAeH8cVz4e1W5IoMjQvZ5Ui8U4aDaYXIKTNeRJkaWXnYi5CYXa6WkVHT0Gz09Q11OBQKeO1yzhXpg1sSctQMzHgUlHnia+MzcOCafhF3sbNRswlg+lZm7rc3gnVARLwDUeQpv/VzKhqbTZ9u2NQiw8KdyfhaQ3YEn0dhZJAHRgZ54P6DBk5EvIHhPb22KxlVKqLtbCtot8FnDFytYJfGheDdCcHYkZiLuxXqFZuSFhnjeHpLs/oDSl/1qCL1kq0/DKFrQMIpHcykUB98M3OIWa+pL8Tw1OCeZpwN1ARc/nULZDTg5Sjk5Pwe9iJOzgM8XKV/OC0U80b3VuaFs4nh1zZDLb6teCsDHvqVK9DnX04gEBG3AEb184SdkG+26+nbJBsR5GHW+WiDR1EI4yIV0gzaxzaG3/btQPFW5t1mn8RbJfWSQNAECadYAHwehdmRvcxqT6srxMDnUfjPM4OwcGey2eajiaLqJmx4djBOZBRh67lctVADjwLG9vXEKQZVnSXVpt8Q9HNjVzHq5SgGTdOgVFJfFHsTpGKTwAayErcApDIa+6+at5hD3yaZImulG0chDUMpqWnE+48PwM016hkjmasnYxTD5gxt0w9Nwewof8ZjbfnAh39dx+Lfr7X7Hp9HIaqPO6aF90BUH3ci4AS9EBG3AAztMmMoTJsoTAr1wfmlMYjt72WGWWlG8bDRFIu+/6CB0TncHHTHxIuqGhDywWGczmJX6q+KomsTE/gCPmoaW5CeX23w9QgEBUTELQBz5/8+N9SX8Vg+j2oXp9XHsrhgfDUzgu202qHrYXM4vRDbzucyOo+3jobFr/90BXH/PQtJiwwbjulvA6eLZVNCEBui/4FX2yRF/oMGLIruY9T1CASAiLhFYO783w3Hb2HU+pOMqxn93e0Zn5sCMCvSH3FhPnoLZPQxdZCPxnCCwp+ECboeBKdvluBgWhEq6iRokdFYNC7IqPkCwJY5Q7HpuXCIGPxmrf7rBmuPFwKhLUTELQBFnrA5o59sjJVmR/m3K0XXBg3g0U9P4XB6IZbGheDN8YEGz/GbMzka58cm/KQpNa+wsgFzvr+IRbtTlJ9tmjEYMSHdDJ6rKo+F98D3Lw3XOYaU0hO4goi4BaDIEzbnmoxu/cOkLJ1NvBcAimuasLD1AdHb08Goea7c335+TMNPL0T5If9BAz7Yl46tCXcgaZEXH41cfxJnssrUCop6uRvmR64Npg2VSSk9wVhIiqGFMCnUBy+N9Mf353LNet3CqkZsOnkLb8b01TrmVGYJTrD09waAN/ek4rs5jxgzPRRVty+bZ9qs+MfEu2oPxo/ib2DqIG+1snkbPoUnBvdAWE8Xo+bZFlJKTzAXRMQtiNgQb7OLOCCPkffzdmxXUHIltwIvb7+MB/WG+Zg0tcjw2dEb+gfq4ZdLeRji5wqhgAepjMbupDxGx7V9v5DRwJ+pD71NctdNMXpu2iCl9ARzQUTcghgW4AY3extU1Blv/sSWt35OxT9ul6OXqxhNUhq/XL6HvIoGOBhZuXn1PnNPcG3sTS3A3tQCPDesB6YN8kVRNbNQRUfCpBEzKaUncAGJiVsQfB6FNdNCO+Tajc0y7LhwFx8duonPjmYhr0Keg93L3Q4zhzFPSTQle5LyMXPLBU7O9cIIP07OowtFKb02C4OUvAcmnwOh80NE3MKIC+tudGoeV/T2sMNfb4zC44N6dPRUlHC1+WuuzL6UvAeo02DJS0OefbM2nlmqJIGgDSLiFsjSuBB8NTMCYpuO/evJLa9Hi0we5tFVMGONsPU6MQRJiwxbEnT74WxJyFFmzRAIhkBE3EKJC/PB9VWTsOOlYXgyvDsmhHTD88PNG9ZQdHDn8yisnBpikmvYC/lwEpnXMZFHsfM6MZQdibl6V/yKnzGBYChkY9OC4fMojO7ridF9PQHIKxV/unjPrHNQWKwqDLGW/JGGSgOzVTSh6P7zdkxfJNwqweW7lZydWxvzRwcofcBNCVN7Wq5a0RG6JmQlbkXweRTWTjfvxmdd08OCmEmhPrjyfiyWxfXn7PyKheqeS3l4g4Oyd13wKHkvTEWrNVPDNGRT38RdFyNC14OIuJUxY5gfhHzzpaUduV6kVjHJ51F4aVQApzYBihJ0gQlWxzZ8CjOH+irta80l4ABzu4LfkvMZ+9gQCG0hIm6FZH0UB7EZwgGA3HHvwp1ytc90tRNTENqdfbn9yRvFeMsIrxVNjOjtjo+fClNrpcaGN3Ynw3/JQfgvOYiAJQfx0cEM5JTWQibTvxkpFPAwO6oXo+t88GcaMcMiGAQRcSslc81kXFgyHm62pt8UPJ9d1u4zbe3EFPTxcsKNDydhdmQvDGTYYm3ruVz07eYEew5bw2UUVRuc/bFg+2UcUGnWQUOeTTLu89Po/d4hzPruot5zFDxg5o1SUttMzLAIBkHRNG1Rj//q6mo4OzujqqoKTk4c9FfsYoxYexwFVdxWNNoL+fj8mUEa+zxKZbRaO7EfzufgyPVi2PAppH4wAfYiAaQyGqPWn9Ragq6Kj7MYA7o74bgBXi3a4FHyzUxNoZSc0lok5VYg4VYZSmqasHhSMIb4uaKsthGPrDmh87z/eWYQpkfobio9ceMZ3CxiVrX6xXPhmBZuOTn5BG4wtaaR7JROhKRFxrmAA0CdRIpXdyZrbNiraCemYGAPZ1zKPYWKOgm2JNzBWzF9leEXJj07C6saOe9yJKOh7F+6NC4ENE0j8U45vv47G+dul0Oqso55avN5AEB3ZxEoCqBpYM/8SES23mNWcQ1yy+pQVN2IyaHeeq/dy9WWsYgTMyyCIZCVeCdBKqPx4rYknLnVPvTBBQrDprOLo/X6fRy4WoA3dqfAXsjHqX89qhSnDw9c7xCDL1X83e1QWtuEuqb2VZRtGdXHHV89HwEnO8P7jNY2tiB05RG945zFfFx6f4JZUh8J5sXUmkb+xXQCDqcXYuS6kyYTcIBdE4PHwnwwyNcFdRIp1sZnQiqjkZhdrtVDxJzklte3E/CXR/khd90UJL03HhNVGkNcuvsAi/aktD0FKxzEAoT11P+LW9UoxdjWZhoEAhvIStzKOZxeiFd3JputoQTTuO3Ve5V44qtzoGl0mDMjG9rmj+9PvY/dSffx8ugAjO9vfMefqZsScO2+7sbIivcbTWErgvVCVuIErSh6TXIh4G52NozGMY3bDvJ1weggDwCweAEHHnqYFFY14MmvzuGva0WYFenHiYADwP5Fo5G+ciJigj21/tIp/h6ZdFtqi+JtZ19qPhKzy0m6YheCbGxaMWx6TerDydYGoLQLLtsmBlIZzXhDzxKQ0cCo9SdRUvNwY3hwL1dOr+EgFmDe6D44nlmqdYxq2Ep1w1gXh9MLsepAhtq/BR9nMVY8HkJW9F0AshK3YoqqGjg7V255vd4VM5smBkk5FShm0LzBknoiqAr4I36ueHYo94ZjTHtqMh2nCKe1fZizaYRNsG7IStyKqaiTmOU6Xo4ivD+lP6tVHVMRorS1velALi2LgaejyCTnZhqO8nTQf31d4TQa8renVQcyEBvirfPh2zbXf1iAG+k4ZEUQEbdiXIxIfWOCnZCHeSN7463YvqAA3C2vg5+7PaNjmYqVlGExZTdHIUpqJCbX+77dHPDfE1l4Ly4EtibIptHXe1NBfFohRgR66DyXvnAak9AMCcVYPyScYsVU1pt2JV4vkeF/p27jk8M3QFFAVQPzDUqFWHGxnlswJgCrWtvWmXp9mFVcix0X8tD/g8OYv/2S8vMGiRQyDjYLdfnOUCr/3XkxD7su6m4IbWxohoRiOgdExK0YZ1tmGSXG8s2ZHBxKK0SAB7NVOMDMJIsJAh6FpXEhSq8WZ4ZZNFxwLKME8364iNd3JWPEuhO4wlFPTG2+M97OYnw9KwJvjJdb8i7fl47bJdo3h5m+7Wgapy8UAxiWJUMwP0TErZhkA0TF3V6It8az9+1e9mca7ITsom/6TLI0MWt4L8yJ8lN6cbvZPwwZxYZ4Qywwb8HQicwyHLxWiAf1zXhl+2U0aOiXaQiTQn1wdnE0ds+PxBfPhWP3/EicXRyNSaE+eGt8EKKDvSCV0Xhjl/ZiI31vOxTkoRFNGUVsQjEEy4aIuBXD3JPDRikUScti8Mb4INahjgf1Ldh08jbrOSrEatE4Zhaze1PyEehpj7wH8m43qlWeSTkVKKrm1leFKa52Ntj72khO4+QK35lp4T0Q1cdduZnI41EY4idPb7xRVIPE7HKtx+t729GWUcR1lgyh4yAibsVQDFX4QX0LHgvrrhQK1V9+Nmw4nmVQnJTPozBSzyadgjqJFB/szwBNy9MPV00doPxeRwkKBSDh3+PgzyKcxIa2hTpnskqx4ViW8vsnbhQr/5+mafx+5T6e2nwef98swaP9vDS+7Xg5irBkcrDWXHemoZjfr9zHudums3MgGA/JTrFiJoR4M+pJ2Syl22UoKEId7+1NZ5WqyCRlTRNMszJUeWmEP8b281J+3VEuf2P6esBBbJpY/OH0QizalYIWldhz26zLrWdzILLh4Y3oIHx75g7+0yrwL2yTb7z29rTHrEg/pOVXIqe0Hu4OQvx3xmB46EhTZPr3cT67HOG9XBk/hAnmh6zErZgXRgYwHvvzpbx2zREmhfrgwtLxsBcy/2dQWNXYrtMPEwxZ/e+5fF9tY22In6vJs1M08dII5j9nNiiyQ1rabB4qvtr47CD4OItBA/jyVDZCPjisFHBV7pTW4dMjN3E4vRg3i2twPrtc78+JSZaMu70QG58LxzuxfdneGsGMEBG3YoQCHh4LY5bL+2dqAYKXH8La+Ix25/j8mXBW133tJ/X0M6a+HYrVvwvDrJraphZM/+octibcgaRFhks5FR1SF1TZyL33CxPfm/WHb+KvN0Yh0MsBYhseFD/WsX09kfpBLF4Z0xuAfN8gyMsB/bo5wt/dDpMGeMNepP8lW1+WzJXlsXgsrLuht0gwE8TF0MqRymgMXHkE9SyyJjR1fP/ieBY2HL/F6tpfzYzArZIabDuXi0qVHHJ9xSIJWaWY/X0Sq2tRAHp72iG7tJ7VcVywe34kYx8TpiRml2PGlguMr03TNPam5KO4uglzovwYiTRTSMWmaSEuhgSd8HkU/vPMIFbHKBz7VHn10UDWoYrXdyVjw/FbagIO6C8W4THdkVWBBjpEwHkUlJkiXMI2O4SiKEyP6IlXH+3DqYAD2rNkCNYBEfFOwKRQH3w9KwI+DPOxZTSwIzFX7bMrdx+wDlVoG0+3/lm5/7rG0EpZHfct5EyFjJb/bLjGmEIdS+J4RjG2ns2BTGZYM2qC8RAR7yQo8rEnhDDzv76YU6EmsKZI3yuqbsKhtPar8WMZxRpGWy6afjY1jRLkPzDcRdKYQh1LgaZpXMqtwOq/MjBgxVEUVnLnqklgDhHxTgSfR2E4w1/6oxnFGLX+pDLkYaoV3z/3pODPlHzl15IWGeI1CLslc6u4Rrlh+6BOgqc2n8fkjQkYuf4k/JccxLjP/ob/koNY+kcamG4x6SvUoQEsmxxs0aENiqIg4Mvn19Asxcr91zt4Rl0TIuKdjNlR/ow9ulVj11waVqkio4F3fknFl6duo0EixY7EXBhrx2FuWdt0KhsztlzAqPUncTCtAMl5D+Cq4iAZ6OUAfw877E7KQ24587i9PluCf/6c2i6byNL418Rg5dvfqZulJKzSARAR72QIBTzMH80sr1kRu35vbxqkMpoTwypVvJ1EmB7RAzIa+PTITQz7+Dg+OXLT6PPSAFzsbLBl9iP44rlwLBrXx/jJMqCoqhHL/7yOYf5ueHJID8wd4Ydgbwc4iATILavHa4/2gb+7HatzTgr10ZomKqPl5mOWLuTLpvQHAEikMiTlcL9/QNANKxHfvHkzwsLC4OTkBCcnJ0RFReHQoUNqYxITExEdHQ17e3s4OTlhzJgxaGggsTJzsjQuBAvGBDBekVfUNSNy7QkAYG1YpYuVUwfg06cHYc0TobDhU6hpbEFTCzcrNVpGQ0rLMC28B0YGenJyTr3XbP1vXkU95kYFYNXUUBx+ayw2PBuOK+/H4K2YvqBYZt5IWmTYejZH5xhN2USWhJ+7vdJR84fzOaTHp5lhJeI9e/bEunXrcOXKFVy+fBnR0dGYNm0arl+Xx8ISExMxadIkTJgwAUlJSbh06RIWLVoEHo8s+M3N0rgQZK6ejCfCmRVrVNRJ8OrOZABQc9d7O6YvurXpcqPv4eBiZ4OvWzu283kUZkX64dziaCyfEoIQH27yZKsaW7BQJRRka2Oef2Pa3P3cHUQQCtjPgUl4SVM2kSVxOL0Qjc3yOoXD14uVoSfiR24ejC72cXNzw6effop58+YhMjISsbGxWL16tcHnI8U+3MK0qAR42Az57OJotQ21tsUgQ/xcMXPLBVxuk3rnYmeDF0cEYFF0oM4NubXxGfjmjO7VJ1Nc7Wxw+f1YHEzNxz9/uap3/LUPJuCRj45DwrSlkBa+eC4c08J7GHUOAPhgXzq2J97VO25OlB8+bG2MYUkorAM0iQgF+ZtdV+8QZLHFPlKpFHv27EFdXR2ioqJQUlKCixcvwsvLCyNGjEC3bt0wduxYnD17Vud5mpqaUF1drfaHwB1sNiy1rTLbFoMIBTzsfiUSsyP9sCyuv9Lm9sr7sXgzJkhvRgXbcI8uHtQ348KdckyN6Imwnrp/QWJDvOBkZ4OQ7vJx/5sxGLnrpiC2v5fO4zTBVTaPryuzGDrTceZEKqOxcv91nfUFpLGE6WEt4mlpaXBwcIBIJMLChQuxd+9ehISE4M6dOwCAlStXYv78+Th8+DAiIiIwfvx43LqlvZx77dq1cHZ2Vv7x9eW+w3hXxhDjqY8ZbKTZ8HlY/UQo5o/pjWnhPTDEzxU/nMvBB/vSlV4nulCEe5ZP6Y/ZkX4GCakChd/2/kWjEaPlPM62Nvh29iMAAFc7ecXjFyfk/y43PDuY8bW4zt8O7ubI6ThzIvd31164RRpLmAfW9bv9+vVDamoqqqqq8Ntvv2Hu3Lk4ffq0MrVowYIFePHFFwEAgwcPxokTJ/D9999j7dq1Gs+3dOlSvPPOO8qvq6uriZBzzEPb2TRU1Ok3c0rLr8ZHBzOwbAoz8V8bn4EtCTlqsd2P4m9g/uj2Hi2qCAU8zBstN3GSymiMWn+SlVXtQx4e8d3coWiQSPFxfAZyy+vh5ShEfFoxqhqasf9qAaaF90BZrdx6N6e0FonZ5XjA0IpX8eKgrdGCIVQ0MLs203HmhDSWsAxYi7hQKERgoLxLy5AhQ3Dp0iV88cUXWLJkCQAgJET9l7Z///7Iy9Pe8FUkEkEk0u57TOCGSaE+iA7uhiFrjqGmsUXv+O8ScvBObD+9nWy0xbcV6XEAdAq5AsUbw8LWzVU2RPVW97q2FfKx+omByq8DPG7hs6NZWBufiVvFNcqOSFIamLHlAuOwjrcJusBbc/m9Nc+9M2H0lr5MJkNTUxP8/f3RvXt33LypngeclZUFPz8/Yy9D4AChgId/DOnJaCwNYPDqozozDCQtMmxJ4C49LjbEGy4sGyG72NkgUo/D4Muje8PDQYii6kZsOpUNiVR9rc8kZLt8Sn9lD0wusebye2uee2eClYgvXboUZ86cQW5uLtLS0rB06VL8/fffeP7550FRFP71r3/hv//9L3777Tfcvn0by5cvR2ZmJubNm2eq+RNYEhvizXhsY7NMmcanCa7T45JyKlBZz867e3akn97Qxt83S5QhFEPxcBS1y9hh4qGuD2P6ZHY0TBpLWOrcOxOswiklJSWYM2cOCgsL4ezsjLCwMBw5cgSxsbEAgLfeeguNjY14++23UVFRgUGDBuHYsWPo08c8FXUE/QwLcIOjmI+aRub+4yv3X9fYku1uBbMSc6bj2MRO7Wx4qG+WYW9KPl4fFwixjeawj6L5grF4OYqVqZbHMorwZ2qBWls7fR7qulDsWaw6kKHWgV4s4GHjc+EWnaKnbe6mCD0RNEOaQnRB/krNx6I9qayO0dQYYWvCHaw+eEPvscvi+mN+axcaVdrmn5/KLMa3esIzgDy08cxQX0zYcAaFVY1YOLY3lkzur3Esmzx5TShy55dP6Y/VB2+oCVXbcYBxedGKn0d8WgH2XS3ExJBu+PQf7LziOwrSWEI7ptY00ii5C/JYeA/su1aAYxkljI/RtEqeHeWPj+Jv6A2pfJeQjbqmltZekjSienugqkGiUxS14eMsxgsjA8DnUXhvcn8s35eOr0/fgZeDCO6OonYCYkxmhEKCpg7yweu7UnRmzSi+98GfaQY1kgYe5uMPC3DDhBBv/JF8H69sv4yh/q6YOyLAoIpQc6GYO8H8kJV4F2bRT8n4i6EtrLYWZVxWX+pC00pXJpMhdOXRdq3p7EV8zB/VG2+MD0JSToXBK3EfZzGWTwnB6oMZrB42owI98MMLQyEwQHQPpxfi3V+uoq7NPVEAXojqhfuVjch70IBerrbY8OxgOIg7fh3WLJUhJa8SeRX1eJrhxnlXwmIrNgnWzxczBrfzRdGEt5NIa4YBl9WXCigKELQ5obezuF2o4mhGscbeonVNUmw8cQthK4/gQV0T445Hqmx8NhxnF0fD1V7I+m3h7O0yTPnfWdQ16U/lLK1pQnVjM2qbWnA4vRALdya3E3BAvtLflpiHYzdKcLOoBsdulCB05RFM3ZTAam6mILOwBs98k4i18fpDawTuISLeheHzKKyaNkDvuJVTB+gMDyyNC8G2uUM5mxdNozX0Agz1d8Xm5yPapfcx2bCsk0jx2q4UTB3EPkYd3d8LfB5lcDjmZnEN7pbXyf+/qAb3tGzuzvvxEsJWHsXTm89j8W/XWF/n2v1qPPbf00jMLsPru5JR08guu4cL+njZAwDK6yQor7We1nudhY5/FyN0KIr+nEv+SNOY3hfs7ahxo07SIsOOxFzcraiHn5sdSmu4/eUd0ccdiXfKcSn3ATILa1Bc3YjZUf7Kh0lSTgXjFfLWs7msri3gUXASy/PV2RSqUACEfKCpdSEd99+zEAl4aGqR4V8T++H1cYHtjnkvrj+e+/YCMlsLkAwhvaAWM7ZcBAD08bDHOxP6GXwuQ7ATCuDrZot7FQ24VVILdwdSvGdOiIgTMCnUB7Eh3rhwpxyJ2eWoqm9CZnEtrtx9gEXR7YVHU5k917wRHYTFk4KxfF86rt2vwsoDGdhz6R4G9nAGDSC3rI7xuVpYTtTN/mHXHkVBiz47AMV7Co/PB6QPwyEK//SSas0PnOEBbpg3KgDfn80xwG5And4e9pg22HhnRUPo6+WIexUN+N/JWwj2doSLSucjgmkhIk4AIA+tjAz0wMjAhyXsZTWNsBepV1CaeiNTkdKnyDDZ+9pI7ErKw6eHM5FZVGPUipUp80Y97IykKGh5dWcyKECr0NIAbHgUGlrj2fYiPhxEAjRIpNj43GBEB2s25qIoCk5igdEC7udmi5P/96iRZzGcsf08cSKzBOdul+PFHy5h9/xIrbn7hnIorRD7rhbgndi+6GuBhmAdBRFxglY8VEIJtU0t2HLmjskFHFCv8uPzKMyO9MPkUG/8mZIv9wGngR/O56KE4xCOgurGFkhltHIO2gpa2tLcuuK34VM4869xjMIKUhmNbedyjZ5zR4va7Eg/eDiIsPSPNKTkVeLtn1Px5cwI8Djc8d506jauF1Qj7X4Vzi2J5uy81g4RcQIj/v3rVcSnF5n0Grqq/DwcRHh59MOCoTF9PfGPrxPR0My88pQpX566jd1JeVgzLRRxrf0vFQZikWuP63SC5PMoXF85AUIbZr9aSTkVqGwwfjOSjZ2uKaAoCnEDfeBmL8ScrUk4lF6EI9eLMHkgs03ltnsss6P81fLiW1pkuFEo7zUwlWG3qq4CEXECIz6ePhAXcsoZWdkygQLw8ugARAd3M6jKL7SHM/a8Eol/fH2+naEVF1TUSfDarmTMzfXDqqnyjjpX7j7Qe/9SGY0reVWMC1+4sGkN6+lkEfniABDZ2x1zovzw3dkcnMgsYSTiTKyM49MLIaPlrQEXaqj+7cqQFEMCI1zshHj90fabnMbwXUIOqhokyo5BbKscB/m64L8zIjidU1t+PH8Xo9fJm0ibwj+bsZ2rg+aNwrCeTti/aDTj65kDxb5K6r1KvWMVeyxt954VVsbDPzqOF7Yl4f0/0wEAId2d4Ew2TdUgIk5gzOwof0Zt3pig+J01tn3XxAHdMLavvNt9oKcDXh3bG68/2gfOYu421e5VNiJs5RHY8Jn9urBJS1Rkv+jCxc4Gie/FIH3lRMT290I/b0fE9vdC+sqJFifgANDbU543nldRjxYdvUyZWBkX1zTh75ulqG71wI8N6cbdRDsJRMQJjBEKeHgsjLmVrT64aN9FURTWPBEKJ7EAt0trcaukFhRFoYqFSyMTqhtb8H+/pOqeC9j7ZzNpn7du+kDweRQcxAJsmTsUR94agy1zh1pMCKUtPs62cLcXQtIiw+/J97WOY2JlDAB2rY1JQrs74fWx3L4NdgaIiBNYEcPCj5wpxsaFfd3sEOAhX/0dv1GCTaduczGtdtQ3yyBq3Wzj0j9bUXDVdkXu4yzG11bYLV4o4GHhWLn99Fd/Z0OmQalPZRZj43HtvXdVeXpIT+Sum4K//jnaID+azo5lPsoJFospWm0Zcs7i6kb8mZKPJyN6IPnuA1y9X8X5vDQxoX83TBnk0y7d0NXeBmumhRosuIqCKyZ2rsl5D/D3zVK8E9vX4PswNS+O9MeLI/0haBOCulNai8f+d1aj5402/NzsuJ5ep4I81gisGBbgplbRaCyGtu/KLqnFd2dzMOyjE3jn51TO5qOP+PRCDOzhguVTQtR+DhV1zVh98IbOdnb6UNi56troLalpxOdHb+L7s6Z3jjQGAZ/XTsC/S8hG9OenlQLO5IWFR8n3YgjaISJOYAWfR2HNtFDOzmdo+65e7nZ4ojVfuL6ZWQ9PLpDSwJhPTuK1XclqnX0AoKiqEa/qaGfHBeW1Epy7XY46SYtVdZGf/tU5rDmYqfz6lTG9cWftFCwYE6DjKGD+aMv2UbcEyE+HwJq4MB+10nRDEAt4RsV7e7raYeHYPgjtbn7PeW1p6Vxl3OiiV2togaah3QPAwhiy+hiS8yqVX//08lC8FyfvxKTNyphHAQvGPMwTJ2iHNIUgGMzLPybh+I1Sg47NWjOZkxWWse3XTMXAHk4I93XBe3EhsBVyl+5YUSdBxOpjALj7GZqS4PcPobHVBEwk4OHcknHwcGi/B6KvYtOaIe3ZCBbLd3OH4aOD1/FdQi7rRSFXv6BMXQbNTVp+NdLyq7HjQh7GB3tg6wvDOTmvq52N0t62sKoBfu72nJzXFKw5cF0p4C62Nri8LBoCgWbJEQp4mDeaVGIaQud41BE6jGVTBuDmmsnK+DQT7G24M0VSzbO21La8JzLLMPbTk1q/L2mRYWvCHXywLx1bE+5A0qI9xk9RFPp4OgAArhdUcz5Xrnh683l812rsxaOA1BUTtAo4wTjIT5VgNEIBD88O7YU/UwsYja9rprE/OR9TI7jxvmbqMtiR3C1vwIcHruNfE4PxcXwGcsvr4e9uBxseDz+0KXpp6xvSlgg/F2QUViP57gPEMTSY4hJ9ne0X/3YVl+8+UH49N8rP7HPURlV9M0Q2PM5tcjsSIuIETlCENZiK6OK91zAlvLtBmSmaaJtnLeTz8OpPyZycmyu+P5eL71VsZxO01LoofEMAaBTywb6u2HkhDykMvEm4Jv5aAd7fl65mBOaj4j558U45fr4sr9KkALwVE4Q3Yywjn/2lHy7hZGYJ/m9CXyyKDuro6XAGEXECJyjCGgt3MhPOhmYZknIqtLr9XbxTju0X7kLE52Hho30Y+WUr8qwBYGvCHeaTt1C+TcjBWzH9IBTwkJRTgaLqRlTUNikzX9Lyq9DUIoVIYJ5VpbaGIIVVjVi4Mxk9XMTIr3z4EN8zPxLDGbo5moNx/TxxMrME57PLiYgTCJqYFOqD4G4OyCyuZTReU54zTdPYknAHH8c/zCnem5qPJ8J7YMGY3gj2Yba7f1dLY2JrgqaBwauPQmzD19j/VNIiw3cJd7BwbCCjSk9jiL9WqLchiKqAPx7mY1ECDkDZpKPFBNbFHQkRcQKnLJ3cH3N/uMRo7I7EuyipbsTcEQ8LOvam5CsF3M1eCGdbG+SU1WFvSj72puQDAPp2c8APLw5Fdxft5didpVS7sVmGRh3FTJ8eycKWhBw1kffR0VzDEKQyGu/vS2c0lgLw9awITLRAvxdB64OtWWa+4jBzQEScwCmj+noqU+D0cfnuA1y++wAfxWfC2VYAN3sRclobIA/zd8Ou+cMh4POQlFOOl364jNomuR1pVnEtxn12Gt/OHoKx/TT3rpwd5Y+P4m9w3sy5l5stZkf6Y1akH6I//9siUhvbrtIVlaObVYqp9G1G6iIpp6Jddao2Nj4XbpECDjysjapttbXtLBARJ3AKn0fhi+fCGcfGFVQ1tKCqQf7LRVHAmzFBSu+NYQHuuLYiFuezy3EovQi/Xr6PphYZXt5+GW9EB2FOlF+77upCAQ/zRgXo9atmS12TFC+NCmDcQLkjoCFfEa86kIHYEG8cyyhql7njKOZjSC9XjA7y1FtYY4omFx1Bea38QeRka4PE7HKThp/MCanYJHBOg0SK/h8cNujYF0b448nBPTDI10XrmKziGjy1+TxqWldUQgEPc6P8sGBsH3i0xj0PpxcyTjmkAHRzEqFOIlWeUxe750cqN1DZXKcjeDumLzYez9L5kOFR0JrSuC/lPt799RpaGLzSuNnb4NKyWIsVxB/O5WDlgQyIbXhqISquw09tMbWmEREncM7yP9Ow40KeQccuiwvG/DF99I6rbmzG3uR8/JiYizul8hCMo0iAoQFusLXh4WAas6bOCrnZPCsCl3IqsJVB5/lx/Tyx7cVhyq9VQxVudkKkF1TixI1SADQmhHhj5nA/hK48wmg+XOMsFqCKYfhA1askPb8Kb/+cilslzDapAeCrmYMRF2YZTYw1hY/mb7+Mk5klWo+ZN9IfMSHenK/MiYgTrI7ZWy8i4VaZQcdOCOmGb+c8wng8TdM4mFaITSdvI7OohvX1VFdhbHxYYkO8sGXOUMbXMcZnxpz0dLVFSXUTJCpt1VztbBA30Bu7Lt7TuqK3JLMqTW9H3k5i1EqaUcug45O3kwgrpw7gbGVOvFMIVoe/u53WQhZ9VNYz20BTQFEUHgvrjsmhPrh6vxL7Uwvww/lcvcctGtcHIwM91VZdbHxYjmWU4K/UAjzGwG5AKqNxvYDZA6aj4+v3HzQo/99OyMf/TeiHl0YF4HB6IQ6mFbXbRHUQCfDJU2GIC7OMzczD6YV4dWdyu59hUTXzcFdRdRMW7ky2mq5KxDuFwDnvGbEiS8p9gPhr7P24+TwKEb1cMbiXC6PxQd0c2zVeUGxWMhXRxb+nMrKcTcqpYBQzfzsmCN5tWrS52NnAxc5G43hbgeZXfsWni8bpD0u1xVkswLNDe+LEu2OR8eEkpYC/ujNZY656bVMLeBaiIlIZjVUHMjh7CL65h9nfb0dDVuIEzrEV8hEb4oVjGdrjj7p4fVcyvoQ8vso2NY5pdoS2cZNCfeDjJEJhdZPec9Q10zqrThUwze7w97DH2cXR7e4XgFrFppu9EN7OthjSyxl9l7ePtXu3hohiQ7zxY2Iualg0ja5qbMHPl+7j9yv56OftiO4utkjMLtcqjKpZMB21oVnf1ILTWaXYfTGP0w3mphYZzt4q1ZrGaikQESeYhC1zhmL+9ksGCTkN4LVdKVhwvxL7rxaq/WLqyyRgEhJxFPMRriP7hc3a605pLfp2c4CbvRAUpVnE2DxYVK0DVNH2oHCzF6KiToJh/q54PtKv3YNuSC9X/J3FfH+CR8m9W1pkNK4XVOt1SqQhL7tn8jAzlp8u3MWG41kor5OATwE2fHk9gikXy+sOZRIRJ3RdtswZitM3SzB3G7MKzrZoKvPWVMiiCpP87ZpGKQasOKw1ra6PpwOKGKzEAWDZn+lY9mc6fJzF8HIUgaIo0ABkMhpSGQ0ZLf8vn0fpfDXnUcCDOmbXVCW0hxPOZJXhTlk9poW3d4UcHeTJWMQVm5OFlQ24XVKLZpkMB64WYG+KfnfKlDzTifix60VYtDtFrYCshQZazFB5ebukVvn3Z6kQESeYlMqG9nFUY2hbyKLpl4uJNa0up8BXRvfGuexyVvMqrGo06lVeRgOv70rBZh7FajPtyfCeOJNVhrLaJtRLWmAnVP+Vnh3lj9UHb+g9z8sj/ZU/Bx8XW/i42AIAbG0EjET8s6NZKKxqwti+nhjSyxW2Qj5K65pQ19gCe6EAvu4PbRCq6iXYdj4XNE3j0X5eGNzLtd35Em+X4dD1IvyZko9qlRRJGz6FYf5usBcJ4OdmiyBvJ3R3FmOInxuEAh5GrT+p9S2MgnyPQSTgMX5IN8uYhcw6EiLiBJOiKL7hEiav8JNCfTC2rxdCVhyGriTaLQk5eHdCsFrFIhvrAAVvjg/EwB4uyq/5PAo8HiUPT8iAF7Yl6Q3T0GAfX348zAfv/JIKGsCvl+9j7gh/te+X1up/sMwb5Y/3Hxug8XtMM3ZkNLDjwl3suHBX4/edbW1Q09gMmlZ/O/rixG3Y8CnYiwSoaWjW2r+UTwGLJwXjlbG6N2u1vYUpfpprpw9EbIg3zt4qZfyGaOkNqS1kX5nQaTFhvFLfL9eui3d1CjjQKj6JuWqfKawD2PBj4l2MC/ZCTEg3xIR0w7hgL4zt64nRQZ64XVLD+MegeDgxRSDgwac1o+XgtfYr5g/3ZwBAu0bEqrz+qHZbVl2dk6jWPx8/EYpH/Fwh5GuXk6qGZshUBJxHPWzR1yylUVmvWcCFAh5eGumP7LVT9Ao48PAtrG2Wj7ezWBmC4/MojO3nhSF+LnrPB1i2lQBAVuIEE1NmQJyXKfp+uXLK6xidJ7usfVXipFAffD0rAiv2XUdxjf57qKxvxqaTt/FmTHtBzC1nZ4tb8KAeAPPX95GBHvj1yn1cy69q973k1sYRI/q44/sXhimbEfdwEeOTI1mQymi8t/cavp6tvcBKW3jKW2WTeWakvHtPg0SK2yU1qG+Wor+3IxxEAhy4Vogj14vQz9sRfTwc0NvTHn29HCEQ8HC7uAbx6UUoqmrAg/pm+DiLEdLdCVG9PdDD1Zbxz6DtfFUbhGjLavplwQiEfHBY6xsX1XqPigwhS4WIOMGkmGoVYyfkKzcPtYUemG5F7U3Ox5ggz3axaIUYbDh2E5tOZes9z7bzOVgUHahhPuxeR9797RqySmoYV0A+HtYdv165j8ZmGT7+6zrqW2SgAPT3cUJFrfwBpPCEUW1GfOFOBU7dLMWxG/oziJgKo62Qj4E9XdQ+mxbeQ+OmKwAEdnPEPxk0/GCLtiyftmO0mbUp7mrF4yEWvakJkHAKwcQMC3CDkM/9L0G9RIrnt17EqPUncThdc3HQYN/2G2aaaGiWYeHOZI3n4fMojAz0ZHSeyvpmjaGQ8DaixoRvzuRgbXyG2mdSGY3E7HLsS81HYna5MttlTL+H8/v2bC52XsjDjgt5eG9vujJEcfV+FYKXH1Kes6VFhiutfTCZapRCGKeF92hXKGWtTAjx1hgGUg2/WDpkJU4wKXwehcje7jhjoJeKPnSlHCoyLJiy5I80jZuKwwLc4GJrwyjTRlOcvrurYQ0qvjnzcNNVkx+IImc+Je+BjrM8RDUj5x9DfJVZH0smBRs0v85Cc6tPzNNDemJ0kIfV2dMSESeYnG9mP2KwNa0+FIGKhTuT8XRED4iFfAS422N2lD/r5s2V9c24kF2OkUEeap/zeRReHOmPDcf1G8JoCh8Na3VWbNDRoUcbP57Pha+brWY/kNbellpqjLSiyMhRWLJ+fy4Xwd5OAAWU1TZZnYgZQ1ltk/Ln+lZMEHoa+MDtSIiLIcEsGFq9aQyR/m4QCfk4ncXcPXByaDdsntV+k08qozFkzTGN/iEKnER8DAtwQ2OLDAEe9vi/CcH47co93K2oR2reA1zL1139qInY/l5IL6jm3K/86YgeOHy9CLVNmkvyTe2xbSncKKzG5C8S4G4vxJXlsSa5BrGiJXQapn95Fsn32mdQWBoK9zpJi0yZzeHnZoeCqgZsPZtr1rmM7OPOuvCIC1R91juzkJ/JKsWc75Pg526H0/8aZ5JrECtaQqfh11dHIvSDQ2hosah1Qzv+uTsFvm6ZuFNWrzfP3NTYizrmV5RJZWxnIK01LbPIQjszMYFkpxDMBp9HYcNzgzt6GnqRSGlkl3a8gAsFPBzNKO6w66tWxnZWmprl4SQe240FC4KIOMGsKIpovJ0suwrOEtDRu9isFFc36B9kpSgKfSzFE90QSDiFYHZUC0eOZRTh+3O5Hd7RxpJwFgvQ1NKCegn3Ln0e9jYoq2NnSvZHcj4q6pqRWVSNkYEeeCyse6cJrzS2ijjfilfiRMQJHYKicCSqjzuGBbhZdMd4czA1zAf7WzsaMW1sbAhldc1Kz3CmnLlVpszz/+XyfZy7XYYPp4VCbMM30SzNR3Vr7r+NDt8XS4eIOKHD0VTS/aBOgtUHu46w7zegJZ2hMBFwxbp0VmQvlNZIUN3YjLT8KtQ0tuCXy/dxr6IBu+YP19oIw1oQtFYTW/NbIBFxgkWgyetiYmhbYW/Ca7tSOmiGXQsBD/jfTPX0Qpqm8cvle/hg33Uk3inHketFVp9+aNv6NtEilSExu5xxG0BLgog4wWLRJOxf8yjGzoIEw2mWAWP7qrcloygKzw7thfsPGvC/k7fx+dEsTBzgbdWrcYfWFM6axhbM2HJB+bk1FTuRYh+C1dG2ebKbrRBx/zujNHuyEwD1pgsrdxnG9vXAjy8Nb/d5VX0zhqw5hhYZjWH+bujuIkZ/H0d4OYrh7WyrXMUqiqVyyutAQW5I5uNia1Gr3A/3X8f353Pbfc5lsROp2CQQDKBBIsVHBzNw+mYJ7lV2jbi6Kfhag4itjc/Q2P9UgY+zGKE9nHDiRonG+LulrHKlMhoj1h5HcY1E6xgfZzHOLo426qFjak2z3i1ZAkEHtkI+1jw5EAlLxmP+aP+Ono7VsupAhlqDZ30CDsgLhI5laBZwxfdf1WL9a06Scip0Cjggn2vcFwloaZGhpLoRMjM0Z2YLEXFCp2fZlAFYMCaAcZMIwkNUKzYlLTJsSdAt4ExR9BOVssl15BimvTNvFtcg8P1DGPbxCexNyTfxrNhDNjYJXYKlcSF4d0Iw4r44g9ulzNq2EeQUVTciMbscP1/KY5Vfro/Cqka8/OMleDqK4GInRJCXA/r7OKGft6Myb/tSbgVyy+oQ7O2EAd2dwDMgrFHd2AwHoaDdsWy7Tg3o7oSnhviyvr6pITFxQpciMbtcLQuBoB83extUsKzyNAZ7IR+De7nC180Wu5PuKT/v7izGhAHeGOTrjEf7esHVXqh2XINEipOZJbhVUoOTN4pB8XjILatDVYO8d+eUgT4Y2NMZvdzskHCrDL9fuY+7Fbr7n/o4i7F7fiTO3i7DuGBP9HBh7zduURubmzdvxubNm5GbmwsAGDBgAD744ANMnjxZbRxN04iLi8Phw4exd+9ePPHEE4wnREScYEqkMhqj1p/sMkVEls4zj/jCz90OJdWNyCquRUZhNao0dFByEAlQ2/Qw5UjeNs8DkQFuGBHogT+S72P/1QKdfu+60Gb7oGljly0WZUXbs2dPrFu3DkFBQaBpGj/++COmTZuGlJQUDBgwQDlu48aNVp07Sui88HkUVjweorFTDuEhpvayUXSSXzt9oFrmh0xGI6OwGuezy/DF8Vuok0jx9awIPNrPC6cyS3AxpwIX7pQjs6gGZ7JKcSarFDhyU3l8T1dbjOjjjmapDBNCvBHgaQ8fJ1uculmCL07cQk6ZPJRmw6fg7STGa48GwtXeRqPtw5ggjw7PoGGC0eEUNzc3fPrpp5g3bx4AIDU1FY899hguX74MHx8fshInWCSaelYSHqJo3WYqKOjPwa5ubEZZTRN6ezq0+96d0lr8evkejt8owa2SWjzi54oFY/sgOtjLoHRA1dqDP1PycepmKRaM6Y2lcf1Zn6vdfVjSSlwVqVSKX3/9FXV1dYiKigIA1NfXY+bMmfjyyy/h7e3N6DxNTU1oanpYfVddzb6FFYHAFlW/lqPXi7BNQ8FHV8YYAecqT9xJbAMnsY3G7/X2dMDiyf2xeHJ/lNU2wd1eaNTbv6I6uEUqw08X8gDI01StAdYinpaWhqioKDQ2NsLBwQF79+5FSEgIAODtt9/GiBEjMG3aNMbnW7t2LVatWsV2GgSC0ag6KQoFlN78Z0J7errY4hF/1w6t2PRwEHF2rk2nbiMptwI8Cojp342z85oS1uEUiUSCvLw8VFVV4bfffsN3332H06dP4/bt23j33XeRkpICBwf56w9FUXrDKZpW4r6+viScQjA78dcK8M4vV5Ue0wT9hHZ3xNLJIYjs424xpfSGUlEnwdCPjkMqo7H+qYF4dmgvTs5rUdkpmoiJiUGfPn1ga2uL//73v+CptMiQSqXg8XgYPXo0/v77b0bnIzFxQkcildF4c08KDl4rJBufLHCxs8G66QOtYiNQG3nl9Rjz6SkAQPLyWLi1SWE0FIsvu5fJZGhqasKSJUtw7do1pKamKv8AwIYNG7Bt2zZjL0MgmAU+j8KmmRG4uWYylk/pj7F9PeAo1h51pABE9naDO0e/8NZKZX0zFlpAKb0x9HK3U7YNTL33oINnwxxWMfGlS5di8uTJ6NWrF2pqarBr1y78/fffOHLkCLy9vTVuZvbq1QsBAQGcTZhAMAdCAQ/zRvfGvNG91TIX3OyEyCyqxr0HDfBzs8PsKH8IW5thTvj8b2R18WrQpX+koaFZBm8ndU/uts6TluRkqIqsNTAh5FvHpibAUsRLSkowZ84cFBYWwtnZGWFhYThy5AhiY2NNNT8CocNp62s+uq+nxnF+HvZdXsQf1Dfj7Z9TAQBudkKseSIUPB7apXOydTJUbJLerahv9/DkisZmKUpafeoHdLeeUC4puycQOGLLmWx8FJ/Z0dOwCpj4dStW71sSsnHqZilUlYpHAfNHB2BpXAhnc6JpGhGrj+FBfTP+eG0EInq5cnJei80TJxAI6syK9CcizhAaciFfdSADsSHyMCybHqsyGsqUUK6EnKIovDQyAE0tMrjYas5Pt0SIiBMIHJF6r7Kjp2BV0JA7GW46eRt7LuUZVD27JSEH704INiq0ohqvf8TfzWLj9dogIk4gcARTf2qCOhuOZxl8rIwGvjmRgTcmhhp0vCb7BTd7G6yZFoq4sO4Gz8uckKYQBAJHsPWnJnDD56fuwn/JQcz+jp3F8OH0Qry6M7ndG0BFXTNe25WCtfEZXE7TZBARJxA4YliAG3ycxaSDUAeRcLsc/ksOovfSgzieUaRzrFRGY9WBDJ0FXd+cyUH8NcvPeyfZKQQChyhWdxb1S2UkCtvYz54ehLK6JnxxPAt3ynQ3UzAnPADajBKcxQLY2gggkcog4AGNLTI0S2WgaTCyV3C3FyJpWQxplEwgdBUmhfpg86wI+DhbZ2ilrVQpvl7xeAhGBnlgWngPnPy/cfB3tzXqOj7OYrwdE2TUOQBgwZgA3Fk3BbnrpmBCf692369qbEFRTSMq6iUoqZWgurEFDc0yxv445XUSZY9RS4VsbBIIHKNqc1tU3YiS6gZcL6hBQWU9errY4amInngkwA2DVx81qWc3E3q4iBEd7IX34kJwOquk3SafUMCDt7MY1wuqMSHEW9mncvljA3DgagH+TC1gdb3oYE/MH90HwwLcAAB7Lt1DUVUj6zcXTXni384dCgCorm3CE5vP4045N28Llr5hTcIpBEIHcTi9EAt3JnfoHCgAN9dMVqboNTZL8fpPyfg7q1StEz2PAlZNC8XsSD8AQLNUhmMZxUjJe4AtCcwsfD0chAjp7gRJiww/vDAUYqFAGX4C9HcSchTzMaSXK0YHeRpdsSmV0Rj60TFGvUN3z49Uq9hli8W7GHINEXFCV+JweiHe3JOKJg7sbxdP6ot9KQXILK5lddzyKf0xb3RvNEikeOvnFBy5XgwA8HOzA59HYUAPZ/g4izF3hD96uLQPo6yNz8CWhBy1BhA8Cgju5oSMomoI+Ty0yGRq3/dwEOH8kmgIBTyNaX4+zmIsn9IfrvYik/mtxF8rwGu7UnSO8XEW4+ziaIuOiRMRJxA6GKmMxrPfnMflu5VGnWfmcF98/GQYnvvmPC7kMHfh6+Npj20vDkVpjQRPbT4PAFg3fSCeHerLuFuOJm+TB/USDP/4BAAg/s3RyCuvx7nsMuxIvAsAGNPXA9tfGg6g4wyy1sZnaG0GwqSFHBOIiBMIVgwbcWqQSLHqQDr2XLpv0LWi+3ng+xeHQ9IiQ9/3D7E6lkcBI/q4o6qhGc8N64Xnh/sZNAdVaJpGwNJ4eDgIcfL/HlW2Wnv751TsTckHAAzu5YK9r400+lrGEH+tEO/vS0dFnUT5GVuDLl0QEScQrBRtYQJ94jB1UwKu3Tes1+yCMfLNvkW7kvGXATnOIgGFxCUxcHPgxh/9P8eyMG9kAJztHnqRyGQyTN+cqLQp+GVBJIYFGB5z5gJTvgkQEScQrBBt+eJM3PsA44X835P6I+SDw4xi7R89GYovT91GZX0z6iVSCAU8vD+lP2YN76XWqYtrVu6/jqeH9ERoD+d237MW/3EmEBEnEKwMqYzGqPUntRo6KYpn9G2YVdRKELHmGOvr8yggc/VkHM8o0rtx52pnA5GAh6LqpnbfGxPkge3zhrO+vrEY+gbDBpqmGcf7jYUU+xAIVkZSToVORz6Fe5++IhI3ByEWjGHfFUtGA6//dAU/X9YfW39Q36xRwAHgzK0y7EjMZX19Y9DmZ1JU1YhXOWz/djKzBK//lIxdF/M4OV9HQkScQOAYpsUhTMYtjQvBgjEBrP1Yjt0owemsUpZHtWfl/uuQcJD+yARdfiaKz1YdyFDLXzeUPZfu4WBaIfamGLaJbEkQEScQOIapmyHTcUvjQnBzzWQ8HdETNnzzxoWlNND3/UN4ujX10JRw9QbDhAAPewDgrHtPR0JEnEDgGH1uhhTkMV5F6TkThAIePntmEK6tmNghLolX71ea/BpM32C+S8g2+lr/HB+EOVF+WDI52OhzdTRExAkEjuHzKKx4XO7poctQypBsC1shH68YECc3Bh4FfPaPQSa/DtM3kxOZpUZ7fTuIBPhwWqjZNjdNCRFxAsEEKNwMvdu4GXo7i42uAlTEyc2RccfnUdj72ghMC++h/Ewqo5GYXY59qflIzC7nJEYNsPNj35KQwypW3yCR4pfL93D1XiUsLCHPaEiKIYFgQkyZ7yxpkeGx/51BVnEdJ+fTBAXgz9dHYJCvPHZs6vQ/NqZgCs8XJpzOKsXc75Pg7STGhffGGzNF1pAUQwLBiuHzKET1cce08B6I6uPOacGKUMBDiE/7Qhlj8XEWY/6oAAh4FGgAy/amAzBP+l90cDf08bRjNPZiDvO3gPT8KgDAUBb7ENYCEXECwYp5KqInZ+eyF/Hx1vhA0DSNLWdz0NIqkOkF1fjiWCaW/5nOafpfU4sUP57Pxa+X76GpRYq18RkIXn4I2aXMfMCPZpRg1PqTeh8eUhmNP5LlqYSDfV0Yz89aIOEUAsGKkcpo9F0WD6mF/BYz9d5ulsowbdM5ZBTKrQWcxAJUN7awvh4TG4Oq+mZsOJ6Fo9eLcOTtMXAU22gcZypIOIVAIGiFz6PwxOAe+geaCaZpgjZ8Hj55OgwvjwqAl6PIIAEHmL0FONvZYOXUAUhYHG12ATcHRMQJBCtn7fSwjp6CEqZpggAQ2sMZ7z8WgjlRxtneMi0CslYDLX0QEScQrByhgGeQxwqXGFLApKCkRrN3C1uyiqux5cwd3C6p4eR81gIRcQKhE7A0LgSBHsyyOoyF6wImPzdu5r1ifwY+ir+BhTuTUcrRg8EaICJOIHQSnhnayyzXaVvkaGwB0+wof6OsBCgAbvY2sOFTGNzLBY/29URxtWV3qOcSQUdPgEAgcIOnE/N4tDEo9g/njfRHTIi30QVMQgEPj4V548C1IoPP8fGTA/FoPy+IbfgGn8NaIStxAqGT4G0mEQfkq9/49CLOKlA3PhcBe6FhAvzKmABMCvXpkgIOEBEnEDoNwwLczGZVq8gIOX+7jJPz8XkU1j1lWJbNN2dyOGsWYY0QEScQOgl8HoXHOGpfxpQ53ycZ7SioILek1uBjV+6/zqpaVNXE69ytMpy7Xca5oZe5IDFxAqETMSrIA3uvFpjtejTkK2FAniFjDFvOGu4TXlTdhAvZ5eDxKL1mY5pMvFThup+nqSEiTiB0Iiobmjvkut+eycGoQE9U1EuUAgpAq4OjTEYjr6Iel3IrkJRTgQf1zahuMq4N3Ou7ktXuv60Yl1Q34n8nb2HHBd19NRWGXsZaBpsLIuIEQifCzUHUIdelAcz+Pkn5tYudvLy9sv6hqLrZ2yCspwtqG1tws6gGNU2Gldpro+0DTCHGX84MR1JuJX48n6vRwKstNOQbt6sOZCA2xNviKz2JiBMInQhzZqjoQlW8FVTUNePvmw+bNwsFPAzo7oSo3u7o6WqHH8/fwU0OvdEVgv3G7quQsvT5Uy3lZ2Lo1ZEQEScQOhGGlL2bGxdbG+yaPxxB3Rxhw3+YWzF1UHeErjzC+fUUAu7raot7DxpYHcvU0KsjIdkpBEIngs+jEN3Po6OnoZPKhmZUNbSoCTgAOIgFCOtpGvvpIX4u+ORp9n1C2Rh6dRRExAmETsa8UX06egp60bbC3b9oNMQC5rL0f7F9mY2bEMyqh6cxhl7mhog4gdDJiOzjDicx95FSLuuIdK1wnx7CrFuRrQ0Pr4zto1OYVcWYz6Ow4vEQ5efaMNbQy9wQEScQOhl8HoVPnubeY7xt9yBbGx487W1YmVcxWeEum8Is33z9k2EQCnhahVmTGE8K9cHmWRHwdtb+EDHW0MvckI1NAqETMinUB9MHd8cfKdwV/gh4FFpkNCgAsyN74cMnBiqbJ1OA3vQ9pitcWyEfsSFeOJZRonVMWE8nTI2QdzRSCHPbAh5vLUU7k0J9EBvircxh97AXARRQVtuks0jIUiE9NgmETsoH+9KxPfGuUedg0sNSUwWkq50NaKinGrKthJy//ZJGIY/p74Xv5g5t97lURmstLupITK1pZCVOIHRSuGi2oG01q0rblS2Tik0mbJkzFA0SKT6Oz0BueT383e3wXlwIbLW4HfJ5lMXndJsCshInEDopkhYZgpcfgqF+TjteGoYRgR4WsZq1Zki3ewKBYBBCAQ/zRxvWe3PBmACM7utJBNwKIOEUAqETo3AW/PZMDiPfEEAu4MY6EhLMBwmnEAhdAEmLDD+cy8Gh9EJkl9bChk9hYHdnyADcKKqBSMDDjGG9MH90HwhZFNsQ9GNqTSMiTiAQCCaExMQJBAKBoBUi4gQCgWDFEBEnEAgEK4aIOIFAIFgxRMQJBALBiiEiTiAQCFYMEXECgUCwYoiIEwgEghVDRJxAIBCsGIvzTlEUkFZXV3fwTAgEAsF4FFpmquJ4ixPxmpoaAICvr28Hz4RAIBC4o6amBs7Ozpyf1+K8U2QyGQoKCuDo6AiKMt4Gs7q6Gr6+vrh3716n9WIh92j9dPb7Azr/PWq7P5qmUVNTg+7du4PH4z6CbXErcR6Ph549mXW7ZoOTk1On/IejCrlH66ez3x/Q+e9R0/2ZYgWugGxsEggEghVDRJxAIBCsmE4v4iKRCCtWrIBIJOroqZgMco/WT2e/P6Dz32NH3Z/FbWwSCAQCgTmdfiVOIBAInRki4gQCgWDFEBEnEAgEK4aIOIFAIFgxnUrEP/roI4wYMQJ2dnZwcXFp9/2rV69ixowZ8PX1ha2tLfr3748vvvhC6/nOnTsHgUCA8PBw002aBVzc3x9//IHY2Fh4enrCyckJUVFROHLkiJnuQD9c/R3+/fffiIiIgEgkQmBgIH744QfTT54B+u4PAP75z39iyJAhEIlEWv/tHTlyBJGRkXB0dISnpyeeeuop5ObmmmzebODqHmmaxmeffYa+fftCJBKhR48e+Oijj0w3cRZwdY8Kbt++DUdHR63n0kWnEnGJRIJ//OMfePXVVzV+/8qVK/Dy8sLOnTtx/fp1LFu2DEuXLsWmTZvaja2srMScOXMwfvx4U0+bMVzc35kzZxAbG4v4+HhcuXIF48aNw+OPP46UlBRz3YZOuLjHnJwcTJkyBePGjUNqaireeustvPzyyxbxsNJ3fwpeeuklPPvssxq/l5OTg2nTpiE6Ohqpqak4cuQIysrKMH36dFNMmTVc3CMAvPnmm/juu+/w2WefITMzE/v378ewYcO4nq5BcHWPANDc3IwZM2Zg9OjRhk2G7oRs27aNdnZ2ZjT2tddeo8eNG9fu82effZZ+//336RUrVtCDBg3idoJGwsX9qRISEkKvWrWKg5lxhzH3+O9//5seMGCA2phnn32WnjhxIpdTNAom96ft396vv/5KCwQCWiqVKj/bv38/TVEULZFIOJ6p4RhzjxkZGbRAIKAzMzNNMzmOMOYeFfz73/+mZ82axerfvCqdaiVuCFVVVXBzc1P7bNu2bbhz5w5WrFjRQbPiDk33p4pMJkNNTY3OMZZO23tMTExETEyM2piJEyciMTHR3FMzCUOGDAGPx8O2bdsglUpRVVWFHTt2ICYmBjY2Nh09PU44cOAAevfujb/++gsBAQHw9/fHyy+/jIqKio6eGqecPHkSv/76K7788kuDz2FxBljm5Pz58/j5559x8OBB5We3bt3CkiVLkJCQAIHAun88mu6vLZ999hlqa2vxzDPPmHFm3KHpHouKitCtWze1cd26dUN1dTUaGhpga2tr7mlySkBAAI4ePYpnnnkGCxYsgFQqRVRUFOLj4zt6apxx584d3L17F7/++iu2b98OqVSKt99+G08//TROnjzZ0dPjhPLycrzwwgvYuXOnUYZgFr8SX7JkCSiK0vknMzOT9XnT09Mxbdo0rFixAhMmTAAASKVSzJw5E6tWrULfvn25vhWNmPP+2rJr1y6sWrUKv/zyC7y8vIy9Fa105D2aA1PdnzaKioowf/58zJ07F5cuXcLp06chFArx9NNPm6zxgLnvUSaToampCdu3b8fo0aPx6KOPYuvWrTh16hRu3rzJ2XVUMfc9zp8/HzNnzsSYMWOMOo/FLzXfffddvPDCCzrH9O7dm9U5MzIyMH78eLzyyit4//33lZ/X1NTg8uXLSElJwaJFiwDI/zHRNA2BQICjR48iOjqa9T3owpz3p8qePXvw8ssv49dff20XeuAac9+jt7c3iouL1T4rLi6Gk5OTSVbhprg/XXz55ZdwdnbGJ598ovxs586d8PX1xcWLFxEZGcnZtRSY+x59fHwgEAjUFlP9+/cHAOTl5aFfv36cXUuBue/x5MmT2L9/Pz777DMA8mwcmUwGgUCAb7/9Fi+99BKj81i8iHt6esLT05Oz812/fh3R0dGYO3duu3QlJycnpKWlqX321Vdf4eTJk/jtt98QEBDA2TwUmPP+FOzevRsvvfQS9uzZgylTpnB2bW2Y+x41hRaOHTuGqKgozuagCtf3p4/6+vp2zQX4fD4A+aLDFJj7HkeOHImWlhZkZ2ejT58+AICsrCwAgJ+fn0muae57TExMhFQqVX69b98+rF+/HufPn0ePHj0Yn8fiRZwNeXl5qKioQF5eHqRSKVJTUwEAgYGBcHBwQHp6OqKjozFx4kS88847KCoqAiD/BfD09ASPx0NoaKjaOb28vCAWi9t93hEYe3+APIQyd+5cfPHFFxg+fLhyjK2trUmN65nCxT0uXLgQmzZtwr///W+89NJLOHnyJH755RedewPmQt/9AfKc4draWhQVFaGhoUE5JiQkBEKhEFOmTMGGDRvw4YcfYsaMGaipqcF7770HPz8/DB48uIPu7CFc3GNMTAwiIiLw0ksvYePGjZDJZHj99dcRGxtrtlCnLri4R8WbhYLLly9r1CC9sM5nsWDmzp1LA2j359SpUzRNy1N9NH3fz89P6zktKcWQi/sbO3asxjFz587tkHtqC1d/h6dOnaLDw8NpoVBI9+7dm962bZvZ70UT+u6PprX/HeXk5CjH7N69mx48eDBtb29Pe3p60lOnTqVv3Lhh/hvSAFf3mJ+fT0+fPp12cHCgu3XrRr/wwgt0eXm5+W9IA1zdoyqGphgSK1oCgUCwYiw+O4VAIBAI2iEiTiAQCFYMEXECgUCwYoiIEwgEghVDRJxAIBCsGCLiBAKBYMUQEScQCAQrhog4gUAgWDFExAkEAsGKISJOIBAIVgwRcQKBQLBiiIgTCASCFfP/+r7bIh7vzUoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sb1_geo.plot()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167e85ce-39cf-4b61-9391-0eb47640580a",
+   "id": "32d51a96-370e-4d14-aa2e-bf3bd69e3383",
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in url_list:\n",
-    "    df = to_snakecase(gpd.read_file(i))[\n",
-    "        [\"object_id\", \"projectid\", \"projecttitle\", \"geometry\", \"programcodes\"]\n",
-    "    ]\n",
-    "    full_gdf = pd.concat([full_gdf, df], axis=0)"
+    "# Fill in NA..turn this into a func\n",
+    "sb1_geo = sb1_geo.fillna(sb1_geo.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e24f8f8-64df-4743-ae7f-47b51c4105c1",
-   "metadata": {
-    "tags": []
-   },
+   "id": "7412b06d-e243-497a-8402-01c34f598f5e",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "full_gdf.shape"
+    "# Subset to join back to the 9,000 projects above\n",
+    "# subset = ['objectid', 'agencyids', 'projecttitle','programcodes', 'projectid','geometry']"
    ]
   },
   {
@@ -599,11 +636,141 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2b42344-6b49-4b26-83f4-f70f02a46c32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sb1_geo2 = sb1_geo[subset]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12bf83bd-dd26-42e0-b339-0738fa2c5365",
+   "metadata": {},
+   "source": [
+    "#### Step 3: Figure out why the rows differ between `sb1_all_projects` and `sb1_geo2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "237a5df4-60b9-4b73-858e-0468dad85d15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_project_names_id(df, project_name_col:str, project_id_col: str):\n",
+    "    df[project_name_col] = (df[project_name_col].str.lower().str.strip().str.split(\"20\").str[0])\n",
+    "    \n",
+    "    df[project_id_col] = df[project_id_col].str.replace(\"'\", \"\").str.lower().str.strip()\n",
+    "    \n",
+    "    # Get rid of | in object cols\n",
+    "    # https://stackoverflow.com/questions/68152902/extracting-only-object-type-columns-in-a-separate-list-from-a-data-frame-in-pand\n",
+    "    for i in df.select_dtypes(include=['object']).columns.to_list():\n",
+    "        df[i] = df[i].str.replace(\"|\", \"\")\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05b55d0d-dea9-4951-bbb2-569277934a01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_all_projects.shape, sb1_geo.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78804134-baa0-405e-91b2-4f27da5b53cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Objectid: no cleaning for either of dfs\n",
+    "# This is a int64 dtype...yet zero merges\n",
+    "pd.merge(\n",
+    "    sb1_all_projects,\n",
+    "    sb1_geo,\n",
+    "    how=\"outer\",\n",
+    "    on=[\"objectid\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80cdc34b-7646-4c0d-8086-5e43b1b13c9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_all_projects = clean_project_names_id(sb1_all_projects, 'projectid', 'projecttitle')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f511481-9d2f-4f8d-9a68-ed21efd96d25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_geo2 = clean_project_names_id(sb1_geo, 'projectid','projecttitle')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1163bba-8831-41d4-9238-dac16c5bc144",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.merge(\n",
+    "    sb1_all_projects,\n",
+    "    sb1_geo2,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"projectid\"],\n",
+    "    right_on = [\"projectid\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f839c3db-9bff-4653-9be0-537aa1cfa5d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.merge(\n",
+    "    sb1_all_projects,\n",
+    "    sb1_geo2,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"projecttitle\", \"ct_districts\", \"agencyid\", \"fiscalyear\"],\n",
+    "    right_on=[\"projecttitle\", \"ct_districts\", \"agencyids\", \"fiscalyears\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "69f2f3b4-c1d0-4d4b-87c5-d2158e115dcc",
    "metadata": {},
    "source": [
     "### Merge 9 Sample Non SHOPP with Geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2258812c-fed6-4b48-84f7-10367a9b8839",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in [\"project_name\", \"ea\", \"ppno\"]:\n",
+    "    nonshopp[i] = nonshopp[i].str.lower()"
    ]
   },
   {
@@ -639,34 +806,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f603d690-cc3d-490e-93e5-760297de703a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nine_projects_ea = [\n",
-    "    \"33560\",\n",
-    "    \"N/A (PID)\",\n",
-    "    \"0F633\",\n",
-    "    \"4W850 \",\n",
-    "    \"0C734\",\n",
-    "    \"23536\",\n",
-    "    \"37510K\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56021431-34cf-4433-af4b-daf4888bc0a7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nine_projects_ea = [x.lower() for x in nine_projects_ea]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "8b7deddf-30b5-4071-8a9c-2bd91c9cdc25",
    "metadata": {},
    "outputs": [],
@@ -688,74 +827,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2258812c-fed6-4b48-84f7-10367a9b8839",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# .str.split(\"20\").str[0]\n",
-    "for i in [\"project_name\", \"ea\", \"ppno\"]:\n",
-    "    nonshopp[i] = nonshopp[i].str.lower()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1166af6b-cbcc-45b7-81a8-3f4dfde5a0a7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "(nonshopp[nonshopp.project_name.isin(nine_projects_names)].reset_index(drop=True))[\n",
-    "    [\"project_name\"]\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c6b3ec7b-d8d1-452e-9323-12861951f41b",
-   "metadata": {},
-   "source": [
-    "* Missing SM 101 Woodside Road Interchange and Port Access Project\n",
-    " and SR-14 Widening Project"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "86fcc2e9-e7d2-413e-bf0f-a133f9e1d628",
    "metadata": {},
    "outputs": [],
    "source": [
-    "(nonshopp[nonshopp.ct_project_id.isin(nine_projects_id)].reset_index(drop=True))[\n",
-    "    [\"project_name\"]\n",
-    "]"
+    "nine_sample_projects = (nonshopp[nonshopp.ct_project_id.isin(nine_projects_id)].reset_index(drop=True))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76e719a2-21fa-4b8f-bce4-100d612e3484",
+   "id": "7fbba442-b295-4a9b-b94d-68dc41c0131f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subset sb1_geo to only districts these 9 projects are located in\n",
+    "sb1_geo3 = sb1_geo2[sb1_geo2[\"ct_districts\"].str.contains(('05|07|04|08'))].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02d7a5b9-36fd-463d-8bb8-710335d9c752",
    "metadata": {
     "scrolled": true,
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# Lower case and clean project names\n",
-    "for i in [sb1_2, df]:\n",
-    "    i[\"project_name\"] = i[\"project_name\"].str.lower().str.strip().str.split(\"20\").str[0]"
+    "sb1_geo3.explore()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b4deeadc-c568-466e-9325-b8e491f5e51f",
+   "cell_type": "markdown",
+   "id": "8e56b218-b6c8-4bec-bc97-300e1ebd1229",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# 67 without accounting for districts\n",
-    "pd.merge(df, sb1_2, how=\"outer\", on=[\"project_name\"], indicator=True)[\n",
-    "    [\"_merge\"]\n",
-    "].value_counts()"
+    "### Merge all other Projects"
    ]
   },
   {
@@ -767,85 +875,13 @@
    "source": [
     "# 62 matches\n",
     "pd.merge(\n",
-    "    df,\n",
-    "    sb1_2,\n",
+    "    nonshopp,\n",
+    "    sb1_all_projects,\n",
     "    how=\"outer\",\n",
-    "    left_on=[\"project_name\", \"district\"],\n",
-    "    right_on=[\"project_name\", \"caltrans_districts\"],\n",
+    "    left_on=[\"project_name\"],\n",
+    "    right_on=[\"projecttitle\"],\n",
     "    indicator=True,\n",
     ")[[\"_merge\"]].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fbdc6b9d-9f9b-41cc-965b-6602a7ceb15f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "project_title_m = pd.merge(\n",
-    "    df,\n",
-    "    sb1_2,\n",
-    "    how=\"left\",\n",
-    "    left_on=[\"project_name\", \"district\"],\n",
-    "    right_on=[\"project_name\", \"caltrans_districts\"],\n",
-    "    indicator=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3366c8f6-0ddf-4b57-8f01-0a7d9101d8d2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "preview = [\n",
-    "    \"project_name\",\n",
-    "    \"district\",\n",
-    "    \"caltrans_districts\",\n",
-    "    \"counties\",\n",
-    "    \"full_county_name\",\n",
-    "    \"project_description_x\",\n",
-    "    \"project_description_y\",\n",
-    "    \"previous_caltrans_nominations\",\n",
-    "    \"sb1_program\",\n",
-    "    \"total_project_cost__$1,000\",\n",
-    "    \"total_cost\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e3e4e316-b22f-4278-8c41-6bd048104212",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# project_title_m.loc[project_title_m._merge == 'both'][preview]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3522a920-706f-4475-9b23-0f2759eef3ba",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "project_title_m.sb1_program.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40591042-e292-424c-9a08-cc0fc7148ae1",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "sb1_csv = project_title_m.project_name.unique().tolist()"
    ]
   },
   {
@@ -929,106 +965,6 @@
     "pd.merge(tircp_shopp, tircp_sb, how=\"outer\", on=[\"project_name\"], indicator=True)[\n",
     "    [\"_merge\"]\n",
     "].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ddd3fc5f-e17f-45a4-96d1-9151ff066edf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import urllib.parse\n",
-    "\n",
-    "import requests"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a7e8656d-12dc-4ab1-9996-b7ac5dcc8ce4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "url = r\"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/query\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37e6f914-1cc7-4515-bb23-930331fe0955",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# params = {\n",
-    "#    'geometry': '-118.21637221791077, 34.094916196179504',\n",
-    "#    'geometryType': 'esriGeometryPoint',\n",
-    "#    'returnGeometry': 'true',\n",
-    "#    'f': 'pjson'\n",
-    "# }"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bacfe953-b85b-4cf0-b07c-6a918817e8df",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# url_final = url + urllib.parse.urlencode(params)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9b118605-a8bf-477c-b070-3ad76211ce8d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# response = requests.get(url=url_final)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5286b27a-87be-4c90-a4ac-7bca4d018790",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# data = response.text"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "933b3718-e5ab-4da8-b671-cace2f32b1a4",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# test = gpd.read_file(data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b1090ff-25b8-48cb-a70d-cb0fdfd0ab86",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer?f=json"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5e0ce5fb-389d-4a9c-acb2-183ceaf72a72",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer/tilemap/0/0/0/8/8?f=json"
    ]
   }
  ],

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -10,19 +10,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "22b768e0-0316-4684-a4b2-683dcd82a323",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import _utils\n",
     "import geopandas as gpd\n",
@@ -33,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c375e3ed-515c-4762-a8aa-2c448a5433f9",
    "metadata": {},
    "outputs": [],
@@ -44,6 +35,18 @@
     "\n",
     "fs = get_fs()\n",
     "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.options.display.max_columns = 200\n",
+    "pd.set_option(\"display.max_rows\", None)\n",
+    "pd.set_option(\"display.max_colwidth\", None)"
    ]
   },
   {
@@ -58,18 +61,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "6b483a64-786d-4d9c-96e8-0bfe429ffd2a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Read in 10 Year non SHOPP with ATP and TIRCP\n",
-    "nonshopp = to_snakecase(pd.read_excel(f\"{_utils.GCS_FILE_PATH}cleaned_data_atp_tircp.xlsx\"))"
+    "nonshopp = to_snakecase(\n",
+    "    pd.read_excel(f\"{_utils.GCS_FILE_PATH}cleaned_data_atp_tircp.xlsx\")\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "aa0c6362-1f89-4112-a55f-6928841266ce",
    "metadata": {},
    "outputs": [],
@@ -77,6 +82,8 @@
     "# Subset to join.\n",
     "non_shopp_subset = [\n",
     "    \"ppno\",\n",
+    "    \"ct_project_id\",\n",
+    "    \"ea\",\n",
     "    \"project_name\",\n",
     "    \"lead_agency\",\n",
     "    \"previous_caltrans_nominations\",\n",
@@ -96,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "a63dc3e3-2485-4331-b370-c6fdf2c57952",
    "metadata": {},
    "outputs": [],
@@ -106,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "06967d23-860f-4d11-a4ed-18675a5070e6",
    "metadata": {},
    "outputs": [],
@@ -115,295 +122,86 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 64,
-   "id": "2258812c-fed6-4b48-84f7-10367a9b8839",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nonshopp.project_name = nonshopp.project_name.str.lower().str.strip().str.split(\"20\").str[0]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "5ba81d8f-2aaa-4138-be99-ed6687892a8a",
    "metadata": {},
    "source": [
     "### Sb1 Geo\n",
-    "* Not every dataset has project names..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "c7bbc54d-4a75-4b6d-8ed8-a44ec2685cd9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pd.options.display.max_columns = 200\n",
-    "pd.set_option(\"display.max_rows\", None)\n",
-    "pd.set_option(\"display.max_colwidth\", None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "9f4ed958-a976-4c2b-8def-63a575f74d21",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_sb1_files():\n",
+    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer\n",
     "\n",
-    "    sb1_gcs_path = f\"{_utils.GCS_FILE_PATH}SB1_geojsons\"\n",
-    "\n",
-    "    # Create a list of all the files in my folder\n",
-    "    files = fs.ls(sb1_gcs_path)\n",
-    "\n",
-    "    # Lower case\n",
-    "    files = [i for i in files if \".geojson\" in i]\n",
-    "\n",
-    "    # For now, delete out any Pt geometries\n",
-    "    # So the df isn't extremely large\n",
-    "    # files= [ x for x in files if \"Pt\" not in x ]\n",
-    "    # files= [ x for x in files if \"pt\" not in x ]\n",
-    "\n",
-    "    # String to add to read the files\n",
-    "    my_string = \"gs://\"\n",
-    "    files = [my_string + i for i in files]\n",
-    "\n",
-    "    return files"
+    "#### Step 1: Read in all projects\n",
+    "* Compare with CSV.\n",
+    "* Clean it up."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "f2d48c49-7b67-472f-a3a5-d4f6e11e3352",
+   "execution_count": null,
+   "id": "57760f7c-453e-4d1e-9055-911fdc5dd74b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sb1_files = get_sb1_files()"
+    "sb1_all_projects_url = \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/22/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "40027b1a-07ec-45d1-be50-386900e1f72d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "22"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(sb1_files)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "2e049563-3660-4bcf-8dcf-9ca5f55fb9af",
+   "execution_count": null,
+   "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with get_fs().open(\"gs://calitp-analytics-data/data-analyses/project_prioritization/SB1_geojsons/SB1_RCA_Projects_032022_Transit_and_Intercity_Rail_Capital_Program.geojson\") as f:\n",
-    "    tircp = to_snakecase(gpd.read_file(f))"
+    "# Read in SB1 csv\n",
+    "# sb1_csv = to_snakecase(pd.read_csv(f\"{_utils.GCS_FILE_PATH}RebuildingCA_map_Data.csv\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "0956687a-ec80-4b83-951d-54cd4af8864f",
+   "execution_count": null,
+   "id": "98ad0ce0-1ec1-4686-b088-51f1d5d4ea72",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with get_fs().open(sb1_files[0]) as f:\n",
-    "    atp = to_snakecase(gpd.read_file(f))"
+    "sb1_all_projects = to_snakecase(gpd.read_file(sb1_all_projects_url))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "affd5c72-1f1a-4048-b93e-9dc47764e63a",
+   "execution_count": null,
+   "id": "1c2e3f9f-55fc-4d4d-a6a4-931da4a68d84",
    "metadata": {},
    "outputs": [],
    "source": [
-    "full_gdf = pd.DataFrame()"
+    "# Same rows, different columns.\n",
+    "# sb1_all_projects.shape, sb1_csv.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "b16b7b3d-abbb-4f44-81c2-e50868f9a305",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "for i in sb1_files:\n",
-    "    with get_fs().open(i) as f:\n",
-    "        df = to_snakecase(gpd.read_file(f))\n",
-    "    full_gdf = pd.concat([full_gdf, df], axis=0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "474ab647-776f-4341-80f0-46d8cd874b0f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "|SHOPP|    2741\n",
-       "|HM|       1163\n",
-       "|LSR|       509\n",
-       "|ATP|       321\n",
-       "|SHOPA|     165\n",
-       "|SGR|       161\n",
-       "|STIP|      126\n",
-       "|TIRCP|      96\n",
-       "|LPP-F|      68\n",
-       "|TCEP|       63\n",
-       "|LPP-C|      57\n",
-       "|STA|        49\n",
-       "|SCCP|       40\n",
-       "|FM|         12\n",
-       "|SRA|        11\n",
-       "Name: programcodes, dtype: int64"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "full_gdf.programcodes.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "9fcb5510-3b08-4ffc-b5db-ff584c49f407",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(5582, 38)"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "full_gdf.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "948200e3-eb60-4f0b-8d4d-bf0a65caf65d",
+   "execution_count": null,
+   "id": "24de4776-90e4-4862-9224-fe1fedf4ef60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "full_gdf[\"project_title2\"] = (\n",
-    "    full_gdf[\"programcodes\"]\n",
-    "    + \" \"\n",
-    "    + full_gdf[\"agencies\"]\n",
-    "    + \" \"\n",
-    "    + full_gdf[\"countynames\"]\n",
-    "    + \" \"\n",
-    "    + full_gdf[\"fiscalyears\"]\n",
-    "    + \" \"\n",
-    "    + full_gdf[\"totalcost\"].astype(str)\n",
-    ")"
+    "# Project ID matches\n",
+    "# csv_projectid = set(sb1_csv.project_id.unique().tolist())\n",
+    "# geojson_projectid = set(sb1_all_projects.projectid.unique().tolist())\n",
+    "# csv_projectid - geojson_projectid"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "114d0f9e-00bc-43e9-9698-55918bcb4cb2",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "full_gdf.projecttitle = full_gdf.projecttitle.fillna(full_gdf.project_title2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "9b7b1538-2ad7-4a82-9519-d581d616153e",
+   "execution_count": null,
+   "id": "3961c1b6-eb36-44ba-8a78-aca089cd2035",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Drop duplicates...since opened all ln/pt file?\n",
-    "full_gdf2 = (\n",
-    "    full_gdf.drop_duplicates(\n",
-    "        subset=[\n",
-    "            \"agencies\",\n",
-    "            \"programcodes\",\n",
-    "            \"sb1funds\",\n",
-    "            \"projectid\",\n",
-    "            \"projecttitle\",\n",
-    "            \"totalcost\",\n",
-    "        ]\n",
-    "    )\n",
-    ").reset_index(drop=True)"
+    "# set(sb1_all_projects.columns).difference(set(sb1_csv.columns))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "8e96fc92-c2ed-455a-bef6-c3889e4e3bb3",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "|SHOPP|    2741\n",
-       "|HM|        913\n",
-       "|LSR|       509\n",
-       "|ATP|       321\n",
-       "|SHOPA|     164\n",
-       "|SGR|       161\n",
-       "|STIP|      126\n",
-       "|TIRCP|      96\n",
-       "|LPP-F|      68\n",
-       "|TCEP|       60\n",
-       "|LPP-C|      57\n",
-       "|STA|        49\n",
-       "|SCCP|       40\n",
-       "|FM|         12\n",
-       "|SRA|        11\n",
-       "Name: programcodes, dtype: int64"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "full_gdf2.programcodes.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "1b5ae135-7dd9-43f3-a063-36c415b4de5d",
    "metadata": {},
    "outputs": [],
@@ -435,58 +233,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "09b254a3-ae7d-4de3-8238-afaa0d35c6e9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Fill in NA\n",
-    "full_gdf2 = full_gdf2.fillna(\n",
-    "    full_gdf.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"})\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "ad31dbbc-592b-4082-b64d-bd5f411ad553",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_gdf2 = full_gdf2[subset]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "0257f8fa-b724-48c3-a171-57a403ad754b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "((5328, 21), 1565)"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "full_gdf2.shape, full_gdf2.projecttitle.nunique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "98b60f3e-8875-4cc2-807a-98266ac56bbb",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Align funding\n",
-    "full_gdf2 = _utils.align_funding_numbers(\n",
-    "    full_gdf2,\n",
+    "sb1_all_projects = _utils.align_funding_numbers(\n",
+    "    sb1_all_projects,\n",
     "    [\n",
     "        \"totalcost\",\n",
     "        \"sb1funds\",\n",
@@ -496,70 +250,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "bf24ac71-79a4-417f-906b-9ca4824b499f",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Lower case and clean project names\n",
-    "full_gdf2.projecttitle = (\n",
-    "    full_gdf2.projecttitle.str.lower().str.strip().str.split(\"20\").str[0]\n",
+    "sb1_all_projects.projecttitle = (\n",
+    "    sb1_all_projects.projecttitle.str.lower().str.strip().str.split(\"20\").str[0]\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "921e3b0a-eec5-471e-aeff-9a04dd1d5a6e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_2293/1072677451.py:3: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Get rid of |\n",
-    "for i in ['programcodes','issb1codes','projecttitle','isiijacode', 'isonshscodes']:\n",
-    "    full_gdf2[i] = full_gdf2[i].str.replace(\"|\", \"\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "41757458-fdcb-4b34-8bd6-b2e6995230b6",
-   "metadata": {},
-   "source": [
-    "#### Low hanging fruit, TIRCP & ATP"
+    "for i in [\"programcodes\", \"issb1code\", \"projecttitle\", \"isiijacode\", \"isonshscode\"]:\n",
+    "    sb1_all_projects[i] = sb1_all_projects[i].str.replace(\"|\", \"\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
+   "id": "a87ebb9b-4ca9-45d0-9e58-01a13ab873ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# No geometry, just drop it\n",
+    "sb1_all_projects = sb1_all_projects.drop(columns=[\"geometry\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "563d4da0-7985-429a-9a88-a2d7929fe765",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array(['ATP', 'FM', 'LPP-C', 'LPP-F', 'LSR', 'SCCP', 'SHOPP', 'SHOPA',\n",
-       "       'HM', 'SRA', 'STA', 'STIP', 'SGR', 'TCEP', 'TIRCP'], dtype=object)"
-      ]
-     },
-     "execution_count": 71,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "full_gdf2.programcodes.unique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "id": "3479af91-30bc-494a-82d7-cbbe1045841f",
    "metadata": {
     "scrolled": true,
@@ -567,12 +304,14 @@
    },
    "outputs": [],
    "source": [
-    "tircp_atp = full_gdf2.loc[full_gdf2.programcodes.str.contains(\"TIRCP|ATP\")].reset_index(drop = True)"
+    "tircp_atp = full_gdf2.loc[full_gdf2.programcodes.str.contains(\"TIRCP|ATP\")].reset_index(\n",
+    "    drop=True\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "id": "ad603d43-2605-4df0-b671-2870222af678",
    "metadata": {
     "scrolled": true,
@@ -586,67 +325,100 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "52d2dcca-c3ad-4c60-bb64-713eeeb70f5b",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "#### Try to merge CSV project ids with Geojson\n",
-    "* CSV version has cleaner project names."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "5a61b35c-5e67-4ea4-b1b0-da721486fdc5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def clean_project_id(df, project_id_col:str):\n",
-    "    df[project_id_col] = (df[project_id_col].str.replace(\"'\",\"\")\n",
-    "                          .str.lower()\n",
-    "                          .str.strip()\n",
-    "                         )\n",
+    "def clean_project_id(df, project_id_col: str):\n",
+    "    df[project_id_col] = df[project_id_col].str.replace(\"'\", \"\").str.lower().str.strip()\n",
     "    return df"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
+   "execution_count": null,
+   "id": "b1616bcb-efe6-451c-9310-7ca2629dcb37",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Read in SB1\n",
-    "sb1_project_id = to_snakecase(pd.read_csv(f\"{_utils.GCS_FILE_PATH}RebuildingCA_map_Data.csv\"))[['project_id','project_name']]"
+    "# Fill in NA\n",
+    "# sb1_2 = sb1_2.fillna(sb1_2.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ea8e6ea-1ab7-42f4-be6d-d0de4d4a4113",
+   "metadata": {},
+   "source": [
+    "#### Step 2: Read in files with geometry "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
+   "id": "120f70b4-586f-4e63-a178-0f68ae97bf41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stopped at Trade Corridor Enhancement Program Pt for testing\n",
+    "url_list = [\n",
+    "    \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/1/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\",\n",
+    "    \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/2/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\",\n",
+    "    \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/3/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8871efb7-866e-4eba-8de0-47aba5974e09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_gdf = pd.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167e85ce-39cf-4b61-9391-0eb47640580a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in url_list:\n",
+    "    df = to_snakecase(gpd.read_file(i))[\n",
+    "        [\"object_id\", \"projectid\", \"projecttitle\", \"geometry\", \"programcodes\"]\n",
+    "    ]\n",
+    "    full_gdf = pd.concat([full_gdf, df], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e24f8f8-64df-4743-ae7f-47b51c4105c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "full_gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b8413685-db5a-43c8-81a4-46e7f98175c0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_2293/2537473179.py:2: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sb1_project_id = clean_project_id(sb1_project_id, \"project_id\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "76b3ea1c-9750-4f68-9659-96de5f83bbc5",
    "metadata": {},
    "outputs": [],
@@ -656,65 +428,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "id": "52ae80b3-b737-45cc-901c-6dbd8334204a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(4050, 9544, 9632)"
-      ]
-     },
-     "execution_count": 69,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "full_gdf2.projectid.nunique(), sb1_project_id.project_id.nunique(), len(sb1_project_id)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "307fd968-aec1-4e26-a2b3-88c80c5a1ab4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_merge    \n",
-       "left_only     5595\n",
-       "both          4174\n",
-       "right_only    1321\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "pd.merge(sb1_project_id, full_gdf2, how=\"outer\",left_on=[\"project_id\"], right_on=['projectid'], indicator=True)[\n",
-    "    [\"_merge\"]\n",
-    "].value_counts()"
+    "pd.merge(\n",
+    "    sb1_project_id,\n",
+    "    full_gdf2,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"project_id\"],\n",
+    "    right_on=[\"projectid\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "id": "c05a86f1-6c69-484e-b6bd-5d3324742824",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sb1_m = pd.merge(full_gdf2, sb1_project_id, how=\"left\",left_on=[\"projectid\"], right_on=['project_id']) "
+    "sb1_m = pd.merge(\n",
+    "    full_gdf2,\n",
+    "    sb1_project_id,\n",
+    "    how=\"left\",\n",
+    "    left_on=[\"projectid\"],\n",
+    "    right_on=[\"project_id\"],\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "id": "e4b1d2d3-7b68-460b-a2eb-dd5f6e59c381",
    "metadata": {},
    "outputs": [],
@@ -723,47 +480,15 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "bb97717c-265b-4564-8a7a-dc99f0168119",
-   "metadata": {},
-   "source": [
-    "### Merge 1 with Non SHOPP\n",
-    "* Didn't work on project names :( "
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "92fc5d14-d99c-470f-9bc5-d903d7b212db",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_merge    \n",
-       "right_only    5495\n",
-       "left_only      905\n",
-       "both             0\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "pd.merge(nonshopp, sb1_m, how=\"outer\", on = ['project_name'], indicator=True)[\n",
+    "pd.merge(nonshopp, sb1_m, how=\"outer\", on=[\"project_name\"], indicator=True)[\n",
     "    [\"_merge\"]\n",
     "].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9080657d-b4de-453c-9663-55bb5e004915",
-   "metadata": {},
-   "source": [
-    "### SB1 CSV"
    ]
   },
   {
@@ -878,7 +603,131 @@
    "id": "69f2f3b4-c1d0-4d4b-87c5-d2158e115dcc",
    "metadata": {},
    "source": [
-    "#### Merge on Project Names"
+    "### Merge 9 Sample Non SHOPP with Geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e217738-36f1-4c7e-939d-dda2c86dc95d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_names = [\n",
+    "    \"LA-210 Median Concrete Barrier Renovation\",\n",
+    "    \"SR-14 Widening Project\",\n",
+    "    \"US 395 Freight Mobility and Safety Project\",\n",
+    "    \"East Bay Greenway Multimodal Corridor Project\",\n",
+    "    \"Watsonville-Santa Cruz Multimodal Corridor Program\",\n",
+    "    \"SM 101 Woodside Road Interchange and Port Access Project\",\n",
+    "    \"I-710 Integrated Corridor Management\",\n",
+    "    \"Five Cities Multimodal Transportation Network Enhancement Project\",\n",
+    "    \"SR-86/Avenue 50 New Interchange (Phase II)\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8834ce41-93b4-4978-a1bf-d4595dad14a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_names = [x.lower() for x in nine_projects_names]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f603d690-cc3d-490e-93e5-760297de703a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_ea = [\n",
+    "    \"33560\",\n",
+    "    \"N/A (PID)\",\n",
+    "    \"0F633\",\n",
+    "    \"4W850 \",\n",
+    "    \"0C734\",\n",
+    "    \"23536\",\n",
+    "    \"37510K\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56021431-34cf-4433-af4b-daf4888bc0a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_ea = [x.lower() for x in nine_projects_ea]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b7deddf-30b5-4071-8a9c-2bd91c9cdc25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_id = [\n",
+    "    \"0422000202\",\n",
+    "    \"0414000032\",\n",
+    "    \"0520000083\",\n",
+    "    \"0515000063\",\n",
+    "    \"0721000056\",\n",
+    "    \"0716000370\",\n",
+    "    \"0813000222\",\n",
+    "    \"0814000144\",\n",
+    "    \"0414000032\",\n",
+    "    \"0720000165\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2258812c-fed6-4b48-84f7-10367a9b8839",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# .str.split(\"20\").str[0]\n",
+    "for i in [\"project_name\", \"ea\", \"ppno\"]:\n",
+    "    nonshopp[i] = nonshopp[i].str.lower()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1166af6b-cbcc-45b7-81a8-3f4dfde5a0a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(nonshopp[nonshopp.project_name.isin(nine_projects_names)].reset_index(drop=True))[\n",
+    "    [\"project_name\"]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6b3ec7b-d8d1-452e-9323-12861951f41b",
+   "metadata": {},
+   "source": [
+    "* Missing SM 101 Woodside Road Interchange and Port Access Project\n",
+    " and SR-14 Widening Project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86fcc2e9-e7d2-413e-bf0f-a133f9e1d628",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(nonshopp[nonshopp.ct_project_id.isin(nine_projects_id)].reset_index(drop=True))[\n",
+    "    [\"project_name\"]\n",
+    "]"
    ]
   },
   {

--- a/project_prioritization/add_sb1.ipynb
+++ b/project_prioritization/add_sb1.ipynb
@@ -59,18 +59,56 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "237a5df4-60b9-4b73-858e-0468dad85d15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def basic_cleaning(df, agency_col: str, project_name_col:str, project_id_col: str, project_desc_col:str):\n",
+    "    \n",
+    "    df = _utils.organization_cleaning(df, agency_col)\n",
+    "    \n",
+    "    # Remove all punctation, lowercase, and strip whitespaces from \n",
+    "    # project titles & descriptions\n",
+    "    for i in [project_name_col, project_desc_col]:\n",
+    "        df[i] = (df[i].str.lower().str.replace('[^\\w\\s]','').str.strip())\n",
+    "                 \n",
+    "    # Some project names contain the year. Remove anything after 20..\n",
+    "    df[project_name_col] = df[project_name_col].str.split(\"20\").str[0]\n",
+    "    \n",
+    "    # Project ID, remove all commas and lowercase if there are strings\n",
+    "    df[project_id_col] = (df[project_id_col].str.replace(\"'\", \"\").str.lower().str.strip())\n",
+    "    \n",
+    "    # Get rid of | in object cols\n",
+    "    # https://stackoverflow.com/questions/68152902/extracting-only-object-type-columns-in-a-separate-list-from-a-data-frame-in-pand\n",
+    "    string_cols = df.select_dtypes(include=['object']).columns.to_list()\n",
+    "    try:\n",
+    "        for i in string_cols:\n",
+    "            df[i] = df[i].str.replace(\"|\", \"\")\n",
+    "    except:\n",
+    "        pass\n",
+    "        \n",
+    "    # Fill in NA\n",
+    "    df = df.fillna(df.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "76e4f5c3-7968-49e6-97d3-a1d165e50af3",
    "metadata": {
     "tags": []
    },
    "source": [
-    "### Non SHOPP-ATP-TIRCP"
+    "### Non SHOPP-ATP-TIRCP\n",
+    "* No year information for projects."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "6b483a64-786d-4d9c-96e8-0bfe429ffd2a",
    "metadata": {},
    "outputs": [],
@@ -83,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "aa0c6362-1f89-4112-a55f-6928841266ce",
    "metadata": {},
    "outputs": [],
@@ -97,6 +135,8 @@
     "    \"lead_agency\",\n",
     "    \"previous_caltrans_nominations\",\n",
     "    \"full_county_name\",\n",
+    "    \"county\",\n",
+    "    \"district_full_name\",\n",
     "    \"district\",\n",
     "    \"project_description\",\n",
     "    \"current_phase\",\n",
@@ -111,25 +151,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "a63dc3e3-2485-4331-b370-c6fdf2c57952",
    "metadata": {},
    "outputs": [],
    "source": [
-    "nonshopp = nonshopp[non_shopp_subset]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "831b6492-b46d-4b82-b11a-87d25b87bcdb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Lower case and clean project names\n",
-    "nonshopp.project_name = (\n",
-    "    nonshopp.project_name.str.lower().str.strip().str.split(\"20\").str[0]\n",
-    ")"
+    "# nonshopp = nonshopp[non_shopp_subset]"
    ]
   },
   {
@@ -139,25 +166,703 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Add a digit in front of single digits\n",
     "nonshopp.district = nonshopp.district.map(\"{:02}\".format)"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "388aab8a-a885-4cd2-98b2-7dd6e5b24b82",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_1639/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
+      "/tmp/ipykernel_1639/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+     ]
+    }
+   ],
+   "source": [
+    "nonshopp = basic_cleaning(nonshopp, \"lead_agency\", \"project_name\", \"ct_project_id\", \"project_description\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "5ba81d8f-2aaa-4138-be99-ed6687892a8a",
+   "id": "69f2f3b4-c1d0-4d4b-87c5-d2158e115dcc",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 9 Sample Non SHOPP "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3e217738-36f1-4c7e-939d-dda2c86dc95d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_names = [\n",
+    "    \"LA-210 Median Concrete Barrier Renovation\",\n",
+    "    \"SR-14 Widening Project\",\n",
+    "    \"US 395 Freight Mobility and Safety Project\",\n",
+    "    \"East Bay Greenway Multimodal Corridor Project\",\n",
+    "    \"Watsonville-Santa Cruz Multimodal Corridor Program\",\n",
+    "    \"SM 101 Woodside Road Interchange and Port Access Project\",\n",
+    "    \"I-710 Integrated Corridor Management\",\n",
+    "    \"Five Cities Multimodal Transportation Network Enhancement Project\",\n",
+    "    \"SR-86/Avenue 50 New Interchange (Phase II)\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8834ce41-93b4-4978-a1bf-d4595dad14a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_names = [x.lower() for x in nine_projects_names]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8b7deddf-30b5-4071-8a9c-2bd91c9cdc25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_projects_id = [\n",
+    "    \"0422000202\",\n",
+    "    \"0414000032\",\n",
+    "    \"0520000083\",\n",
+    "    \"0515000063\",\n",
+    "    \"0721000056\",\n",
+    "    \"0716000370\",\n",
+    "    \"0813000222\",\n",
+    "    \"0814000144\",\n",
+    "    \"0414000032\",\n",
+    "    \"0720000165\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "86fcc2e9-e7d2-413e-bf0f-a133f9e1d628",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_sample_projects = (nonshopp[nonshopp.ct_project_id.isin(nine_projects_id)].reset_index(drop=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87abc3fd-7d93-45da-ac5c-886f01e00d0b",
+   "metadata": {},
+   "source": [
+    "* Solutions for Congest Corridors (SCCP): 1\n",
+    "* Trade Corridor Enhancement Program (TCEP): 3\n",
+    "* Only 3 projects seem to have been awarded. \n",
+    "    * east bay greenway multimodal corridor project phase 1\n",
+    "    * us 101woodside road interchange and port access project\n",
+    "    * watsonvillesanta cruz multimodal corridor program wscmcp cycle 3 project contract 1 sr 1 freedom to state park aux lanes bus on shoulders and coastal rail trail segment 12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d001144d-7528-43d7-8b60-32d925ccf080",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# nine_sample_projects[['project_name','project_description','county','previous_caltrans_nominations']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da7daae5-7482-4535-aa72-08a3145b757e",
    "metadata": {},
    "source": [
     "### Sb1 Geo\n",
-    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer\n",
-    "\n",
-    "#### Step 1: Read in all projects\n",
+    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ea8e6ea-1ab7-42f4-be6d-d0de4d4a4113",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Step 1: Read in files with geometry "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "66078fe9-1813-4114-8cd3-f202d767d42f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url_pt1 = \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/\"\n",
+    "url_pt2 = \"/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1d4ea347-27e9-46e0-896b-d46d31cb583c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rest_server():\n",
+    "    full_gdf = pd.DataFrame()\n",
+    "    for i in [*range(0,22)]:\n",
+    "        df = to_snakecase(gpd.read_file(f\"{url_pt1}{i}{url_pt2}\"))\n",
+    "        full_gdf = pd.concat([full_gdf, df], axis=0)\n",
+    "    return full_gdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "8871efb7-866e-4eba-8de0-47aba5974e09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_geo1 = rest_server()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "bf8f1b02-f703-487f-b0af-6b3b5aa494f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['objectid', 'agencyids', 'agencies', 'programcodes', 'iijaprogram',\n",
+       "       'iijacodes', 'projectstatuscodes', 'fiscalyears', 'fiscalyearcodes',\n",
+       "       'projectstatuses', 'sb1funds', 'iijafunds', 'totalcost', 'dateupdated',\n",
+       "       'projectcount', 'assemblydistricts', 'senatedistricts',\n",
+       "       'congressionaldistricts', 'assemblycodes', 'senatecodes',\n",
+       "       'congressionalcodes', 'countynames', 'citynames', 'countycodes',\n",
+       "       'citycodes', 'ct_codes', 'ct_districts', 'issb1', 'isiija', 'isonshs',\n",
+       "       'issb1codes', 'isiijacode', 'isonshscodes', 'popup', 'geometry',\n",
+       "       'projectid', 'projecttitle', 'projectdescription'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_geo1.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "2f810e79-6227-4c12-940d-3b8f92f7e1fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_1639/3292077459.py:8: FutureWarning: The default value of regex will change from True to False in a future version.\n",
+      "/tmp/ipykernel_1639/3292077459.py:21: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.\n"
+     ]
+    }
+   ],
+   "source": [
+    "sb1_geo2 = basic_cleaning(sb1_geo1, 'agencies','projecttitle','projectid',\n",
+    "                         'projectdescription')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "52ac67ea-44e6-43d4-b5d5-c2f345554418",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sb1_geo = sb1_geo.drop(columns = 'popup')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "d7bec9fb-c72f-4644-91c8-b8d019843a70",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SHOPP    2741\n",
+       "HM       1163\n",
+       "LSR       509\n",
+       "ATP       321\n",
+       "SHOPA     165\n",
+       "SGR       161\n",
+       "STIP      126\n",
+       "TIRCP      96\n",
+       "LPP-F      68\n",
+       "TCEP       63\n",
+       "LPP-C      57\n",
+       "STA        49\n",
+       "SCCP       40\n",
+       "FM         12\n",
+       "SRA        11\n",
+       "Name: programcodes, dtype: int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_geo2.programcodes.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "3a14fd39-d217-42dc-9d8d-b8a1b1f7b559",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# All geometry is valid\n",
+    "sb1_geo2.geometry.is_valid.sum() == len(sb1_geo2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f51de107-8fb6-4d05-86a6-6111753452c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_1639/3707436155.py:1: UserWarning: GeoSeries.notna() previously returned False for both missing (None) and empty geometries. Now, it only returns False for missing values. Since the calling GeoSeries contains empty geometries, the result has changed compared to previous versions of GeoPandas.\n",
+      "Given a GeoSeries 's', you can use '~s.is_empty & s.notna()' to get back the old behaviour.\n",
+      "\n",
+      "To further ignore this warning, you can do: \n",
+      "import warnings; warnings.filterwarnings('ignore', 'GeoSeries.notna', UserWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_geo2.geometry.notna().sum()  == len(sb1_geo2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "3a14399a-65f7-4c4a-8dff-770a5a8428c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5581"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sb1_geo2[~sb1_geo2.geometry.is_empty]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "225588db-cf65-4420-91f5-529f94f04e0f",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Throw out missing geometry\n",
+    "missing_geo = sb1_geo2[sb1_geo2.geometry.is_empty]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "52e55d21-d807-4bf8-ac14-6e0d7c1b624f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb1_geo2 = sb1_geo2[~sb1_geo2.geometry.is_empty].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "cd71460f-35f5-46ae-a93a-5191bdde60f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sb1_geo2) == len(sb1_geo2[~sb1_geo2.geometry.is_empty]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "9f70a4a8-8b23-4bd8-b362-2d27c7e642e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "None                        1321\n",
+       "major damage restoration     465\n",
+       "safety improvements          366\n",
+       "pavement rehabilitation      305\n",
+       "pavement  hm1                220\n",
+       "Name: projecttitle, dtype: int64"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb1_geo2.projecttitle.value_counts().head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "a8e5a8eb-23bb-4741-a674-06d3448b1431",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sb1_geo.countynames.sort_values().unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "a4f51702-caca-4c01-b7d6-23de04012ead",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sb1_geo.explore()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a91b5261-4f89-439a-b82e-7877b7707551",
+   "metadata": {},
+   "source": [
+    "#### Compare with 9 Sample Projects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "7fbba442-b295-4a9b-b94d-68dc41c0131f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subset sb1_geo to only programs these 9 projects have applied for\n",
+    "tcep_sccp1 = sb1_geo2[sb1_geo2[\"programcodes\"].str.contains(('TCEP|SCCP'))].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "729a5f9b-34ce-4802-8195-2319a38bc857",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subset sb1_geo to only programs these 9 projects are located in\n",
+    "tcep_sccp2 = sb1_geo2[sb1_geo2[\"countynames\"].str.contains(('Alameda|San Mateo|Santa Cruz|San Luis Obispo|Los Angeles|San Bernardino|Riverside'))].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "9002f8e2-75d1-4b3a-a7b6-b01efa548b5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subset sb1_geo to only programs these 9 projects have applied for\n",
+    "tcep_sccp2 = tcep_sccp2[tcep_sccp2[\"programcodes\"].str.contains(('TCEP|SCCP'))].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "cb74fc0e-5ed1-4a40-acd7-84aa24a72733",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(37, 38)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tcep_sccp2.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "3fef812f-a54c-403e-992b-6bb51dcebdd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TCEP    26\n",
+       "SCCP    11\n",
+       "Name: programcodes, dtype: int64"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tcep_sccp2.programcodes.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "d9ed4ea2-9e66-4ddd-b1b6-1c65d7ceaf97",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "right_only    37\n",
+       "left_only      9\n",
+       "both           0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "    nine_sample_projects,\n",
+    "    tcep_sccp2,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"ct_project_id\"],\n",
+    "    right_on=[\"projectid\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "a7475dba-a1dc-414c-8f13-c94d34003069",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "right_only    37\n",
+       "left_only      9\n",
+       "both           0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "    nine_sample_projects,\n",
+    "    tcep_sccp2,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"project_name\"],\n",
+    "    right_on=[\"projecttitle\"],\n",
+    "    indicator=True,\n",
+    ")[[\"_merge\"]].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3a52b8f-aa23-44c6-aee4-59bae929ce38",
+   "metadata": {},
+   "source": [
+    "* Eyeballing matches\n",
+    "    * route 395 widening from sr 18 to chamberlaine way in SB1 could match us 395 freight mobility and safety project in Non SHOPP\n",
+    "    * state route 1 state park to bayporter auxiliary lanes in SB1 is watsonvillesanta cruz multimodal corridor program wscmcp cycle 3 project contract 1 sr 1 freedom to state park aux lanes bus on shoulders and coastal rail trail segment 12 in non SHOPP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "c03ada7e-43f2-4f22-9ff2-d6ad9704337f",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# tcep_sccp2[['projecttitle','agencies','countynames', 'projectdescription']].sort_values(['countynames','projecttitle'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "2eec244d-6141-4655-898d-d10e23cca51d",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#nine_sample_projects[['project_name','lead_agency','full_county_name','project_description']].sort_values(['full_county_name','project_name'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "bc283dad-5081-4d09-b160-006c9992472a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_shopp_projects_sb1_list = ['route 395 widening from sr 18 to chamberlaine way', \n",
+    "                             'state route 1  state park to bayporter auxiliary lanes']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "2e3dad1e-5626-49a9-aff0-746fb54858e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_shopp_projects_in_sb1 = sb1_geo2[sb1_geo2[\"projecttitle\"].isin(non_shopp_projects_sb1_list)].reset_index(drop = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "3586edee-5451-481b-b3b1-2713acae7dc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_shopp_projects_in_sb1.projecttitle = non_shopp_projects_in_sb1.projecttitle.replace({\n",
+    "    'route 395 widening from sr 18 to chamberlaine way': 'us 395 freight mobility and safety project',\n",
+    "    'state route 1  state park to bayporter auxiliary lanes': 'watsonvillesanta cruz multimodal corridor program wscmcp cycle 3 project contract 1  sr 1 freedom to state park aux lanes bus on shoulders and coastal rail trail segment 12'\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "5d02f7da-fb30-4fe6-a62c-f73e2efd872e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nine_sample_projects_geo = pd.merge(\n",
+    "    non_shopp_projects_in_sb1[['projecttitle','geometry', 'projectdescription']],\n",
+    "    nine_sample_projects,\n",
+    "    how=\"outer\",\n",
+    "    left_on=[\"projecttitle\"],\n",
+    "    right_on=[\"project_name\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "b1ffa7f6-a4d1-4ffb-986d-5f9681dc2f00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# _utils.geojson_gcs_export(nine_sample_projects_geo,_utils.GCS_FILE_PATH, 'nine_sample_projects_geom')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "418cf408-395b-4129-9627-c194bb7eee7b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Step 2: Read in all projects\n",
     "* Compare with CSV.\n",
     "* Clean it up."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 46,
    "id": "57760f7c-453e-4d1e-9055-911fdc5dd74b",
    "metadata": {},
    "outputs": [],
@@ -167,7 +872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "a316c10a-3ba0-4d96-a2a3-16a7324fdf60",
    "metadata": {},
    "outputs": [],
@@ -178,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "98ad0ce0-1ec1-4686-b088-51f1d5d4ea72",
    "metadata": {},
    "outputs": [],
@@ -188,28 +893,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "cd7b978f-e0fe-4cf9-9cfa-fe0993b78e27",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "((9632, 37), 5453)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sb1_all_projects.shape, sb1_all_projects.projecttitle.nunique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1c2e3f9f-55fc-4d4d-a6a4-931da4a68d84",
    "metadata": {},
    "outputs": [],
@@ -220,7 +914,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "24de4776-90e4-4862-9224-fe1fedf4ef60",
    "metadata": {},
    "outputs": [],
@@ -233,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "3961c1b6-eb36-44ba-8a78-aca089cd2035",
    "metadata": {},
    "outputs": [],
@@ -243,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "98b60f3e-8875-4cc2-807a-98266ac56bbb",
    "metadata": {},
    "outputs": [],
@@ -260,7 +954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "bf24ac71-79a4-417f-906b-9ca4824b499f",
    "metadata": {},
    "outputs": [],
@@ -273,7 +967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "a87ebb9b-4ca9-45d0-9e58-01a13ab873ef",
    "metadata": {},
    "outputs": [],
@@ -283,153 +977,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "563d4da0-7985-429a-9a88-a2d7929fe765",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'full_gdf2' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[19], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mfull_gdf2\u001b[49m\u001b[38;5;241m.\u001b[39mprogramcodes\u001b[38;5;241m.\u001b[39munique()\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'full_gdf2' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "full_gdf2.programcodes.unique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3479af91-30bc-494a-82d7-cbbe1045841f",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "tircp_atp = full_gdf2.loc[full_gdf2.programcodes.str.contains(\"TIRCP|ATP\")].reset_index(\n",
-    "    drop=True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ad603d43-2605-4df0-b671-2870222af678",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "tircp_atp_nonshopp = nonshopp.loc[\n",
-    "    nonshopp.previous_caltrans_nominations.str.contains(\"TIRCP|ATP\")\n",
-    "].reset_index(drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "b1616bcb-efe6-451c-9310-7ca2629dcb37",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Fill in NA\n",
-    "sb1_all_projects = sb1_all_projects.fillna(sb1_all_projects.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "1ea8e6ea-1ab7-42f4-be6d-d0de4d4a4113",
+   "id": "59a4eef7-4b8b-40bd-af1a-f15f81a077ba",
    "metadata": {},
    "source": [
-    "#### Step 2: Read in files with geometry \n",
-    "* https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "66078fe9-1813-4114-8cd3-f202d767d42f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "url_pt1 = \"https://odpsvcs.dot.ca.gov/arcgis/rest/services/RCA/RCA_Projects_032022/FeatureServer/\"\n",
-    "url_pt2 = \"/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=*+&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=&gdbVersion=&historicMoment=&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&multipatchOption=&resultOffset=&resultRecordCount=&returnTrueCurves=false&sqlFormat=none&f=geojson\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "1d4ea347-27e9-46e0-896b-d46d31cb583c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def rest_server():\n",
-    "    full_gdf = pd.DataFrame()\n",
-    "    for i in [*range(0,22)]:\n",
-    "        df = to_snakecase(gpd.read_file(f\"{url_pt1}{i}{url_pt2}\"))\n",
-    "        full_gdf = pd.concat([full_gdf, df], axis=0)\n",
-    "    return full_gdf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "8871efb7-866e-4eba-8de0-47aba5974e09",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sb1_geo = rest_server()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "90737e33-59b9-4ad1-bf45-1e933b4cc099",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<AxesSubplot:>"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAGdCAYAAADkAUNdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAA9hAAAPYQGoP6dpAACJk0lEQVR4nO2deVxU5f7HP2dmmBn2HUFFQEERERFTwTURXLC0rFtpLpWZVnbbfveqmalpqS1Xu9eyMrPU1FZTE3dNUVFUQEFEFEGUfZF9GZg5vz+GGWdglnNmzgwz8LxfL1/F8JxznoPyOc/5Pt/v50vRNE2DQCAQCFYJr6MnQCAQCATDISJOIBAIVgwRcQKBQLBiiIgTCASCFUNEnEAgEKwYIuIEAoFgxRARJxAIBCuGiDiBQCBYMYKOnkBbZDIZCgoK4OjoCIqiOno6BAKBYBQ0TaOmpgbdu3cHj8f9utniRLygoAC+vr4dPQ0CgUDglHv37qFnz56cn9fiRNzR0RGA/IadnJw6eDYEAoFgHNXV1fD19VVqG9dYnIgrQihOTk5ExAkEQqfBVOFhsrFJIBAIVgwRcQKBQLBiiIgTCASCFUNEnEAgEKwYIuIEAoFgxRARJxAIBCuGiDiBQCBYMUTECQQCwYohIk4gEAhWjFEivm7dOlAUhbfeegsAUFFRgTfeeAP9+vWDra0tevXqhX/+85+oqqriYq6dDqmMRmJ2Ofal5iMxuxxSGd2pr0sgELjH4LL7S5cu4ZtvvkFYWJjys4KCAhQUFOCzzz5DSEgI7t69i4ULF6KgoAC//fYbJxPmEqmMRlJOBUpqGuHlKMawADfweeZxTjycXohVBzJQWNWo/MzHWYwVj4dgUqgP6/NJWmTYkZiLuxX18HOzw+wofwgF7Z/Rmq7rYmuDF0f6Y1F0kNnun0AgcANF0zTrZVhtbS0iIiLw1VdfYc2aNQgPD8fGjRs1jv31118xa9Ys1NXVQSDQ/8yorq6Gs7MzqqqqWHunNEik+Dg+A7nl9fB3t8N7cSGwFfI1juVaRNlwOL0Qr+5MRtsfvEI+N8+KYDWHtfEZ2JKQA9UFNY8C5o8OwNK4EL3XVeBiZ4N10wea/P4JhK6EMZrGBIPCKa+//jqmTJmCmJgYvWMVE2ci4MYwf/sl9P/gMHZcyEPCrTLsuJCH/h8cxvztl9qNPZxeiIU7k9UEHACKqhrx6s5kHE4vNNk8pTIaqw5kaBRSxWerDmQwDnGsjc/AN2fUBRwAZDTwzZkcvLL9EvLK63VeV0FlfbPJ759AIHALaxHfs2cPkpOTsXbtWr1jy8rKsHr1arzyyitaxzQ1NaG6ulrtD1vmb7+EYxklGr93LKNETcilMhpLfk/TOFafiHIRS07KqWj38Gg7h8KqRiTlVOg9l6RFhm8TcnSOOZpRgplbLuBMVqnO66pen81DhEAgdCyslsf37t3Dm2++iWPHjkEsFuscW11djSlTpiAkJAQrV67UOm7t2rVYtWoVm2mo0SCRahVwBccySnA6swSj+nrizT0pqGxo1jpWVUSj+rgrP9cUfnGzF2J4gBv6eNojqrcHIvu4640pl9ToF1Km4348nwsmwTCJVIaLOeWMrgtovn8CgWCZsBLxK1euoKSkBBEREcrPpFIpzpw5g02bNqGpqQl8Ph81NTWYNGkSHB0dsXfvXtjY2Gg959KlS/HOO+8ov1YYqDPl4/gMRuPm/nAJzrYCVDW0MBqvKqLaYskVdRIcSi8CAGw6lc0opuzlqPvhx2bcpVxmwhzu64yxfb3w9ek7jMYDzB82BAKhY2El4uPHj0damnoo4sUXX0RwcDAWL14MPp+P6upqTJw4ESKRCPv379e7YheJRBCJROxn3kpueT3jsUwFHHgookxiyQoq65uxcGcy5o30R0yIt8Zsl2EBbvBxFusMbfg4yzNl9GEnZPbXZycUMLquKkwfNgQCoWNhJeKOjo4IDQ1V+8ze3h7u7u4IDQ1FdXU1JkyYgPr6euzcuVMtxu3p6Qk+X3OmiDH4u9sh4Ra353SxtVGKqL4Ytia2nsvF1nO58HEWY9nkYAwNcMe7v6ZCRgO2NnwM7OGk85xTB/kwSvV7KqIn/kwtYDSOz6Ow4vEQLNyZrHe8o0iAoqoGJGaXmzXtkkAgsIfTlJHk5GRcvHgRABAYGKj2vZycHPj7+3N5OQDAe3Eh2HEhj9NzvjjSXylcRdWGhxUKqxqxaE9qu8+dxLp/7PuvFuLfk/rrFc8RgR6wE/JRL5FqHWMv5GNEoAcAYFKoD76eFYElf6Shsl77vkBNUwve/uUqAPOlXRIIBMMwKE/clLDNqRy65hhKayWcXd9BJMDVFRPA51GIv1aAxX9cQ02jdpFkg7u9ELZCPu4/aNA79u2YILwZ01fvOEW6pDa+1pBzLpXR2HTyNrady9G5yQsYnrtOIBDkWGSeuKVQUSvhVMAB4JOnwsDnUVgbn4HXdqVwJuDPDfVF0nvj0a+bA6PxG47fYpSvrVhdd3NU31fwdhJpFHAA4PMovBkThCvLY7F7fiQ2PBsON3vNm880SNohgWDJWFy3ezY89+15Ts+3YEwA4sJ8EH+tEN+c0Z1/zZaoPu6Q0sCJzFLGx6w6kIHYEG+9YZVJoT6IDfFmbSHA51GI6uOOxOxyVNTpXpGTtEMCwTKxahEvqTFsFe5iZ6MWE3azt8GaaaGIC+sOqYzG+/vSuZqiEi9HMf71ayqrY9oKpy5/FIUgGwLTuL8x+wMEAsE0WLWIezkK9cZ0VXEQ8fHZPwbpXLUm5VSgoo67EA0FwNtZjCF+rnh+ywXWxyvytTX5o3wUfwPzRgUgOribUSZeFbVNnI3rSFMxAqErYtUivueVEYhYc4zx+NVPPCzE0bZqZVPksiyuP6oampFdWoND6cWgALV8coV0rXg8BFfuPoCM8Zkf4uUoVvqjtEVGA1sScrBFpfTekGwSN3shJ+M60lSMQOiqWPXGppuDEB4O2qtB2+LtpL+AhWmRi5u9DV4aFYD/m9gPm2c9gq9nRcDbWf1Yb2exMquDbQUkBbkAhvu6qIm0Pgwx8fJ2tjV6nKKqtSNMxQiEroxVr8QB4PL7EzBw5WG9WSRMqyCZVjaumRaqFibQt7loSAXkisdDsOvi3XYOhbqgIX8AMN0UBYyvItXnzMh2PgQCgTlWvRJXkLZyEmZH9tL6fQpyQWQiIIrKRl3Is1i6azw2qo87poX3QFQbM6xhAW5wtmX2zHSxs8FbMX0RG+KNuxXMbQUUsHFCVMx7xeMh0PXT0fXzY+rMOPSjY3jqq3NYfygTs7dexNHrRYzmRyAQtNMpRByQx7u/mjm4Xb6zSECxLlSZOMAbj4f5wIavLlru9kJ8NTNCrdECU/g8CqunheofCLkHy4bjWRi1/iTqm5j7vbSFTQhnUqgPNs+KgI9z+zcGigKcbbXHw5lep6KuGVfyKrH5dDYSbpXh2v2HbftomkZ6fhUadFSfEgiE9lh9OEWVuLDumBjqg6ScCuxNvodfruSjuYVGUDdHVue5XlANdwcRmqU0ds+P5CzTYmp4DwgFvHabfwIehRYNMZPCqkb8lpzfbsOUKWxDOJpCQr9duYffk/Px6k9X8HRET0T2dsew3m5wEtsoM1FuFdcaMDtgb+p9/N/EfgCAB/XNqGpohq2Qj/+euIUFY3tDJODea4dA6Gx0KhEHHoY0ovq4Iy2/GgVVjThyvQivPRqo/+BWJFIZfjifC0B7FouhtBVKDwcR3v0lFUXV2tP32Aq4Iq2RyR5AW9rmmw/ydcbFnArcf9CA787m4LuzOeDzKPR0sUV5nQS1Rrwp5D9oRFV9M5ztbCCjaeV8MwqqGfmkEwiETijiqhx4YxQEfPYRI9UslkNphZg8kNv0OFWhTMwu1yngbFFNa+RiE9FOKMBfb4zC6axSXLhTjsTscuSW1xsUq9fESz8k4ffXRsLD4aFtwEujAmBjwN8bgdAV6dQiLpPRmPvjRdwuqcVn/whXs5fVFSLp7mILR5EANU0t2HTqNucirgrb1MP3JgfjfmUD/Nzs0M1RhI8OZaqFZrxNkJftYifEtPAemBbeA1IZjai1J1BSw82Dp0DDhqghbxAEQlel04r44fRC/Ou3a6hplL/uz9hyAS528k1P1ZJ7bcUoo/t6ID6tCMUmLjVnG7c+lVmC3QuilF9PDutu1gpJ+bX0C3g3JxGKGbxhdNewkUogEJjTKd9ZFYUnCgFXUFnf3M5Hu20xiqIZskIG/d3tTTpXRY42UxJzKhB/7WEjCF1pjaaA6ZvD2zFBjMZ9/8IwY6ZDIHR5Op2Is2mnBqh3uI+/VohR609ixpYLOJgmz2FOL6gyabUhk7z0trzzy9V2trCKh8++1HwkZpebzDaW6ZuDn7sD/Nx1V4L6udvC2Y55xS2BQGiP1TeFaEtidjlmGGA0pQ1zNUX4KzVfYxcgbTwW5oNNM+UNq83pWSKV0Ri1/qTe6s6zi6PB51EY++lJ3C1v3wTDz90Wp/8VzencCARLhDSFYAnXXdpVV+qmbIrwWHgPTBnozXj8wWuFkLTIzO5ZwudRmDpI94NBtUfo6X9F4+oHEzC458N/vKumDiACTiBwRKcTcVN0aWdbxs6ExmZpuxzr/86IgNiG2V8JDWDpH9ewcv91rZ4lpujII5XR+PnyfZ1j9l8tVLums50NfnttlPLeknJMF+4hELoanU7Ew31dIOSbZnOPq1X+qcwSPLX5PEJXHEFWcY3ycz6Pwn/+Ec74PL8n5+vNMef64bPp5G2dTZY1XfNwunyvobFZbsZ7MK0Io9afJM6GBAIHdCoRX/1XBkI+OAyJtGM39fRBg8b1gmoAwMIdV9S+FxfmAz83ZtawTDHm4aO6YXrudhk2nbrF6prEopZAMC2dJk986qYEXLtfrXOMq50NaEDvSrItxpSxayI6uBumR/TAH8n5ENm09wcZGeSBuxfvcXItwPCHT/y1Qry/L92gTkdejmJiUUsgmIFOsRJf/Ve6XgGnAJxfMh5X3o/Fk+HtbWR1HQdwV8auoKk1tNDHs30eeh8PB8bncbO30Wohq2gsYcjDZ218Bl7blWyQgIsFPAwLcGNsUctluIdA6GpYvYhLWmTYevau3nE0gF0X74LPo9DdhXm4QrU7D1f8fbMEh1rDCE8P6dnu+zOH+zE6j4+zGGta7W3bCrkxD5/4awUa28ExxVEsAJ9HMQ7jcJ1RRCB0Jaw+nPLjeeZiozBtcmFYYDImyB3bXhzO6Qqcpmks25sOGQ30cLFFZG91l8TD6YVYuT+D0bkUeeCbeVS7PHFNHipMmhhLZTTe35duxB0CpbUSrI3PwKP9ujEan1vGjZkWgdAVsXoRv5T7gPFYPzc7AIAHwxjxlbuVhkxJJzIayK9sgKudDX58aSjEKjHxw+mFWLgzWe857EV8fP6PQUqB1tcaTnFuJgVBSTkVqKhjt2egiW/P5OCtmH7wdhLpzaDZcykPi6IDSVycQDAAqxdxeyHzxgGzo/wBMGuYDAB1Eiku3CnHyEAPQ6amER4FfPJ0GKYO6g6R4GE0Syqj8e4vV3UeK+BR2DrnEYzq69lO8Nr6gKuiyBBpu8GoyBBRDRdxFdqgAey8kIsZw3phw3HdGS2KuDjX3u0EQlfA6mPi0yPax5Q1MSm0G4StojkswA32Imbin5hdbvDcNEFRFJ4I74Fvz9zBdwl3lJ+fv12GOj2tyVpkNHg8itWKVV+GCAAs25uOxmb5tbkslrqU+wD+HswMxEhcnEAwDKsX8RGBHoxW44fTi/HM1+eRcLMUADAmiNnqOru0Rv8glsz4NhEbjmXhRGaJ8rP/nWSWf/1Hsu5qybYwyRApr5Mg7osEVDU0s3ZV1IW9kM/4oWCKSlsCoStg9SLO51H4/JlBjMYm5T7A7G1J6PtePPp2Y2ZEc+52OSQtMmOmqFYw89TX53AlrxI0gH6tvT+lMhpXVZoG60LXal2TkyHTFa5QwINTa1bJisd1d76PC2Xm8TI9oqfyoWCKNEgCgdAJYuKAfGNvwzPhePuXVEbjpQC+OMFs5Vvd2ILItcfx8ZMDDUoz1LShCMhj4x881h+AfLXcxPBBMcTPhfF1fJzFeG5oL0bnXf5YCChKLrWTQn2weVZEu/O52dtgzbRQTAz1wemVR3Q+UOyEPIwI9FA+FF7VsGFrqhx8AqEr0SlEHAAOXss32bkr6pqxcGcyvmaZL65tQxGQZ6kcu1GCSaE+rOLBdU3thVPXxuXG41lwsbNBVX2zxnkoqlHbpjrqy3j5/JlBOjNpnn3EVzlW8VB47adkqPpemaKVHIHQ1bD6cAogry48nllq8uv836/XGIdW9DWnUJScS2U0q3jw1rM5SgdAqYzGuVtlWPJ7mk4nwwaJVGeTDG0rYV1dgyaF+uDrWRHtMn1sbXgI8nJAQJuq00mhPnhicA8A8iybH18chrOLo4mAEwhGYvUr8bXxGUZVF7KhtqkFEauP4jOVHG1tnL9dxrjkfFiAG9zshYxK3OskUmw6eQv9vB01hmk0oS1UI+BR+OwfYQYLqabV+pt7UnCrpBb9vB3bjX9jXCD2JuejRUbjvb1pOPLWGDiIrf6fIIHQoVj1SlzSIjNawN+O6atzE68ttU1SLNTgvqe6qfj6T5cx+/skRucrqWkEn0cpy+eZ8O2ZO1iowRlQFyIBD4vGBWLr3Eew/LH+cBAJ0CKjcd7IFMq2q3UZTSPY2xF+GnqTBng64Pnh8hh9fmUDRq0/idvF3Gf/EAhdCateBu1IzDXq+G6OQiyKDkQ/bwe8t5edW5+q+562zUsmKEIpcWE+eDzdGweuFek9Rl8+uSZ+eHGYWjGNm70Qb/98FdfuVzEqx2fKmicGYkxfD9gJNf/TWvPkQHg5ifGfY1mobGjGlP+dxYE3RqFvt/YrdwKBoB+rFnGFF4qhNElpHMsowqRQH0QHd8Pg1Uc1bhxqQhEKOX69EFvP6zfg0kTb1LqNz0XgaMZhxpkqTNBmo6sQzaziGjyy5ige1D/sMmRMf85JbdIPNT0g/jk+CEHdHPDaT8loapHhxW1J+Owf4Zw8RAiEroZVi7jCC8VQquqb1crOXxndW2+JuCrGNmRW7UUJAMcyijgXcEDzxmWIjxNsbXhoaJapCTggf0C1Lcc3BF1+LZNDffCff8jTQvMrG9V+lqZq8kwgdEasOiau8EIxlLZNkBdFBzF2OOSCb8/kKGPrUhmNxb9f4/T8umx0P46/gYZm7Q8MY/tzMunoYyvU/M+PdP0hEJhj1SL++dFMo8+hmiXC51FYN30go41OLt72aQDL96VDKqNxIbscVQ0teo8B5FklunCxtcFPLw/XmMInldHYeCwLWxL0bwgb2rCBiV/Lyv3XtVrutn24EggE7VitiEtaZIyEiCmKghtFYYq2FTnV+ufN8UGcXLe0RoKotSew5xLzuHqLFmFTzG3dUwMxsrVaUpXD6YUYue4ENjKsVgWA//v1Kjb/nY0qFi3tmPi1FFU3oaiadP0hEIzFakV8R2IuuFykqRbcTAr1wZX3Y/F2TBBcbNXFXBGiYOrOx4SSmiZGWSkKfJzFeDc2CN5OIo1z0xQ+ib8m9yrX5+3dlvzKBqw/nIknN5/D7ZJaRsdw6UhI3A0JBN1Y7camsZkpChTZG0P8XJGYXa6WIfFmTF8sig7SmH7HpUUtBeisqGzLP6MDMWO4H14bp3lubTNCymua8M+fU1jPi0cB4b4uKKxqxJ3SOjz55Tnsf2MUAvQ8wLh0JCTuhgSCbqxWxI3NTFFAA4jo5YxhHx1HZcPDkIFqhoSmZgXDAtzQzVGI4hr2jYQVKB4gf74+AsM/Psn4uBOZJZgx3E9jIwhjctbbsmnGYMSFdUdJdSPmb7+Mq/ersHDHFeyaPxzuDiKtxymcC4uqGrX6tXRzEgGgUFytfYym1EgCgaCO1YZTZkf5g2K5uajtZg+mFasJOKA/Q+KTwzdQUqtbwH1dxXC31x5bB+Tpf92cmDduBoBTmSWY+30S/korUPtcW0aIIcwf7Y+4sO4AAC8nMb6Z/Qg8HUW4WVyDD/Zf13ksn0dh2eRgrW8XNICVUwdg5dQQANw2eSYQuhpWuxIXCnh4eVQAq81NNhnYNB6aVCkqMxXo82uxE/Lxn2ce+qtoWh0b4+AnpYHTWaU4nVWKdwVXYcPnoYeLLW6V1LAKy2hj/ugALJsSovaZt7MY388diqlfnsXBa4XwccrAuxP6wVZDQ4618Rn4loEdgjbLW+JuSCAwh6Jp2qJyuKqrq+Hs7Iyqqio4Oelv3PDiDxdxKrPMpHPaPT9SGbZokEgR8sFhvWL5+dNh6O5qpzVO3bYqMTW3Ek98fc6Ed6EfN3sh1kwLRVyYdvH89EgmvjyVDQDo42mP7+YOVYuRMzUk83EW4+ziaPB5FCrrJQj/8BgAYMucRxAd7EVW4IROA1tNY4vVrsQVbHthOEatO4H7labLYlBkSBxOL8S/frvGaLX77m/ywh03exs8Gd4DMSHeOsvJw/1dWM3J3cEG/b2dUVbbhJyyOqMrPd+OCcKi6CC94vmvicEY4ueKxb+nIbu0DlP+m4C10wciOtgLIgGf0QockKcPLtp1BXOiApQ59z7OYsSGdDPqPgiErobVr8QBeTNjY0vgdfHKmN6I6OWitcEDU5iUk/svOcj4fKpvCMb8DFxsBVj3FDNLWsUbxa2SGvx4PhfZpXXK79kL+QaZcznbClDV0ILRQR7YMW846+MJBEvG1Ctxq93YVGVYgFu75gRc8u2ZO1obL7CBSTl57ropeHygJ8PzNSj/X18vS11UNbQwKnM/nF6IUetPYsaWC/hg33Vkl9bB1oYPz9ZMFUMEXHF9AKQ6k0AwgE4h4nwepcx0MBVts1cMgWk5eXgvD0bnU7XOVfSyBNpne7CZl6RFhnO3y/DZkZv47Egmzt0qg1RGa818aWyWorS2CZG9XcE38l9Ten4VEXICgSWdQsSBh+3CRALubsnFzgZ7XxvBWU46wKyc3E1HDraucYpsj25tKjl9nMV6bQIU84pYfQzPf3cRm07dxqZT2Xh+60UMWX0US/7Q3gIOAC7ceQAnsXHmYdWNLaTMnkBgSacRcUAuYhkfTsI/x/UxelUIAOumD8TgXq5Y91SY8Sdrw+2SGuSU1aJZ2n5DkmloyNtJjF8u3cOavzJQ2BpamRTqg7OLozGunyc2PjsIu+dH4uziaAR4MHsQ1Ta1N+GqbGhBJQPvlJEaiqLYQsrsCQR2WH12Slv4PArvTAzGm7H98OaeFPx1jb2dadsNSH0ViIawfN/DgpnpET0wa7gfzmeXoZe7HaYM7A4fZ7HOoh1FQ4k/U/Lx8+V7KKxqxBfPhUPA56GmsQWu9kKM69cNzq1GXi52Qo5mrp3YAd7o4WprVMs8UmZPILCj04m4Aj6PwqaZEXASX8OupHuMjnlppD9iNaQCKuLNr+5MZu1zogkeBTXzrj+S8/FHcr7y67T7VcrrabtWSU2jvCvRQG+0yGg0tkhRUtOE7i62cLUX4j/PhKuNHx3kqffBYCxejmJMi5N3tGcr5KTMnkAwjE4VTtHEvQcN+ge1cii9SGsutyLe7O2svlJ0EAlgp6FqURMKq9ivno/A9VUTceSt0XgvLhjBKp3heRSwJSEHf98sbedSqIpUBizcmYymZik+f2YQvpwZge4u2sv3+TwKUweZrgJStdXc0rgQZK2ZjOH+royOJWX2BILhdIo8cV0s/zMNOy7kMR6vmnutCU2VlwCUn3k4iAAaOJFZjD9TC9QySLTlictkNKobm7EvNR8rtDRK0IatgEL6h5P1ip9URmPU+pMmW4l/rcUCV9Iiw47EXOSW1wOgUVLdiCMZJWpjSDs2QmeGVGwayXtxIaxEXN/GmibnQADtPhsZ5IFlU0IYdZHn8Si42Akxd0QATmSWIO1+FWqbWtAs1f98bWihcf5WGUb3051brq9RgzHMG+mvVYCFAh7mje6t9tl3CXew5uANAMAT4d3xweMD4GZv+pg9gdAZ6fThFFshH7EhXozHezBM72OCQvCnhfdAVB93RqGC7S8NR8oHEzA8gHmmx+8p9/WOOZ7BvOkEW8YEMitOUvDy6N6YNyoAAPBnagEiPz6BN/ekIJth0wkCgfCQTi/iALBlzlCE92T2GiNpNqzqkGtsbZj/1aTkVer8vlRGY29qvs4xxvDi9kv44vgt7EvNR2J2OaOCnfen9MeqqQPg6SiCRCrDvtQCxPznNOb/eAlV9YZ7tBMIXQ2jRHzdunWgKApvvfWW8rPGxka8/vrrcHd3h4ODA5566ikUFxcbO0+jcWBYiLL1HHd9O41hAgsjqLsV9Vgbrz2WnpRTgYo6/XnePAr434zB+Onl4Vg0LhCLxvXBlIHeeo+T0cCG41l4c08qZmy5gFHrT+ot4acoCnNH+OPSshgcWDQKvT3sQQM4dqMEYz49heMZHf9vhkCwBgwW8UuXLuGbb75BWJh6Iczbb7+NAwcO4Ndff8Xp06dRUFCA6dOnGz1RY6liWDbPdJyp6enGrofnt2dyINHiZMi0gGZOlB/iBvqAR1EI6uYAGz4PB9PYh2GYeMSoMrCnM46+NQZPDu4BAY9CVUMLXt5+GceIkBMIejFIxGtra/H8889jy5YtcHV9mEZWVVWFrVu34j//+Q+io6MxZMgQbNu2DefPn8eFC6ZzGWRCWE9nTseZmmEBbqw2+2gAW89ma/we0wIaVzuR0uDqzT2p2HD8FuPrt50LoN8jRhWBgIcNz4bj6opYPD2kJwDg/369ivsPuOmlSiB0VgwS8ddffx1TpkxBTEyM2udXrlxBc3Oz2ufBwcHo1asXEhMTjZupkbw/ZQCn40wNn0dhzbRQVsesP5ylMazCxOHQxc4GG49ncZbBwsQjRhP2Iht8/ORADPOXO1N+d+YOJ/MhEDorrEV8z549SE5Oxtq1a9t9r6ioCEKhEC4uLmqfd+vWDUVFml/Lm5qaUF1drfbHFAgFPL3mWCIBD0IODbSMZWKoN+wZFhIp+OZMTjsh1+VwqPq1KQoGDPFCEQp4WDi2N24W1+CHxLvYnpjL/cQIhE4CK8W6d+8e3nzzTfz0008Qi7nxuFi7di2cnZ2Vf3x9fTk5b1uScir0dr9papHhwp1yk1zfEJJyKgzy6N6S0D4+PinUB189P7idw6G3sxhvxwQxMrgyhNwyw8Ih0f274d0JfQEAK/Zfx1enbhObWgJBA6yKfa5cuYKSkhJEREQoP5NKpThz5gw2bdqEI0eOQCKRoLKyUm01XlxcDG9vzVkOS5cuxTvvvKP8urq62iRCznRF+PKPlzBloA/sRAL4udlhdpR/h63ODXX0k9HAjsTcdkU2wT7OOPnuo7h6v0qtAOmvawVcTFcjG49noZ+3A+tqzMPphfjpwl0AAE0Dnxy5ie2JuVg5dQCp7CQQVGAl4uPHj0daWpraZy+++CKCg4OxePFi+Pr6wsbGBidOnMBTTz0FALh58yby8vIQFRWl8ZwikQgiEXcFNtpgurnX0CzDbypmVGsO3sArYwKwNM60TSc0YYyj392K9itgRUNj1epSqYxGWU2TwdfRBw1gyR9pcBTZILL1urqqWOslLdhy5o7GTdWi6ia8ujMZm7WU+BMIXRFWIu7o6IjQUPXNNnt7e7i7uys/nzdvHt555x24ubnByckJb7zxBqKiohAZGcndrA1AsbnHduOOxkNHPnML+bAANziKBahpbO/xrY/kuw/wyvbLGOrvirkjAiAU8NAgkeLj+AzkltfD390OQ3u5Yu2RmyZ1NgSAyvpmPL/1IlxabXFVQzdtfVMSskp1ZsXQkGe9xIZ4E7MsAgEcGGA9+uijCA8Px8aNGwHIi33effdd7N69G01NTZg4cSK++uorreGUtpjSLOZweiEW7kw26FgKwM01k80eWjlwtQBv7E4x6hwUgF7utrhbztzRUfVYAFgUHYic0hr8lcZt7rbi/IrV9eAPj+IBg/i8PqMyAsFSMLUBVqd3MWzL6gPXsfVcrkHHxvT3RHcXO7PHyudvv4RjbZz/zEXblfLUTQm4dp/7DCKxDQ8RvVxxIbscuref5Wx4ZhCejOjJ+TwIBK4h3e45JiaE2RuBJo7fKMX2xLtYffAG+r5/CJM2nuFwZtp5qoPEavmU/ji7OFot/rx/0WiEMfShYUNjswznGQo4oN4kmkDoynQ5Eeeyc0xmUY1OzxIukMpoLPkjTf9AE+DhKNIYd96/aDTSV05EbH8v9PN2xKBWUTdnhJppM2kCobPT6f3E28LnUfB0FKK0hpuV3JaEHLw7Idio0IqmRhMK8dx08pbJcrj1oSs7xkEswJa5Q5VfH04vxKoDGSbfJFXAtJk0gdDZ6XIiDgA9XGw5E3FtOdlM0SR+3k5izBjWC73cbPFtQseUnfuw7Hc5KdQHsSHeuHCnHK//lIxKExqJsZ0bgdCZ6ZIivmXOIxj60QkAQLC3I2L6d0N2aQ0OpRuWeaEpJ5sJh9MLNTZDLqpuxIbjWQadkyvY9LtUTV30c7PFrOG9sOlvzWZc5p4bgdDZ6ZIi7ukohljAQ2OLDMXVjfi/if0AyEV15f4MFFWzCwn01NGgWBtSGY1VBzJM4ldiLG/HBOktplGEgD6Kz0B6/sNslQQdx9iL+Khvkhp8z652Nlg7fSAp9CEQVOiSIg4AYiEfjS0ytXjzpFAfRAd3Q+Ta44yaKCgwRJRM2fPSGHycxVgUHaRzjKHx77omKexs+KhvlkJswwOfohh5w0wb1B3PDPVFZG9mLe4IhK5ElxXxpmZ5MltbAb5y9wErAQeA/Er2RTSG+qKYGl2hCqmMxqaTtwz2GQcAO6FcxJ8b2guDe7ngnV+u6jS2crWzwX+eDSfiTSBooUuKeINECjshDw2t/TT/SrmPxwbLc7ENEVc/NzvWxxjji2IqnMV8raGKw+mFWLHvOoqN8Fl5L64/HER89HCxxdh+XqBpGh/su66zm9La6QOJgBMIOuhyIq6p+nHRz1exL60QW+YMZS2uPAqYHeXPeh4KL5eiqkaLiYtXNUpRVd8MZzv1fqTG2BWo0s1JhGnhPZRfy2jgy5kRqG6Q4MO/bqjtRbStFCUQCJrpUiKuq3z9WEYJ5m+/hK9nPcJKXOePDjAoR1zRqOHVncmgYJqGDIbw0g9J+P21kcqvuSw2avuA5PMojAryAABMDPXB+ewy3KuoR4CHQzt3QwKBoJkuU7HZIJHq9R85llECSYtM2QWHCYN6uhg8p0mhPtg8KwLezpYTWilos1l5Ibvc6GIjCvpzu3++dA8fHbyBHRfyMCzADedvleGtPSl4ZftlfHs6W2sTaAKhq9NlVuIr96czHrf+6UF4K6Yvo1ztRbtScCvUx+BVo6JIRlGxmVtWh91JeSiqNp3Hty66t3mg/HQx16jzKX4qmjZMGyRSrDlwHedzytEipXHvQQPsbHjo81682rijGcX4+FAm5o/2xzIL6YFKIFgKXUbEj2YwK+Q5mlGM9QB6uTHL/ZYB+DujGONDDTfW4vMoNVvVRdFBSMqpwP2KOvzrd/P6pnz/wjDl/x9OL0S8gQVQChxEfAR42GFn4l2k5lXC1V6Iivom/HLpvkbL2fpm7SvuLQm54FFUhzToIBAslS4j4lIZs9dxxTg2Lnlv/ZqCtNDJBs1LE0pR7+OOIxlFOH6jlLNz68LP3Va5qakoRmKDgEdhRB83zBvZG9sv5OJEZilqmqS4ll8DADibbXz/Ui68agiEzkSX+U3wZOh65+kgQkreA3xzhnnZeE2TzGQx23mj+pjkvG3xc7fF6X9FK782pBhJKqNx5lY5lu1Lw4lM0zx4FF41BAJBTpcR8Uf8XRmNG+TrjANXC1HC0iDrexMZVZm6KMjPzRZXP5igJuCGXleRYXP/gWnnbKhXDYHQGekyIi4U8BmNsxfZ4M2YQNgLmY1XsO7ITczffsmQqemEad66ocl4c6L84SBuH1WzxGIkBfVN7HuOEgidlS4j4oN9ma3E+RQFZ1shrn84CV/NHMzqGscySvD05nPYm3wfW87cwSeHMvHWnhR8cjgT526X6Swv18awADdlg2FdqJ65t6cdbnw4CWIGcePVB29g1PqTOJxeqPb5g7omWGqa9m/J+e3mSyB0VbpMj83E7HLM2HJB7zg3extcWharTIdbc+A6vjOwJ2dbXOxssI6lC1/8tQK8viuFdTFQWE8nvPZooEar27Yoio0+fjIUsSHeuHK3gtFxHQUFwNtZjLOLo0lBEMHiIT02OWJYgBvc7IV6x1XUNSMpp0L59fuPD0BMfy9O5lBZ34yFO5MZryIPpxfiNQMEHACu3a/GqEBPxITon7vi/O/tTcfwj49jye/XLFbAAfl8C6sa1f6eCISuSpcRcT6PwhPh3RmNbbup993coZg/2p+zuaw6kKE3tGJIil9bZm5J1Ful2pZuTmJUNlhHzNlSnSAJBHPSZUQcAGIZdrp//890vLgtSS1tcNmUAbDXH5pmBJNVJBd+49dUmjUwpYeL5W5otsWSN18JBHPRpURc4Ryoj5rGFpy6WYoZWxLVPmdpM66Ts7dLsS81H4nZ5cpVuVRGIzG7HPtS83HutnkKfNoy2USugW52Nhjfz5OTczHxYiEQugpdpmITeOgcyNRW9crdSrz7Syo+eXoQ5/HXL089LCbycRbjsTAf/J6cz6pS1BQ8PcQX353N4dQiN6a/F76bOxSJ2eU4cdO4h5MuLxYCoSvSZbJTVPnieBar7jRCAc/qXPR83US4V8HeRMtRzMfMYb3w7ZkcTkT8v88MwtQIecMNqYzGqPUnjXpAiPg8DPJ1xhvRQRgR6EGEnGDxkOwUE+DvYc9oHNWqD9Ym4ABA0zx4OejPxmlLTaMU357JwStjAmDHsuBJFR9nMb6eFaEUcODhmxBgeHFSk1SGpNwHmP19EsJWHiH54oQuT5cUcaYbYk4i6/3xFFQ2YExfw2LQNIA/U/IhZljl2pYhvVxwdnG0xnx4bR7qjmL216qTSFmlbBIInZEuGU5RvNbryv5wtxeivIPj01xAUfJVrwHFogaTvnKixlJ+VaQyWumh7uUoRnxaIXZcuGvQ9XxI4Q/BgjG1pnWpjU0FfB4FoUD3LzzVSfSApuUr62F+Lki6W2ny64X1dNIr4EB7D/WMgiqDr6lI2VQ9H4HQVbDeeIER1Da24G55g84xZbXWvwpXxRwC3tvDDvsXjTbo2NlR/kZ5tZy7XWqQNw2BYO10SRF/++cURuMEPMM34LoaQj6FNU8MNPx4AQ/zRwcYfPymU9kajbwIhM5OlxTxvAe6V+EKWmTyUAQRcv1IpDSe33oRNY3MKqJUC5sUBU9L40KwYIzhQl5U1YhXyUYnoYvRJWPivVxtcbOohvF4Y1/S+RRwdcVElNQ0Ivrz00aezXKhaWDLmTtYFB2k1j5N0iLDjsRc3K2oh5+bHbycxPg4/obaxrKPsxgrHg/B0rgQuNuL8PGhTPbXh/yBu+pABmJDvMlGJ6FL0CVFfMOzgxG68gjr42x4FJoNiLtKaeDq/UqMbC1O4Tp2GxvsiWMmaofGlv+evI3/nryNFyL9sPKJUKyNz8CWhBy92TGKVfTmWRG4x/BNSROqDodko5PQFeiSIu4gFqC3px3ulLJr82WIgCtIzC7HyEAP9PGwR1ZJrd7xdkI+6iVSRue+cq8So4M8kHCrzOD5cc0PF+5i16U8SKTMfmaKUUwtEfRBHA4JXYUuGRMHgGNvPwqBAa/bkQHMOgS1Ry5TG2eEMxpdL5FiykBmrosVdc2wszG8utJUMBVwU0AcDgldhS4r4nwehU0s268BgJOtEF/NjGDUYEKVqN4eAIAQH2cMY9i0ecIAb8yN8mM09khGMav5dGb4FIjDIaHL0GVFHJCXgH89K4KRPa2C+qYWTAz1xqVlMdg9PxIbng2HiEEvy9sl1cosjJGBzMrhvRzFrFq5EeRIaev0uyEQDKFLlt23RSqjsTXhDuOMCEUmhUJgD6cXMo7ldnMUorZJijo98W5vJxHOLRkPAHotAgjtmR3ZC6uNyFsnELiCuBiaAT6PwrzRvWHP0LWvsKoRC3cmI/5aAYCHK3pvJ5HeY4trJHoFHABmDOsFPo9SOv9RIPnqbLh890FHT4FAMAtExFvh8yh8/swgVscs2p2CA1cfCvm5JeOVIRYHkXEbjcduPIxxa3P+I2jHUdQlE68IXRASTmnD4fRCrNyfgaJq5uGLBWMCsDQuRPn1uVtleH7rRaPnMqK3G+xEAtCg4SiywZPhPZB8rxJbEu4wTj/saBxFAtRJWtTyxHkUMHeEP7adyzXZdW98OAm2RvihEwhcQVwMzcykUB/Ehnhjw7EsbDp1m9Ex35zJQXJeJf4ZHYThvd3x65V7nMzl/B31lnB/phZwcl5zYWvDQ9qqie0qNmdH+WNHYq7JrhvgbkcEnNBlICKuAT6PwshAD8YiDgCXWrvNEOS42fKRvGISALm51QsjA5T+4YfSCvDD+RyTXXtKWHeTnZtAsDSIiGthWIAbfJzFJCvEQCoapJi//RK2zBmK+GsFWPZnOh7UMzPHMhZSbk/oSpCNTS2o9oMkqNPb3ZbRuGMZJVi9Px2v7Uoxm4C72tkgsjcRcULXgYi4DiaF+uCrmYM7TZcfrrijp6GGKlvPG9ZyzVDWTh9I3AsJXQoi4nqIC+uO/z7HvjyfwBwuJNfbSYS3Y4LQ1CJTVsYyxcIStAgEVpCYOAMeH9Qd6fmV+OaM6TbjujKPh3lj/7Ui1sctn9IfHo4i5JbVY3dSHjYcv6X8noutDV4cGYBF0YE6V+YtUhn2XLqHCSHd4OkoAkVeuwhWBlmJM2RpXAi+mjkYLrbkucc1BVVNBh3n4yyGSMDDxuNZ7fL6KxuaseF4FoasOYbD6YWgaVrjinv/1QK8/2c6hn18glVtAIFgKZBiH5ZIZTTe3J2Cv9JICzCueCK8u8E58CIBD00szK6eGdITlQ3NWDC2D67kVuDTozfRLKUxrq8nvnthKImnEziHeKdYGHwehU3PRyCil3NHT6XTMC28O2z4hoknGwEHgOzSWhzNKMZTm8/j40OZaG71PD+VVYqBK4+Q/pwEq4OIuIH8unAkbMhPz2hc7WzwcfxDMTUlC8f2ga1Q+19avUSKhaTRMsHKIDJkIHwehUXRQR09DauHBnCrtV2drQ0P3RzZNdtgQ5CnPc7drtA7bsW+dM77oBIIpoLs0hnBouggbDufi0ozFbJ0JnycxaAAFLRWxPo4i3Hq3bGwEfCV5fllNU1YffAGZ9dMvV8JJtJcXCMhjZYJVgNZiRsBn0dh3XTSeIANT0X4YPmU/jj9r3FKS4PRQR5IXDoeYqEAfB6FqD7umBbeAy+MDNDZdYkC4GJnozfPnAJaz8M87k4aLROsBSLiRqJoCOFiZ9PRU7EKfk8uxOqDNxC+6qhyVRzRy0XjWD6Pgp2WjQeFHK+bPhCbdfz8FeNWPB4Cf3c7xvMkjZYJ1gIRcQ6YFOqDK+/H4vVxfTp6KlZDffNDP/TYEG+NY+K+OIPssnqN3/N2FmPzrAhMCvVR/vzfjgmCi62N1nGzo/zBJIPQWcwnjZYJVgOJiXMEn0dhVKAnvjyV3dFTsSrc7G3Q36d97uzEjadxs6hW+XW4rzMWT+qPkppGeDmKMSzATS2nm8+j8GZMXyyKDlLG1NuOEwp4mD86QG/lbVWjFMcyikiTaoJVQEScQxT2tUVVjYw20AhARV0zHllzDJ88MRDRod7g8yjM2XpRTcD/91w4Hg/vweh8ipi6NpbGhUBGA1sSdAv5qgMZiA3xJsU/BIuHVThl8+bNCAsLg5OTE5ycnBAVFYVDhw4pv19UVITZs2fD29sb9vb2iIiIwO+//875pC2Vzm5fOzpQszhSbf7Llgf1zZi/Kxl93otH4HvxOHOrTPm9bS8+wljAmRId3E3vmMKqRiTl6E9HJBA6GlYi3rNnT6xbtw5XrlzB5cuXER0djWnTpuH69esAgDlz5uDmzZvYv38/0tLSMH36dDzzzDNISUkxyeQtEUVTY2MbJVsifb0c8PIof7jbq+dyezuL8dXMwdj58nA4iY277xaV/Oy5UX4Y10+/4LKFaebJsYwiSGU0ErPLsS81n7U7IoFgDoz2TnFzc8Onn36KefPmwcHBAZs3b8bs2bOV33d3d8f69evx8ssvMzqfpXunMOWTwzfw1d93OnoanHPxvfEorm5EbWMLSmub4OUoxoM6CVYfzOC0C9LZf49DTzfm2SRsSMwux4wtF/SOs+FTcLcXoqj6oUGXj7MYKx4PIfFyAmMs1jtFKpViz549qKurQ1RUFABgxIgR+Pnnn1FRUQGZTIY9e/agsbERjz76qNbzNDU1obq6Wu1PZ2BkH8+OnoJJ+OjAdfh72GNEoAemhfdAVYMEr+9K5ryN3b0HzBtPsGVYgBsjN8pmKa0m4ABQVNWIV0lpPsGCYC3iaWlpcHBwgEgkwsKFC7F3716EhMjjwL/88guam5vh7u4OkUiEBQsWYO/evQgMDNR6vrVr18LZ2Vn5x9fX1/C7sSAi+7h3ypDK/rQi2AvlAnjudhmW/5lukk1cUxbb8HkU+nZzNOhYxb2uOpBBQisEi4C1iPfr1w+pqam4ePEiXn31VcydOxcZGRkAgOXLl6OyshLHjx/H5cuX8c477+CZZ55BWlqa1vMtXboUVVVVyj/37t0z/G4sCD6PwidPhXX0NExC4HvxCF1xBM9/dxGltRKTXENTsQ2X8WljirNokI1PguVgdEw8JiYGffr0wb///W8EBgYiPT0dAwYMUPt+YGAgvv76a0bn6ywxcQUfHbyOLQm5HT0Nq8KWD6SvjlNL7zucXohVB9Tj7sbEp7ecuYOP4o3zZfniuXBM05A5k1dej/rmFgR7W/+/X4LxWGxMXIFMJkNTUxPq6+WVdTye+in5fD5kMnaez52JZVMGYP7ogI6eRocyzN+F1fhP/xHeTsBf3dk+7m5MfHruCH+jG2BreluoamjGc98mYuaWi7hZVGPcBQgEBrAS8aVLl+LMmTPIzc1FWloali5dir///hvPP/88goODERgYiAULFiApKQnZ2dn4/PPPcezYMTzxxBMmmr51sGxKCL6aGQGRoOsVjtgJ+Ui9X8V4vA2fwoWcCkhaZKiok6CyXoIV+65rjLsbE58WCnh4xcCHq8JQS1Np/rnbZSioaoRIwIMr8dMhmAFWFZslJSWYM2cOCgsL4ezsjLCwMBw5cgSxsbEAgPj4eCxZsgSPP/44amtrERgYiB9//BFxcXEmmbw1ERfmg/zKBqNf4a0NVzsb5Fcy36RsltLYeTEPOy/mMRqvGp9max07uJcrAHbNr1UNtTRVc1bUSRDV2x1Twnzg5URMtAimh/TYNCOSFhmClx9CV0lqoAD8vCASV+9VwdtZhD9TCnAptwLVjS1aj7ET8lEvkWr9vja0xae1IZXRGLX+JOvUSG8nEVZOHUDyxAmMMbWmEe8UM8LUgKmzQANIu1+F+WN6AwDiBnbHhTvl2HnhLs5klaJORaxt+BReHdsb70wIRm1jC47fKEZRVQOaZTQ+P5ql91psrWOTcioMym3//JlwjAz0YH0cgWAqiIibmaVx8pz6riLkvyffx7zRvTVml6jSIqXxv5PZCOnujEmhPnhisHxVLZXR2HUxT6fgaotP68LQPPSy2ib9gwgEM0L8xDuApXEhyFozGUN8nTt6KiYno7AG87df0phdooq2TUo+j0JoD92voKE9nFi7DRra9CG3rM6g4wgEU0FW4h2EUMBDSA9nXLnHPHPDWjmWUcJonGKT8kJ2Ofp3d4KjWACaBo7rOf5YRgkkLTIIBczXJIbaBu84fwd2QgHuPaiHn5sdZkf5s7ougcA1RMQ7EKll7SlbDKdvleDny/cQ0t0Jt4trGInsjsRczBvdm/E1FLbBr+5MBgUwFvKyeqlahtFH8Tcwf3SAMkxGIJgbIuIdCN/YapNOyret+wXVjc04n13O6Ji7FZrbuOlCYRusK1avDxn9cH+jrZBLZbTWLkMEAlcQEe9ApF24klUTFOTe5AO6O+H4jRL8fbOU8bG+robZ1k4K9UFsiDciPz5ulA/MloQcvDshWBlaMdQmgAg/gS1ExDsIqYzGb1fyO3oaFseKx0PQy80ex28wi6MrCDbQlRCQh1ZeHBmAT47cNPgcMvphSEdhE9A2RKOwCVA0bm7LtnN38J9jt1CjkkdP/MsJ+iA7Mh1EUk4FJFLzxsRtbXjYNvcR/DRvuN6MD3Pjo9KVPqS7E84vicbA7syFuayuySiHw5dZxNO1kVteB6mMxqoDGaxtAn5OysOqAzfUBBwg/uUE/ZCVeAdhSr9sTVAANjwbjnH95e3O/goajdrGFjyy5igaW0z3MNFXgWkn5GPLnEcQ2dtdLWzg4SBCWgFzA6nVB2+gou5hOITtClYo4GHBGOMKsQoqG/UWEWmyCZDKaGw8cUvreAqkcTNBO2Ql3kEYmqdsKF/ObP8K7yAWYONzg012TXd7G70l9PUSKXgU1U6cdiTmsrqWqoADcqFku4JdGheCBWMC0FYnme4/P9rPi/HDWXUcG+EnENpCRLyDUOQpm4uNx29qDDFMCvXB17MijGqSYCyahM+QbBNNsHU4XBoXgszVk7F8Sn/MifLD8in9cXP1ZCwYo9vxcMGYAMyO8sPxjCJG11F9iBsi/ASCAhJO6SBU85TNERnPKqlDyAeH8cVz4e1W5IoMjQvZ5Ui8U4aDaYXIKTNeRJkaWXnYi5CYXa6WkVHT0Gz09Q11OBQKeO1yzhXpg1sSctQMzHgUlHnia+MzcOCafhF3sbNRswlg+lZm7rc3gnVARLwDUeQpv/VzKhqbTZ9u2NQiw8KdyfhaQ3YEn0dhZJAHRgZ54P6DBk5EvIHhPb22KxlVKqLtbCtot8FnDFytYJfGheDdCcHYkZiLuxXqFZuSFhnjeHpLs/oDSl/1qCL1kq0/DKFrQMIpHcykUB98M3OIWa+pL8Tw1OCeZpwN1ARc/nULZDTg5Sjk5Pwe9iJOzgM8XKV/OC0U80b3VuaFs4nh1zZDLb6teCsDHvqVK9DnX04gEBG3AEb184SdkG+26+nbJBsR5GHW+WiDR1EI4yIV0gzaxzaG3/btQPFW5t1mn8RbJfWSQNAECadYAHwehdmRvcxqT6srxMDnUfjPM4OwcGey2eajiaLqJmx4djBOZBRh67lctVADjwLG9vXEKQZVnSXVpt8Q9HNjVzHq5SgGTdOgVFJfFHsTpGKTwAayErcApDIa+6+at5hD3yaZImulG0chDUMpqWnE+48PwM016hkjmasnYxTD5gxt0w9Nwewof8ZjbfnAh39dx+Lfr7X7Hp9HIaqPO6aF90BUH3ci4AS9EBG3AAztMmMoTJsoTAr1wfmlMYjt72WGWWlG8bDRFIu+/6CB0TncHHTHxIuqGhDywWGczmJX6q+KomsTE/gCPmoaW5CeX23w9QgEBUTELQBz5/8+N9SX8Vg+j2oXp9XHsrhgfDUzgu202qHrYXM4vRDbzucyOo+3jobFr/90BXH/PQtJiwwbjulvA6eLZVNCEBui/4FX2yRF/oMGLIruY9T1CASAiLhFYO783w3Hb2HU+pOMqxn93e0Zn5sCMCvSH3FhPnoLZPQxdZCPxnCCwp+ECboeBKdvluBgWhEq6iRokdFYNC7IqPkCwJY5Q7HpuXCIGPxmrf7rBmuPFwKhLUTELQBFnrA5o59sjJVmR/m3K0XXBg3g0U9P4XB6IZbGheDN8YEGz/GbMzka58cm/KQpNa+wsgFzvr+IRbtTlJ9tmjEYMSHdDJ6rKo+F98D3Lw3XOYaU0hO4goi4BaDIEzbnmoxu/cOkLJ1NvBcAimuasLD1AdHb08Goea7c335+TMNPL0T5If9BAz7Yl46tCXcgaZEXH41cfxJnssrUCop6uRvmR64Npg2VSSk9wVhIiqGFMCnUBy+N9Mf353LNet3CqkZsOnkLb8b01TrmVGYJTrD09waAN/ek4rs5jxgzPRRVty+bZ9qs+MfEu2oPxo/ib2DqIG+1snkbPoUnBvdAWE8Xo+bZFlJKTzAXRMQtiNgQb7OLOCCPkffzdmxXUHIltwIvb7+MB/WG+Zg0tcjw2dEb+gfq4ZdLeRji5wqhgAepjMbupDxGx7V9v5DRwJ+pD71NctdNMXpu2iCl9ARzQUTcghgW4AY3extU1Blv/sSWt35OxT9ul6OXqxhNUhq/XL6HvIoGOBhZuXn1PnNPcG3sTS3A3tQCPDesB6YN8kVRNbNQRUfCpBEzKaUncAGJiVsQfB6FNdNCO+Tajc0y7LhwFx8duonPjmYhr0Keg93L3Q4zhzFPSTQle5LyMXPLBU7O9cIIP07OowtFKb02C4OUvAcmnwOh80NE3MKIC+tudGoeV/T2sMNfb4zC44N6dPRUlHC1+WuuzL6UvAeo02DJS0OefbM2nlmqJIGgDSLiFsjSuBB8NTMCYpuO/evJLa9Hi0we5tFVMGONsPU6MQRJiwxbEnT74WxJyFFmzRAIhkBE3EKJC/PB9VWTsOOlYXgyvDsmhHTD88PNG9ZQdHDn8yisnBpikmvYC/lwEpnXMZFHsfM6MZQdibl6V/yKnzGBYChkY9OC4fMojO7ridF9PQHIKxV/unjPrHNQWKwqDLGW/JGGSgOzVTSh6P7zdkxfJNwqweW7lZydWxvzRwcofcBNCVN7Wq5a0RG6JmQlbkXweRTWTjfvxmdd08OCmEmhPrjyfiyWxfXn7PyKheqeS3l4g4Oyd13wKHkvTEWrNVPDNGRT38RdFyNC14OIuJUxY5gfhHzzpaUduV6kVjHJ51F4aVQApzYBihJ0gQlWxzZ8CjOH+irta80l4ABzu4LfkvMZ+9gQCG0hIm6FZH0UB7EZwgGA3HHvwp1ytc90tRNTENqdfbn9yRvFeMsIrxVNjOjtjo+fClNrpcaGN3Ynw3/JQfgvOYiAJQfx0cEM5JTWQibTvxkpFPAwO6oXo+t88GcaMcMiGAQRcSslc81kXFgyHm62pt8UPJ9d1u4zbe3EFPTxcsKNDydhdmQvDGTYYm3ruVz07eYEew5bw2UUVRuc/bFg+2UcUGnWQUOeTTLu89Po/d4hzPruot5zFDxg5o1SUttMzLAIBkHRNG1Rj//q6mo4OzujqqoKTk4c9FfsYoxYexwFVdxWNNoL+fj8mUEa+zxKZbRaO7EfzufgyPVi2PAppH4wAfYiAaQyGqPWn9Ragq6Kj7MYA7o74bgBXi3a4FHyzUxNoZSc0lok5VYg4VYZSmqasHhSMIb4uaKsthGPrDmh87z/eWYQpkfobio9ceMZ3CxiVrX6xXPhmBZuOTn5BG4wtaaR7JROhKRFxrmAA0CdRIpXdyZrbNiraCemYGAPZ1zKPYWKOgm2JNzBWzF9leEXJj07C6saOe9yJKOh7F+6NC4ENE0j8U45vv47G+dul0Oqso55avN5AEB3ZxEoCqBpYM/8SES23mNWcQ1yy+pQVN2IyaHeeq/dy9WWsYgTMyyCIZCVeCdBKqPx4rYknLnVPvTBBQrDprOLo/X6fRy4WoA3dqfAXsjHqX89qhSnDw9c7xCDL1X83e1QWtuEuqb2VZRtGdXHHV89HwEnO8P7jNY2tiB05RG945zFfFx6f4JZUh8J5sXUmkb+xXQCDqcXYuS6kyYTcIBdE4PHwnwwyNcFdRIp1sZnQiqjkZhdrtVDxJzklte3E/CXR/khd90UJL03HhNVGkNcuvsAi/aktD0FKxzEAoT11P+LW9UoxdjWZhoEAhvIStzKOZxeiFd3JputoQTTuO3Ve5V44qtzoGl0mDMjG9rmj+9PvY/dSffx8ugAjO9vfMefqZsScO2+7sbIivcbTWErgvVCVuIErSh6TXIh4G52NozGMY3bDvJ1weggDwCweAEHHnqYFFY14MmvzuGva0WYFenHiYADwP5Fo5G+ciJigj21/tIp/h6ZdFtqi+JtZ19qPhKzy0m6YheCbGxaMWx6TerDydYGoLQLLtsmBlIZzXhDzxKQ0cCo9SdRUvNwY3hwL1dOr+EgFmDe6D44nlmqdYxq2Ep1w1gXh9MLsepAhtq/BR9nMVY8HkJW9F0AshK3YoqqGjg7V255vd4VM5smBkk5FShm0LzBknoiqAr4I36ueHYo94ZjTHtqMh2nCKe1fZizaYRNsG7IStyKqaiTmOU6Xo4ivD+lP6tVHVMRorS1velALi2LgaejyCTnZhqO8nTQf31d4TQa8renVQcyEBvirfPh2zbXf1iAG+k4ZEUQEbdiXIxIfWOCnZCHeSN7463YvqAA3C2vg5+7PaNjmYqVlGExZTdHIUpqJCbX+77dHPDfE1l4Ly4EtibIptHXe1NBfFohRgR66DyXvnAak9AMCcVYPyScYsVU1pt2JV4vkeF/p27jk8M3QFFAVQPzDUqFWHGxnlswJgCrWtvWmXp9mFVcix0X8tD/g8OYv/2S8vMGiRQyDjYLdfnOUCr/3XkxD7su6m4IbWxohoRiOgdExK0YZ1tmGSXG8s2ZHBxKK0SAB7NVOMDMJIsJAh6FpXEhSq8WZ4ZZNFxwLKME8364iNd3JWPEuhO4wlFPTG2+M97OYnw9KwJvjJdb8i7fl47bJdo3h5m+7Wgapy8UAxiWJUMwP0TErZhkA0TF3V6It8az9+1e9mca7ITsom/6TLI0MWt4L8yJ8lN6cbvZPwwZxYZ4Qywwb8HQicwyHLxWiAf1zXhl+2U0aOiXaQiTQn1wdnE0ds+PxBfPhWP3/EicXRyNSaE+eGt8EKKDvSCV0Xhjl/ZiI31vOxTkoRFNGUVsQjEEy4aIuBXD3JPDRikUScti8Mb4INahjgf1Ldh08jbrOSrEatE4Zhaze1PyEehpj7wH8m43qlWeSTkVKKrm1leFKa52Ntj72khO4+QK35lp4T0Q1cdduZnI41EY4idPb7xRVIPE7HKtx+t729GWUcR1lgyh4yAibsVQDFX4QX0LHgvrrhQK1V9+Nmw4nmVQnJTPozBSzyadgjqJFB/szwBNy9MPV00doPxeRwkKBSDh3+PgzyKcxIa2hTpnskqx4ViW8vsnbhQr/5+mafx+5T6e2nwef98swaP9vDS+7Xg5irBkcrDWXHemoZjfr9zHudums3MgGA/JTrFiJoR4M+pJ2Syl22UoKEId7+1NZ5WqyCRlTRNMszJUeWmEP8b281J+3VEuf2P6esBBbJpY/OH0QizalYIWldhz26zLrWdzILLh4Y3oIHx75g7+0yrwL2yTb7z29rTHrEg/pOVXIqe0Hu4OQvx3xmB46EhTZPr3cT67HOG9XBk/hAnmh6zErZgXRgYwHvvzpbx2zREmhfrgwtLxsBcy/2dQWNXYrtMPEwxZ/e+5fF9tY22In6vJs1M08dII5j9nNiiyQ1rabB4qvtr47CD4OItBA/jyVDZCPjisFHBV7pTW4dMjN3E4vRg3i2twPrtc78+JSZaMu70QG58LxzuxfdneGsGMEBG3YoQCHh4LY5bL+2dqAYKXH8La+Ix25/j8mXBW133tJ/X0M6a+HYrVvwvDrJraphZM/+octibcgaRFhks5FR1SF1TZyL33CxPfm/WHb+KvN0Yh0MsBYhseFD/WsX09kfpBLF4Z0xuAfN8gyMsB/bo5wt/dDpMGeMNepP8lW1+WzJXlsXgsrLuht0gwE8TF0MqRymgMXHkE9SyyJjR1fP/ieBY2HL/F6tpfzYzArZIabDuXi0qVHHJ9xSIJWaWY/X0Sq2tRAHp72iG7tJ7VcVywe34kYx8TpiRml2PGlguMr03TNPam5KO4uglzovwYiTRTSMWmaSEuhgSd8HkU/vPMIFbHKBz7VHn10UDWoYrXdyVjw/FbagIO6C8W4THdkVWBBjpEwHkUlJkiXMI2O4SiKEyP6IlXH+3DqYAD2rNkCNYBEfFOwKRQH3w9KwI+DPOxZTSwIzFX7bMrdx+wDlVoG0+3/lm5/7rG0EpZHfct5EyFjJb/bLjGmEIdS+J4RjG2ns2BTGZYM2qC8RAR7yQo8rEnhDDzv76YU6EmsKZI3yuqbsKhtPar8WMZxRpGWy6afjY1jRLkPzDcRdKYQh1LgaZpXMqtwOq/MjBgxVEUVnLnqklgDhHxTgSfR2E4w1/6oxnFGLX+pDLkYaoV3z/3pODPlHzl15IWGeI1CLslc6u4Rrlh+6BOgqc2n8fkjQkYuf4k/JccxLjP/ob/koNY+kcamG4x6SvUoQEsmxxs0aENiqIg4Mvn19Asxcr91zt4Rl0TIuKdjNlR/ow9ulVj11waVqkio4F3fknFl6duo0EixY7EXBhrx2FuWdt0KhsztlzAqPUncTCtAMl5D+Cq4iAZ6OUAfw877E7KQ24587i9PluCf/6c2i6byNL418Rg5dvfqZulJKzSARAR72QIBTzMH80sr1kRu35vbxqkMpoTwypVvJ1EmB7RAzIa+PTITQz7+Dg+OXLT6PPSAFzsbLBl9iP44rlwLBrXx/jJMqCoqhHL/7yOYf5ueHJID8wd4Ydgbwc4iATILavHa4/2gb+7HatzTgr10ZomKqPl5mOWLuTLpvQHAEikMiTlcL9/QNANKxHfvHkzwsLC4OTkBCcnJ0RFReHQoUNqYxITExEdHQ17e3s4OTlhzJgxaGggsTJzsjQuBAvGBDBekVfUNSNy7QkAYG1YpYuVUwfg06cHYc0TobDhU6hpbEFTCzcrNVpGQ0rLMC28B0YGenJyTr3XbP1vXkU95kYFYNXUUBx+ayw2PBuOK+/H4K2YvqBYZt5IWmTYejZH5xhN2USWhJ+7vdJR84fzOaTHp5lhJeI9e/bEunXrcOXKFVy+fBnR0dGYNm0arl+Xx8ISExMxadIkTJgwAUlJSbh06RIWLVoEHo8s+M3N0rgQZK6ejCfCmRVrVNRJ8OrOZABQc9d7O6YvurXpcqPv4eBiZ4OvWzu283kUZkX64dziaCyfEoIQH27yZKsaW7BQJRRka2Oef2Pa3P3cHUQQCtjPgUl4SVM2kSVxOL0Qjc3yOoXD14uVoSfiR24ejC72cXNzw6effop58+YhMjISsbGxWL16tcHnI8U+3MK0qAR42Az57OJotQ21tsUgQ/xcMXPLBVxuk3rnYmeDF0cEYFF0oM4NubXxGfjmjO7VJ1Nc7Wxw+f1YHEzNxz9/uap3/LUPJuCRj45DwrSlkBa+eC4c08J7GHUOAPhgXzq2J97VO25OlB8+bG2MYUkorAM0iQgF+ZtdV+8QZLHFPlKpFHv27EFdXR2ioqJQUlKCixcvwsvLCyNGjEC3bt0wduxYnD17Vud5mpqaUF1drfaHwB1sNiy1rTLbFoMIBTzsfiUSsyP9sCyuv9Lm9sr7sXgzJkhvRgXbcI8uHtQ348KdckyN6Imwnrp/QWJDvOBkZ4OQ7vJx/5sxGLnrpiC2v5fO4zTBVTaPryuzGDrTceZEKqOxcv91nfUFpLGE6WEt4mlpaXBwcIBIJMLChQuxd+9ehISE4M6dOwCAlStXYv78+Th8+DAiIiIwfvx43LqlvZx77dq1cHZ2Vv7x9eW+w3hXxhDjqY8ZbKTZ8HlY/UQo5o/pjWnhPTDEzxU/nMvBB/vSlV4nulCEe5ZP6Y/ZkX4GCakChd/2/kWjEaPlPM62Nvh29iMAAFc7ecXjFyfk/y43PDuY8bW4zt8O7ubI6ThzIvd31164RRpLmAfW9bv9+vVDamoqqqqq8Ntvv2Hu3Lk4ffq0MrVowYIFePHFFwEAgwcPxokTJ/D9999j7dq1Gs+3dOlSvPPOO8qvq6uriZBzzEPb2TRU1Ok3c0rLr8ZHBzOwbAoz8V8bn4EtCTlqsd2P4m9g/uj2Hi2qCAU8zBstN3GSymiMWn+SlVXtQx4e8d3coWiQSPFxfAZyy+vh5ShEfFoxqhqasf9qAaaF90BZrdx6N6e0FonZ5XjA0IpX8eKgrdGCIVQ0MLs203HmhDSWsAxYi7hQKERgoLxLy5AhQ3Dp0iV88cUXWLJkCQAgJET9l7Z///7Iy9Pe8FUkEkEk0u57TOCGSaE+iA7uhiFrjqGmsUXv+O8ScvBObD+9nWy0xbcV6XEAdAq5AsUbw8LWzVU2RPVW97q2FfKx+omByq8DPG7hs6NZWBufiVvFNcqOSFIamLHlAuOwjrcJusBbc/m9Nc+9M2H0lr5MJkNTUxP8/f3RvXt33LypngeclZUFPz8/Yy9D4AChgId/DOnJaCwNYPDqozozDCQtMmxJ4C49LjbEGy4sGyG72NkgUo/D4Muje8PDQYii6kZsOpUNiVR9rc8kZLt8Sn9lD0wusebye2uee2eClYgvXboUZ86cQW5uLtLS0rB06VL8/fffeP7550FRFP71r3/hv//9L3777Tfcvn0by5cvR2ZmJubNm2eq+RNYEhvizXhsY7NMmcanCa7T45JyKlBZz867e3akn97Qxt83S5QhFEPxcBS1y9hh4qGuD2P6ZHY0TBpLWOrcOxOswiklJSWYM2cOCgsL4ezsjLCwMBw5cgSxsbEAgLfeeguNjY14++23UVFRgUGDBuHYsWPo08c8FXUE/QwLcIOjmI+aRub+4yv3X9fYku1uBbMSc6bj2MRO7Wx4qG+WYW9KPl4fFwixjeawj6L5grF4OYqVqZbHMorwZ2qBWls7fR7qulDsWaw6kKHWgV4s4GHjc+EWnaKnbe6mCD0RNEOaQnRB/krNx6I9qayO0dQYYWvCHaw+eEPvscvi+mN+axcaVdrmn5/KLMa3esIzgDy08cxQX0zYcAaFVY1YOLY3lkzur3Esmzx5TShy55dP6Y/VB2+oCVXbcYBxedGKn0d8WgH2XS3ExJBu+PQf7LziOwrSWEI7ptY00ii5C/JYeA/su1aAYxkljI/RtEqeHeWPj+Jv6A2pfJeQjbqmltZekjSienugqkGiUxS14eMsxgsjA8DnUXhvcn8s35eOr0/fgZeDCO6OonYCYkxmhEKCpg7yweu7UnRmzSi+98GfaQY1kgYe5uMPC3DDhBBv/JF8H69sv4yh/q6YOyLAoIpQc6GYO8H8kJV4F2bRT8n4i6EtrLYWZVxWX+pC00pXJpMhdOXRdq3p7EV8zB/VG2+MD0JSToXBK3EfZzGWTwnB6oMZrB42owI98MMLQyEwQHQPpxfi3V+uoq7NPVEAXojqhfuVjch70IBerrbY8OxgOIg7fh3WLJUhJa8SeRX1eJrhxnlXwmIrNgnWzxczBrfzRdGEt5NIa4YBl9WXCigKELQ5obezuF2o4mhGscbeonVNUmw8cQthK4/gQV0T445Hqmx8NhxnF0fD1V7I+m3h7O0yTPnfWdQ16U/lLK1pQnVjM2qbWnA4vRALdya3E3BAvtLflpiHYzdKcLOoBsdulCB05RFM3ZTAam6mILOwBs98k4i18fpDawTuISLeheHzKKyaNkDvuJVTB+gMDyyNC8G2uUM5mxdNozX0Agz1d8Xm5yPapfcx2bCsk0jx2q4UTB3EPkYd3d8LfB5lcDjmZnEN7pbXyf+/qAb3tGzuzvvxEsJWHsXTm89j8W/XWF/n2v1qPPbf00jMLsPru5JR08guu4cL+njZAwDK6yQor7We1nudhY5/FyN0KIr+nEv+SNOY3hfs7ahxo07SIsOOxFzcraiHn5sdSmu4/eUd0ccdiXfKcSn3ATILa1Bc3YjZUf7Kh0lSTgXjFfLWs7msri3gUXASy/PV2RSqUACEfKCpdSEd99+zEAl4aGqR4V8T++H1cYHtjnkvrj+e+/YCMlsLkAwhvaAWM7ZcBAD08bDHOxP6GXwuQ7ATCuDrZot7FQ24VVILdwdSvGdOiIgTMCnUB7Eh3rhwpxyJ2eWoqm9CZnEtrtx9gEXR7YVHU5k917wRHYTFk4KxfF86rt2vwsoDGdhz6R4G9nAGDSC3rI7xuVpYTtTN/mHXHkVBiz47AMV7Co/PB6QPwyEK//SSas0PnOEBbpg3KgDfn80xwG5And4e9pg22HhnRUPo6+WIexUN+N/JWwj2doSLSucjgmkhIk4AIA+tjAz0wMjAhyXsZTWNsBepV1CaeiNTkdKnyDDZ+9pI7ErKw6eHM5FZVGPUipUp80Y97IykKGh5dWcyKECr0NIAbHgUGlrj2fYiPhxEAjRIpNj43GBEB2s25qIoCk5igdEC7udmi5P/96iRZzGcsf08cSKzBOdul+PFHy5h9/xIrbn7hnIorRD7rhbgndi+6GuBhmAdBRFxglY8VEIJtU0t2HLmjskFHFCv8uPzKMyO9MPkUG/8mZIv9wGngR/O56KE4xCOgurGFkhltHIO2gpa2tLcuuK34VM4869xjMIKUhmNbedyjZ5zR4va7Eg/eDiIsPSPNKTkVeLtn1Px5cwI8Djc8d506jauF1Qj7X4Vzi2J5uy81g4RcQIj/v3rVcSnF5n0Grqq/DwcRHh59MOCoTF9PfGPrxPR0My88pQpX566jd1JeVgzLRRxrf0vFQZikWuP63SC5PMoXF85AUIbZr9aSTkVqGwwfjOSjZ2uKaAoCnEDfeBmL8ScrUk4lF6EI9eLMHkgs03ltnsss6P81fLiW1pkuFEo7zUwlWG3qq4CEXECIz6ePhAXcsoZWdkygQLw8ugARAd3M6jKL7SHM/a8Eol/fH2+naEVF1TUSfDarmTMzfXDqqnyjjpX7j7Qe/9SGY0reVWMC1+4sGkN6+lkEfniABDZ2x1zovzw3dkcnMgsYSTiTKyM49MLIaPlrQEXaqj+7cqQFEMCI1zshHj90fabnMbwXUIOqhokyo5BbKscB/m64L8zIjidU1t+PH8Xo9fJm0ibwj+bsZ2rg+aNwrCeTti/aDTj65kDxb5K6r1KvWMVeyxt954VVsbDPzqOF7Yl4f0/0wEAId2d4Ew2TdUgIk5gzOwof0Zt3pig+J01tn3XxAHdMLavvNt9oKcDXh3bG68/2gfOYu421e5VNiJs5RHY8Jn9urBJS1Rkv+jCxc4Gie/FIH3lRMT290I/b0fE9vdC+sqJFifgANDbU543nldRjxYdvUyZWBkX1zTh75ulqG71wI8N6cbdRDsJRMQJjBEKeHgsjLmVrT64aN9FURTWPBEKJ7EAt0trcaukFhRFoYqFSyMTqhtb8H+/pOqeC9j7ZzNpn7du+kDweRQcxAJsmTsUR94agy1zh1pMCKUtPs62cLcXQtIiw+/J97WOY2JlDAB2rY1JQrs74fWx3L4NdgaIiBNYEcPCj5wpxsaFfd3sEOAhX/0dv1GCTaduczGtdtQ3yyBq3Wzj0j9bUXDVdkXu4yzG11bYLV4o4GHhWLn99Fd/Z0OmQalPZRZj43HtvXdVeXpIT+Sum4K//jnaID+azo5lPsoJFospWm0Zcs7i6kb8mZKPJyN6IPnuA1y9X8X5vDQxoX83TBnk0y7d0NXeBmumhRosuIqCKyZ2rsl5D/D3zVK8E9vX4PswNS+O9MeLI/0haBOCulNai8f+d1aj5402/NzsuJ5ep4I81gisGBbgplbRaCyGtu/KLqnFd2dzMOyjE3jn51TO5qOP+PRCDOzhguVTQtR+DhV1zVh98IbOdnb6UNi56troLalpxOdHb+L7s6Z3jjQGAZ/XTsC/S8hG9OenlQLO5IWFR8n3YgjaISJOYAWfR2HNtFDOzmdo+65e7nZ4ojVfuL6ZWQ9PLpDSwJhPTuK1XclqnX0AoKiqEa/qaGfHBeW1Epy7XY46SYtVdZGf/tU5rDmYqfz6lTG9cWftFCwYE6DjKGD+aMv2UbcEyE+HwJq4MB+10nRDEAt4RsV7e7raYeHYPgjtbn7PeW1p6Vxl3OiiV2togaah3QPAwhiy+hiS8yqVX//08lC8FyfvxKTNyphHAQvGPMwTJ2iHNIUgGMzLPybh+I1Sg47NWjOZkxWWse3XTMXAHk4I93XBe3EhsBVyl+5YUSdBxOpjALj7GZqS4PcPobHVBEwk4OHcknHwcGi/B6KvYtOaIe3ZCBbLd3OH4aOD1/FdQi7rRSFXv6BMXQbNTVp+NdLyq7HjQh7GB3tg6wvDOTmvq52N0t62sKoBfu72nJzXFKw5cF0p4C62Nri8LBoCgWbJEQp4mDeaVGIaQud41BE6jGVTBuDmmsnK+DQT7G24M0VSzbO21La8JzLLMPbTk1q/L2mRYWvCHXywLx1bE+5A0qI9xk9RFPp4OgAArhdUcz5Xrnh683l812rsxaOA1BUTtAo4wTjIT5VgNEIBD88O7YU/UwsYja9rprE/OR9TI7jxvmbqMtiR3C1vwIcHruNfE4PxcXwGcsvr4e9uBxseDz+0KXpp6xvSlgg/F2QUViP57gPEMTSY4hJ9ne0X/3YVl+8+UH49N8rP7HPURlV9M0Q2PM5tcjsSIuIETlCENZiK6OK91zAlvLtBmSmaaJtnLeTz8OpPyZycmyu+P5eL71VsZxO01LoofEMAaBTywb6u2HkhDykMvEm4Jv5aAd7fl65mBOaj4j558U45fr4sr9KkALwVE4Q3Yywjn/2lHy7hZGYJ/m9CXyyKDuro6XAGEXECJyjCGgt3MhPOhmYZknIqtLr9XbxTju0X7kLE52Hho30Y+WUr8qwBYGvCHeaTt1C+TcjBWzH9IBTwkJRTgaLqRlTUNikzX9Lyq9DUIoVIYJ5VpbaGIIVVjVi4Mxk9XMTIr3z4EN8zPxLDGbo5moNx/TxxMrME57PLiYgTCJqYFOqD4G4OyCyuZTReU54zTdPYknAHH8c/zCnem5qPJ8J7YMGY3gj2Yba7f1dLY2JrgqaBwauPQmzD19j/VNIiw3cJd7BwbCCjSk9jiL9WqLchiKqAPx7mY1ECDkDZpKPFBNbFHQkRcQKnLJ3cH3N/uMRo7I7EuyipbsTcEQ8LOvam5CsF3M1eCGdbG+SU1WFvSj72puQDAPp2c8APLw5Fdxft5didpVS7sVmGRh3FTJ8eycKWhBw1kffR0VzDEKQyGu/vS2c0lgLw9awITLRAvxdB64OtWWa+4jBzQEScwCmj+noqU+D0cfnuA1y++wAfxWfC2VYAN3sRclobIA/zd8Ou+cMh4POQlFOOl364jNomuR1pVnEtxn12Gt/OHoKx/TT3rpwd5Y+P4m9w3sy5l5stZkf6Y1akH6I//9siUhvbrtIVlaObVYqp9G1G6iIpp6Jddao2Nj4XbpECDjysjapttbXtLBARJ3AKn0fhi+fCGcfGFVQ1tKCqQf7LRVHAmzFBSu+NYQHuuLYiFuezy3EovQi/Xr6PphYZXt5+GW9EB2FOlF+77upCAQ/zRgXo9atmS12TFC+NCmDcQLkjoCFfEa86kIHYEG8cyyhql7njKOZjSC9XjA7y1FtYY4omFx1Bea38QeRka4PE7HKThp/MCanYJHBOg0SK/h8cNujYF0b448nBPTDI10XrmKziGjy1+TxqWldUQgEPc6P8sGBsH3i0xj0PpxcyTjmkAHRzEqFOIlWeUxe750cqN1DZXKcjeDumLzYez9L5kOFR0JrSuC/lPt799RpaGLzSuNnb4NKyWIsVxB/O5WDlgQyIbXhqISquw09tMbWmEREncM7yP9Ow40KeQccuiwvG/DF99I6rbmzG3uR8/JiYizul8hCMo0iAoQFusLXh4WAas6bOCrnZPCsCl3IqsJVB5/lx/Tyx7cVhyq9VQxVudkKkF1TixI1SADQmhHhj5nA/hK48wmg+XOMsFqCKYfhA1askPb8Kb/+cilslzDapAeCrmYMRF2YZTYw1hY/mb7+Mk5klWo+ZN9IfMSHenK/MiYgTrI7ZWy8i4VaZQcdOCOmGb+c8wng8TdM4mFaITSdvI7OohvX1VFdhbHxYYkO8sGXOUMbXMcZnxpz0dLVFSXUTJCpt1VztbBA30Bu7Lt7TuqK3JLMqTW9H3k5i1EqaUcug45O3kwgrpw7gbGVOvFMIVoe/u53WQhZ9VNYz20BTQFEUHgvrjsmhPrh6vxL7Uwvww/lcvcctGtcHIwM91VZdbHxYjmWU4K/UAjzGwG5AKqNxvYDZA6aj4+v3HzQo/99OyMf/TeiHl0YF4HB6IQ6mFbXbRHUQCfDJU2GIC7OMzczD6YV4dWdyu59hUTXzcFdRdRMW7ky2mq5KxDuFwDnvGbEiS8p9gPhr7P24+TwKEb1cMbiXC6PxQd0c2zVeUGxWMhXRxb+nMrKcTcqpYBQzfzsmCN5tWrS52NnAxc5G43hbgeZXfsWni8bpD0u1xVkswLNDe+LEu2OR8eEkpYC/ujNZY656bVMLeBaiIlIZjVUHMjh7CL65h9nfb0dDVuIEzrEV8hEb4oVjGdrjj7p4fVcyvoQ8vso2NY5pdoS2cZNCfeDjJEJhdZPec9Q10zqrThUwze7w97DH2cXR7e4XgFrFppu9EN7OthjSyxl9l7ePtXu3hohiQ7zxY2Iualg0ja5qbMHPl+7j9yv56OftiO4utkjMLtcqjKpZMB21oVnf1ILTWaXYfTGP0w3mphYZzt4q1ZrGaikQESeYhC1zhmL+9ksGCTkN4LVdKVhwvxL7rxaq/WLqyyRgEhJxFPMRriP7hc3a605pLfp2c4CbvRAUpVnE2DxYVK0DVNH2oHCzF6KiToJh/q54PtKv3YNuSC9X/J3FfH+CR8m9W1pkNK4XVOt1SqQhL7tn8jAzlp8u3MWG41kor5OATwE2fHk9gikXy+sOZRIRJ3RdtswZitM3SzB3G7MKzrZoKvPWVMiiCpP87ZpGKQasOKw1ra6PpwOKGKzEAWDZn+lY9mc6fJzF8HIUgaIo0ABkMhpSGQ0ZLf8vn0fpfDXnUcCDOmbXVCW0hxPOZJXhTlk9poW3d4UcHeTJWMQVm5OFlQ24XVKLZpkMB64WYG+KfnfKlDzTifix60VYtDtFrYCshQZazFB5ebukVvn3Z6kQESeYlMqG9nFUY2hbyKLpl4uJNa0up8BXRvfGuexyVvMqrGo06lVeRgOv70rBZh7FajPtyfCeOJNVhrLaJtRLWmAnVP+Vnh3lj9UHb+g9z8sj/ZU/Bx8XW/i42AIAbG0EjET8s6NZKKxqwti+nhjSyxW2Qj5K65pQ19gCe6EAvu4PbRCq6iXYdj4XNE3j0X5eGNzLtd35Em+X4dD1IvyZko9qlRRJGz6FYf5usBcJ4OdmiyBvJ3R3FmOInxuEAh5GrT+p9S2MgnyPQSTgMX5IN8uYhcw6EiLiBJOiKL7hEiav8JNCfTC2rxdCVhyGriTaLQk5eHdCsFrFIhvrAAVvjg/EwB4uyq/5PAo8HiUPT8iAF7Yl6Q3T0GAfX348zAfv/JIKGsCvl+9j7gh/te+X1up/sMwb5Y/3Hxug8XtMM3ZkNLDjwl3suHBX4/edbW1Q09gMmlZ/O/rixG3Y8CnYiwSoaWjW2r+UTwGLJwXjlbG6N2u1vYUpfpprpw9EbIg3zt4qZfyGaOkNqS1kX5nQaTFhvFLfL9eui3d1CjjQKj6JuWqfKawD2PBj4l2MC/ZCTEg3xIR0w7hgL4zt64nRQZ64XVLD+MegeDgxRSDgwac1o+XgtfYr5g/3ZwBAu0bEqrz+qHZbVl2dk6jWPx8/EYpH/Fwh5GuXk6qGZshUBJxHPWzR1yylUVmvWcCFAh5eGumP7LVT9Ao48PAtrG2Wj7ezWBmC4/MojO3nhSF+LnrPB1i2lQBAVuIEE1NmQJyXKfp+uXLK6xidJ7usfVXipFAffD0rAiv2XUdxjf57qKxvxqaTt/FmTHtBzC1nZ4tb8KAeAPPX95GBHvj1yn1cy69q973k1sYRI/q44/sXhimbEfdwEeOTI1mQymi8t/cavp6tvcBKW3jKW2WTeWakvHtPg0SK2yU1qG+Wor+3IxxEAhy4Vogj14vQz9sRfTwc0NvTHn29HCEQ8HC7uAbx6UUoqmrAg/pm+DiLEdLdCVG9PdDD1Zbxz6DtfFUbhGjLavplwQiEfHBY6xsX1XqPigwhS4WIOMGkmGoVYyfkKzcPtYUemG5F7U3Ox5ggz3axaIUYbDh2E5tOZes9z7bzOVgUHahhPuxeR9797RqySmoYV0A+HtYdv165j8ZmGT7+6zrqW2SgAPT3cUJFrfwBpPCEUW1GfOFOBU7dLMWxG/oziJgKo62Qj4E9XdQ+mxbeQ+OmKwAEdnPEPxk0/GCLtiyftmO0mbUp7mrF4yEWvakJkHAKwcQMC3CDkM/9L0G9RIrnt17EqPUncThdc3HQYN/2G2aaaGiWYeHOZI3n4fMojAz0ZHSeyvpmjaGQ8DaixoRvzuRgbXyG2mdSGY3E7HLsS81HYna5MttlTL+H8/v2bC52XsjDjgt5eG9vujJEcfV+FYKXH1Kes6VFhiutfTCZapRCGKeF92hXKGWtTAjx1hgGUg2/WDpkJU4wKXwehcje7jhjoJeKPnSlHCoyLJiy5I80jZuKwwLc4GJrwyjTRlOcvrurYQ0qvjnzcNNVkx+IImc+Je+BjrM8RDUj5x9DfJVZH0smBRs0v85Cc6tPzNNDemJ0kIfV2dMSESeYnG9mP2KwNa0+FIGKhTuT8XRED4iFfAS422N2lD/r5s2V9c24kF2OkUEeap/zeRReHOmPDcf1G8JoCh8Na3VWbNDRoUcbP57Pha+brWY/kNbellpqjLSiyMhRWLJ+fy4Xwd5OAAWU1TZZnYgZQ1ltk/Ln+lZMEHoa+MDtSIiLIcEsGFq9aQyR/m4QCfk4ncXcPXByaDdsntV+k08qozFkzTGN/iEKnER8DAtwQ2OLDAEe9vi/CcH47co93K2oR2reA1zL1139qInY/l5IL6jm3K/86YgeOHy9CLVNmkvyTe2xbSncKKzG5C8S4G4vxJXlsSa5BrGiJXQapn95Fsn32mdQWBoK9zpJi0yZzeHnZoeCqgZsPZtr1rmM7OPOuvCIC1R91juzkJ/JKsWc75Pg526H0/8aZ5JrECtaQqfh11dHIvSDQ2hosah1Qzv+uTsFvm6ZuFNWrzfP3NTYizrmV5RJZWxnIK01LbPIQjszMYFkpxDMBp9HYcNzgzt6GnqRSGlkl3a8gAsFPBzNKO6w66tWxnZWmprl4SQe240FC4KIOMGsKIpovJ0suwrOEtDRu9isFFc36B9kpSgKfSzFE90QSDiFYHZUC0eOZRTh+3O5Hd7RxpJwFgvQ1NKCegn3Ln0e9jYoq2NnSvZHcj4q6pqRWVSNkYEeeCyse6cJrzS2ijjfilfiRMQJHYKicCSqjzuGBbhZdMd4czA1zAf7WzsaMW1sbAhldc1Kz3CmnLlVpszz/+XyfZy7XYYPp4VCbMM30SzNR3Vr7r+NDt8XS4eIOKHD0VTS/aBOgtUHu46w7zegJZ2hMBFwxbp0VmQvlNZIUN3YjLT8KtQ0tuCXy/dxr6IBu+YP19oIw1oQtFYTW/NbIBFxgkWgyetiYmhbYW/Ca7tSOmiGXQsBD/jfTPX0Qpqm8cvle/hg33Uk3inHketFVp9+aNv6NtEilSExu5xxG0BLgog4wWLRJOxf8yjGzoIEw2mWAWP7qrcloygKzw7thfsPGvC/k7fx+dEsTBzgbdWrcYfWFM6axhbM2HJB+bk1FTuRYh+C1dG2ebKbrRBx/zujNHuyEwD1pgsrdxnG9vXAjy8Nb/d5VX0zhqw5hhYZjWH+bujuIkZ/H0d4OYrh7WyrXMUqiqVyyutAQW5I5uNia1Gr3A/3X8f353Pbfc5lsROp2CQQDKBBIsVHBzNw+mYJ7lV2jbi6Kfhag4itjc/Q2P9UgY+zGKE9nHDiRonG+LulrHKlMhoj1h5HcY1E6xgfZzHOLo426qFjak2z3i1ZAkEHtkI+1jw5EAlLxmP+aP+Ono7VsupAhlqDZ30CDsgLhI5laBZwxfdf1WL9a06Scip0Cjggn2vcFwloaZGhpLoRMjM0Z2YLEXFCp2fZlAFYMCaAcZMIwkNUKzYlLTJsSdAt4ExR9BOVssl15BimvTNvFtcg8P1DGPbxCexNyTfxrNhDNjYJXYKlcSF4d0Iw4r44g9ulzNq2EeQUVTciMbscP1/KY5Vfro/Cqka8/OMleDqK4GInRJCXA/r7OKGft6Myb/tSbgVyy+oQ7O2EAd2dwDMgrFHd2AwHoaDdsWy7Tg3o7oSnhviyvr6pITFxQpciMbtcLQuBoB83extUsKzyNAZ7IR+De7nC180Wu5PuKT/v7izGhAHeGOTrjEf7esHVXqh2XINEipOZJbhVUoOTN4pB8XjILatDVYO8d+eUgT4Y2NMZvdzskHCrDL9fuY+7Fbr7n/o4i7F7fiTO3i7DuGBP9HBh7zduURubmzdvxubNm5GbmwsAGDBgAD744ANMnjxZbRxN04iLi8Phw4exd+9ePPHEE4wnREScYEqkMhqj1p/sMkVEls4zj/jCz90OJdWNyCquRUZhNao0dFByEAlQ2/Qw5UjeNs8DkQFuGBHogT+S72P/1QKdfu+60Gb7oGljly0WZUXbs2dPrFu3DkFBQaBpGj/++COmTZuGlJQUDBgwQDlu48aNVp07Sui88HkUVjweorFTDuEhpvayUXSSXzt9oFrmh0xGI6OwGuezy/DF8Vuok0jx9awIPNrPC6cyS3AxpwIX7pQjs6gGZ7JKcSarFDhyU3l8T1dbjOjjjmapDBNCvBHgaQ8fJ1uculmCL07cQk6ZPJRmw6fg7STGa48GwtXeRqPtw5ggjw7PoGGC0eEUNzc3fPrpp5g3bx4AIDU1FY899hguX74MHx8fshInWCSaelYSHqJo3WYqKOjPwa5ubEZZTRN6ezq0+96d0lr8evkejt8owa2SWjzi54oFY/sgOtjLoHRA1dqDP1PycepmKRaM6Y2lcf1Zn6vdfVjSSlwVqVSKX3/9FXV1dYiKigIA1NfXY+bMmfjyyy/h7e3N6DxNTU1oanpYfVddzb6FFYHAFlW/lqPXi7BNQ8FHV8YYAecqT9xJbAMnsY3G7/X2dMDiyf2xeHJ/lNU2wd1eaNTbv6I6uEUqw08X8gDI01StAdYinpaWhqioKDQ2NsLBwQF79+5FSEgIAODtt9/GiBEjMG3aNMbnW7t2LVatWsV2GgSC0ag6KQoFlN78Z0J7errY4hF/1w6t2PRwEHF2rk2nbiMptwI8Cojp342z85oS1uEUiUSCvLw8VFVV4bfffsN3332H06dP4/bt23j33XeRkpICBwf56w9FUXrDKZpW4r6+viScQjA78dcK8M4vV5Ue0wT9hHZ3xNLJIYjs424xpfSGUlEnwdCPjkMqo7H+qYF4dmgvTs5rUdkpmoiJiUGfPn1ga2uL//73v+CptMiQSqXg8XgYPXo0/v77b0bnIzFxQkcildF4c08KDl4rJBufLHCxs8G66QOtYiNQG3nl9Rjz6SkAQPLyWLi1SWE0FIsvu5fJZGhqasKSJUtw7do1pKamKv8AwIYNG7Bt2zZjL0MgmAU+j8KmmRG4uWYylk/pj7F9PeAo1h51pABE9naDO0e/8NZKZX0zFlpAKb0x9HK3U7YNTL33oINnwxxWMfGlS5di8uTJ6NWrF2pqarBr1y78/fffOHLkCLy9vTVuZvbq1QsBAQGcTZhAMAdCAQ/zRvfGvNG91TIX3OyEyCyqxr0HDfBzs8PsKH8IW5thTvj8b2R18WrQpX+koaFZBm8ndU/uts6TluRkqIqsNTAh5FvHpibAUsRLSkowZ84cFBYWwtnZGWFhYThy5AhiY2NNNT8CocNp62s+uq+nxnF+HvZdXsQf1Dfj7Z9TAQBudkKseSIUPB7apXOydTJUbJLerahv9/DkisZmKUpafeoHdLeeUC4puycQOGLLmWx8FJ/Z0dOwCpj4dStW71sSsnHqZilUlYpHAfNHB2BpXAhnc6JpGhGrj+FBfTP+eG0EInq5cnJei80TJxAI6syK9CcizhAaciFfdSADsSHyMCybHqsyGsqUUK6EnKIovDQyAE0tMrjYas5Pt0SIiBMIHJF6r7Kjp2BV0JA7GW46eRt7LuUZVD27JSEH704INiq0ohqvf8TfzWLj9dogIk4gcARTf2qCOhuOZxl8rIwGvjmRgTcmhhp0vCb7BTd7G6yZFoq4sO4Gz8uckKYQBAJHsPWnJnDD56fuwn/JQcz+jp3F8OH0Qry6M7ndG0BFXTNe25WCtfEZXE7TZBARJxA4YliAG3ycxaSDUAeRcLsc/ksOovfSgzieUaRzrFRGY9WBDJ0FXd+cyUH8NcvPeyfZKQQChyhWdxb1S2UkCtvYz54ehLK6JnxxPAt3ynQ3UzAnPADajBKcxQLY2gggkcog4AGNLTI0S2WgaTCyV3C3FyJpWQxplEwgdBUmhfpg86wI+DhbZ2ilrVQpvl7xeAhGBnlgWngPnPy/cfB3tzXqOj7OYrwdE2TUOQBgwZgA3Fk3BbnrpmBCf692369qbEFRTSMq6iUoqZWgurEFDc0yxv445XUSZY9RS4VsbBIIHKNqc1tU3YiS6gZcL6hBQWU9errY4amInngkwA2DVx81qWc3E3q4iBEd7IX34kJwOquk3SafUMCDt7MY1wuqMSHEW9mncvljA3DgagH+TC1gdb3oYE/MH90HwwLcAAB7Lt1DUVUj6zcXTXni384dCgCorm3CE5vP4045N28Llr5hTcIpBEIHcTi9EAt3JnfoHCgAN9dMVqboNTZL8fpPyfg7q1StEz2PAlZNC8XsSD8AQLNUhmMZxUjJe4AtCcwsfD0chAjp7gRJiww/vDAUYqFAGX4C9HcSchTzMaSXK0YHeRpdsSmV0Rj60TFGvUN3z49Uq9hli8W7GHINEXFCV+JweiHe3JOKJg7sbxdP6ot9KQXILK5lddzyKf0xb3RvNEikeOvnFBy5XgwA8HOzA59HYUAPZ/g4izF3hD96uLQPo6yNz8CWhBy1BhA8Cgju5oSMomoI+Ty0yGRq3/dwEOH8kmgIBTyNaX4+zmIsn9IfrvYik/mtxF8rwGu7UnSO8XEW4+ziaIuOiRMRJxA6GKmMxrPfnMflu5VGnWfmcF98/GQYnvvmPC7kMHfh6+Npj20vDkVpjQRPbT4PAFg3fSCeHerLuFuOJm+TB/USDP/4BAAg/s3RyCuvx7nsMuxIvAsAGNPXA9tfGg6g4wyy1sZnaG0GwqSFHBOIiBMIVgwbcWqQSLHqQDr2XLpv0LWi+3ng+xeHQ9IiQ9/3D7E6lkcBI/q4o6qhGc8N64Xnh/sZNAdVaJpGwNJ4eDgIcfL/HlW2Wnv751TsTckHAAzu5YK9r400+lrGEH+tEO/vS0dFnUT5GVuDLl0QEScQrBRtYQJ94jB1UwKu3Tes1+yCMfLNvkW7kvGXATnOIgGFxCUxcHPgxh/9P8eyMG9kAJztHnqRyGQyTN+cqLQp+GVBJIYFGB5z5gJTvgkQEScQrBBt+eJM3PsA44X835P6I+SDw4xi7R89GYovT91GZX0z6iVSCAU8vD+lP2YN76XWqYtrVu6/jqeH9ERoD+d237MW/3EmEBEnEKwMqYzGqPUntRo6KYpn9G2YVdRKELHmGOvr8yggc/VkHM8o0rtx52pnA5GAh6LqpnbfGxPkge3zhrO+vrEY+gbDBpqmGcf7jYUU+xAIVkZSToVORz6Fe5++IhI3ByEWjGHfFUtGA6//dAU/X9YfW39Q36xRwAHgzK0y7EjMZX19Y9DmZ1JU1YhXOWz/djKzBK//lIxdF/M4OV9HQkScQOAYpsUhTMYtjQvBgjEBrP1Yjt0owemsUpZHtWfl/uuQcJD+yARdfiaKz1YdyFDLXzeUPZfu4WBaIfamGLaJbEkQEScQOIapmyHTcUvjQnBzzWQ8HdETNnzzxoWlNND3/UN4ujX10JRw9QbDhAAPewDgrHtPR0JEnEDgGH1uhhTkMV5F6TkThAIePntmEK6tmNghLolX71ea/BpM32C+S8g2+lr/HB+EOVF+WDI52OhzdTRExAkEjuHzKKx4XO7poctQypBsC1shH68YECc3Bh4FfPaPQSa/DtM3kxOZpUZ7fTuIBPhwWqjZNjdNCRFxAsEEKNwMvdu4GXo7i42uAlTEyc2RccfnUdj72ghMC++h/Ewqo5GYXY59qflIzC7nJEYNsPNj35KQwypW3yCR4pfL93D1XiUsLCHPaEiKIYFgQkyZ7yxpkeGx/51BVnEdJ+fTBAXgz9dHYJCvPHZs6vQ/NqZgCs8XJpzOKsXc75Pg7STGhffGGzNF1pAUQwLBiuHzKET1cce08B6I6uPOacGKUMBDiE/7Qhlj8XEWY/6oAAh4FGgAy/amAzBP+l90cDf08bRjNPZiDvO3gPT8KgDAUBb7ENYCEXECwYp5KqInZ+eyF/Hx1vhA0DSNLWdz0NIqkOkF1fjiWCaW/5nOafpfU4sUP57Pxa+X76GpRYq18RkIXn4I2aXMfMCPZpRg1PqTeh8eUhmNP5LlqYSDfV0Yz89aIOEUAsGKkcpo9F0WD6mF/BYz9d5ulsowbdM5ZBTKrQWcxAJUN7awvh4TG4Oq+mZsOJ6Fo9eLcOTtMXAU22gcZypIOIVAIGiFz6PwxOAe+geaCaZpgjZ8Hj55OgwvjwqAl6PIIAEHmL0FONvZYOXUAUhYHG12ATcHRMQJBCtn7fSwjp6CEqZpggAQ2sMZ7z8WgjlRxtneMi0CslYDLX0QEScQrByhgGeQxwqXGFLApKCkRrN3C1uyiqux5cwd3C6p4eR81gIRcQKhE7A0LgSBHsyyOoyF6wImPzdu5r1ifwY+ir+BhTuTUcrRg8EaICJOIHQSnhnayyzXaVvkaGwB0+wof6OsBCgAbvY2sOFTGNzLBY/29URxtWV3qOcSQUdPgEAgcIOnE/N4tDEo9g/njfRHTIi30QVMQgEPj4V548C1IoPP8fGTA/FoPy+IbfgGn8NaIStxAqGT4G0mEQfkq9/49CLOKlA3PhcBe6FhAvzKmABMCvXpkgIOEBEnEDoNwwLczGZVq8gIOX+7jJPz8XkU1j1lWJbNN2dyOGsWYY0QEScQOgl8HoXHOGpfxpQ53ycZ7SioILek1uBjV+6/zqpaVNXE69ytMpy7Xca5oZe5IDFxAqETMSrIA3uvFpjtejTkK2FAniFjDFvOGu4TXlTdhAvZ5eDxKL1mY5pMvFThup+nqSEiTiB0Iiobmjvkut+eycGoQE9U1EuUAgpAq4OjTEYjr6Iel3IrkJRTgQf1zahuMq4N3Ou7ktXuv60Yl1Q34n8nb2HHBd19NRWGXsZaBpsLIuIEQifCzUHUIdelAcz+Pkn5tYudvLy9sv6hqLrZ2yCspwtqG1tws6gGNU2Gldpro+0DTCHGX84MR1JuJX48n6vRwKstNOQbt6sOZCA2xNviKz2JiBMInQhzZqjoQlW8FVTUNePvmw+bNwsFPAzo7oSo3u7o6WqHH8/fwU0OvdEVgv3G7quQsvT5Uy3lZ2Lo1ZEQEScQOhGGlL2bGxdbG+yaPxxB3Rxhw3+YWzF1UHeErjzC+fUUAu7raot7DxpYHcvU0KsjIdkpBEIngs+jEN3Po6OnoZPKhmZUNbSoCTgAOIgFCOtpGvvpIX4u+ORp9n1C2Rh6dRRExAmETsa8UX06egp60bbC3b9oNMQC5rL0f7F9mY2bEMyqh6cxhl7mhog4gdDJiOzjDicx95FSLuuIdK1wnx7CrFuRrQ0Pr4zto1OYVcWYz6Ow4vEQ5efaMNbQy9wQEScQOhl8HoVPnubeY7xt9yBbGx487W1YmVcxWeEum8Is33z9k2EQCnhahVmTGE8K9cHmWRHwdtb+EDHW0MvckI1NAqETMinUB9MHd8cfKdwV/gh4FFpkNCgAsyN74cMnBiqbJ1OA3vQ9pitcWyEfsSFeOJZRonVMWE8nTI2QdzRSCHPbAh5vLUU7k0J9EBvircxh97AXARRQVtuks0jIUiE9NgmETsoH+9KxPfGuUedg0sNSUwWkq50NaKinGrKthJy//ZJGIY/p74Xv5g5t97lURmstLupITK1pZCVOIHRSuGi2oG01q0rblS2Tik0mbJkzFA0SKT6Oz0BueT383e3wXlwIbLW4HfJ5lMXndJsCshInEDopkhYZgpcfgqF+TjteGoYRgR4WsZq1Zki3ewKBYBBCAQ/zRxvWe3PBmACM7utJBNwKIOEUAqETo3AW/PZMDiPfEEAu4MY6EhLMBwmnEAhdAEmLDD+cy8Gh9EJkl9bChk9hYHdnyADcKKqBSMDDjGG9MH90HwhZFNsQ9GNqTSMiTiAQCCaExMQJBAKBoBUi4gQCgWDFEBEnEAgEK4aIOIFAIFgxRMQJBALBiiEiTiAQCFYMEXECgUCwYoiIEwgEghVDRJxAIBCsGIvzTlEUkFZXV3fwTAgEAsF4FFpmquJ4ixPxmpoaAICvr28Hz4RAIBC4o6amBs7Ozpyf1+K8U2QyGQoKCuDo6AiKMt4Gs7q6Gr6+vrh3716n9WIh92j9dPb7Azr/PWq7P5qmUVNTg+7du4PH4z6CbXErcR6Ph549mXW7ZoOTk1On/IejCrlH66ez3x/Q+e9R0/2ZYgWugGxsEggEghVDRJxAIBCsmE4v4iKRCCtWrIBIJOroqZgMco/WT2e/P6Dz32NH3Z/FbWwSCAQCgTmdfiVOIBAInRki4gQCgWDFEBEnEAgEK4aIOIFAIFgxnUrEP/roI4wYMQJ2dnZwcXFp9/2rV69ixowZ8PX1ha2tLfr3748vvvhC6/nOnTsHgUCA8PBw002aBVzc3x9//IHY2Fh4enrCyckJUVFROHLkiJnuQD9c/R3+/fffiIiIgEgkQmBgIH744QfTT54B+u4PAP75z39iyJAhEIlEWv/tHTlyBJGRkXB0dISnpyeeeuop5ObmmmzebODqHmmaxmeffYa+fftCJBKhR48e+Oijj0w3cRZwdY8Kbt++DUdHR63n0kWnEnGJRIJ//OMfePXVVzV+/8qVK/Dy8sLOnTtx/fp1LFu2DEuXLsWmTZvaja2srMScOXMwfvx4U0+bMVzc35kzZxAbG4v4+HhcuXIF48aNw+OPP46UlBRz3YZOuLjHnJwcTJkyBePGjUNqaireeustvPzyyxbxsNJ3fwpeeuklPPvssxq/l5OTg2nTpiE6Ohqpqak4cuQIysrKMH36dFNMmTVc3CMAvPnmm/juu+/w2WefITMzE/v378ewYcO4nq5BcHWPANDc3IwZM2Zg9OjRhk2G7oRs27aNdnZ2ZjT2tddeo8eNG9fu82effZZ+//336RUrVtCDBg3idoJGwsX9qRISEkKvWrWKg5lxhzH3+O9//5seMGCA2phnn32WnjhxIpdTNAom96ft396vv/5KCwQCWiqVKj/bv38/TVEULZFIOJ6p4RhzjxkZGbRAIKAzMzNNMzmOMOYeFfz73/+mZ82axerfvCqdaiVuCFVVVXBzc1P7bNu2bbhz5w5WrFjRQbPiDk33p4pMJkNNTY3OMZZO23tMTExETEyM2piJEyciMTHR3FMzCUOGDAGPx8O2bdsglUpRVVWFHTt2ICYmBjY2Nh09PU44cOAAevfujb/++gsBAQHw9/fHyy+/jIqKio6eGqecPHkSv/76K7788kuDz2FxBljm5Pz58/j5559x8OBB5We3bt3CkiVLkJCQAIHAun88mu6vLZ999hlqa2vxzDPPmHFm3KHpHouKitCtWze1cd26dUN1dTUaGhpga2tr7mlySkBAAI4ePYpnnnkGCxYsgFQqRVRUFOLj4zt6apxx584d3L17F7/++iu2b98OqVSKt99+G08//TROnjzZ0dPjhPLycrzwwgvYuXOnUYZgFr8SX7JkCSiK0vknMzOT9XnT09Mxbdo0rFixAhMmTAAASKVSzJw5E6tWrULfvn25vhWNmPP+2rJr1y6sWrUKv/zyC7y8vIy9Fa105D2aA1PdnzaKioowf/58zJ07F5cuXcLp06chFArx9NNPm6zxgLnvUSaToampCdu3b8fo0aPx6KOPYuvWrTh16hRu3rzJ2XVUMfc9zp8/HzNnzsSYMWOMOo/FLzXfffddvPDCCzrH9O7dm9U5MzIyMH78eLzyyit4//33lZ/X1NTg8uXLSElJwaJFiwDI/zHRNA2BQICjR48iOjqa9T3owpz3p8qePXvw8ssv49dff20XeuAac9+jt7c3iouL1T4rLi6Gk5OTSVbhprg/XXz55ZdwdnbGJ598ovxs586d8PX1xcWLFxEZGcnZtRSY+x59fHwgEAjUFlP9+/cHAOTl5aFfv36cXUuBue/x5MmT2L9/Pz777DMA8mwcmUwGgUCAb7/9Fi+99BKj81i8iHt6esLT05Oz812/fh3R0dGYO3duu3QlJycnpKWlqX321Vdf4eTJk/jtt98QEBDA2TwUmPP+FOzevRsvvfQS9uzZgylTpnB2bW2Y+x41hRaOHTuGqKgozuagCtf3p4/6+vp2zQX4fD4A+aLDFJj7HkeOHImWlhZkZ2ejT58+AICsrCwAgJ+fn0muae57TExMhFQqVX69b98+rF+/HufPn0ePHj0Yn8fiRZwNeXl5qKioQF5eHqRSKVJTUwEAgYGBcHBwQHp6OqKjozFx4kS88847KCoqAiD/BfD09ASPx0NoaKjaOb28vCAWi9t93hEYe3+APIQyd+5cfPHFFxg+fLhyjK2trUmN65nCxT0uXLgQmzZtwr///W+89NJLOHnyJH755RedewPmQt/9AfKc4draWhQVFaGhoUE5JiQkBEKhEFOmTMGGDRvw4YcfYsaMGaipqcF7770HPz8/DB48uIPu7CFc3GNMTAwiIiLw0ksvYePGjZDJZHj99dcRGxtrtlCnLri4R8WbhYLLly9r1CC9sM5nsWDmzp1LA2j359SpUzRNy1N9NH3fz89P6zktKcWQi/sbO3asxjFz587tkHtqC1d/h6dOnaLDw8NpoVBI9+7dm962bZvZ70UT+u6PprX/HeXk5CjH7N69mx48eDBtb29Pe3p60lOnTqVv3Lhh/hvSAFf3mJ+fT0+fPp12cHCgu3XrRr/wwgt0eXm5+W9IA1zdoyqGphgSK1oCgUCwYiw+O4VAIBAI2iEiTiAQCFYMEXECgUCwYoiIEwgEghVDRJxAIBCsGCLiBAKBYMUQEScQCAQrhog4gUAgWDFExAkEAsGKISJOIBAIVgwRcQKBQLBiiIgTCASCFfP/+r7bIh7vzUoAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "sb1_geo.plot()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "32d51a96-370e-4d14-aa2e-bf3bd69e3383",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Fill in NA..turn this into a func\n",
-    "sb1_geo = sb1_geo.fillna(sb1_geo.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
+    "#### Step 3: Figure out why the rows differ between `sb1_all_projects` and `sb1_geo2`"
    ]
   },
   {
@@ -441,26 +993,6 @@
    "source": [
     "# Subset to join back to the 9,000 projects above\n",
     "# subset = ['objectid', 'agencyids', 'projecttitle','programcodes', 'projectid','geometry']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b8413685-db5a-43c8-81a4-46e7f98175c0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sb1_project_id = clean_project_id(sb1_project_id, \"project_id\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "76b3ea1c-9750-4f68-9659-96de5f83bbc5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_gdf2 = clean_project_id(full_gdf2, \"projectid\")"
    ]
   },
   {
@@ -610,17 +1142,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3a9fb1a-9cbf-45a9-a0a6-cc96dbb16b09",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Fill in NA\n",
-    "sb1_2 = sb1_2.fillna(sb1_2.dtypes.replace({\"float64\": 0.0, \"object\": \"None\"}))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "7510fd40-c15e-42ba-a4f1-68031c2e6b3e",
    "metadata": {},
    "outputs": [],
@@ -643,33 +1164,6 @@
    "outputs": [],
    "source": [
     "# sb1_geo2 = sb1_geo[subset]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12bf83bd-dd26-42e0-b339-0738fa2c5365",
-   "metadata": {},
-   "source": [
-    "#### Step 3: Figure out why the rows differ between `sb1_all_projects` and `sb1_geo2`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "237a5df4-60b9-4b73-858e-0468dad85d15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def clean_project_names_id(df, project_name_col:str, project_id_col: str):\n",
-    "    df[project_name_col] = (df[project_name_col].str.lower().str.strip().str.split(\"20\").str[0])\n",
-    "    \n",
-    "    df[project_id_col] = df[project_id_col].str.replace(\"'\", \"\").str.lower().str.strip()\n",
-    "    \n",
-    "    # Get rid of | in object cols\n",
-    "    # https://stackoverflow.com/questions/68152902/extracting-only-object-type-columns-in-a-separate-list-from-a-data-frame-in-pand\n",
-    "    for i in df.select_dtypes(include=['object']).columns.to_list():\n",
-    "        df[i] = df[i].str.replace(\"|\", \"\")\n",
-    "    return df"
    ]
   },
   {
@@ -752,110 +1246,6 @@
     "    right_on=[\"projecttitle\", \"ct_districts\", \"agencyids\", \"fiscalyears\"],\n",
     "    indicator=True,\n",
     ")[[\"_merge\"]].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "69f2f3b4-c1d0-4d4b-87c5-d2158e115dcc",
-   "metadata": {},
-   "source": [
-    "### Merge 9 Sample Non SHOPP with Geojson"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2258812c-fed6-4b48-84f7-10367a9b8839",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for i in [\"project_name\", \"ea\", \"ppno\"]:\n",
-    "    nonshopp[i] = nonshopp[i].str.lower()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3e217738-36f1-4c7e-939d-dda2c86dc95d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nine_projects_names = [\n",
-    "    \"LA-210 Median Concrete Barrier Renovation\",\n",
-    "    \"SR-14 Widening Project\",\n",
-    "    \"US 395 Freight Mobility and Safety Project\",\n",
-    "    \"East Bay Greenway Multimodal Corridor Project\",\n",
-    "    \"Watsonville-Santa Cruz Multimodal Corridor Program\",\n",
-    "    \"SM 101 Woodside Road Interchange and Port Access Project\",\n",
-    "    \"I-710 Integrated Corridor Management\",\n",
-    "    \"Five Cities Multimodal Transportation Network Enhancement Project\",\n",
-    "    \"SR-86/Avenue 50 New Interchange (Phase II)\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8834ce41-93b4-4978-a1bf-d4595dad14a6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nine_projects_names = [x.lower() for x in nine_projects_names]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8b7deddf-30b5-4071-8a9c-2bd91c9cdc25",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nine_projects_id = [\n",
-    "    \"0422000202\",\n",
-    "    \"0414000032\",\n",
-    "    \"0520000083\",\n",
-    "    \"0515000063\",\n",
-    "    \"0721000056\",\n",
-    "    \"0716000370\",\n",
-    "    \"0813000222\",\n",
-    "    \"0814000144\",\n",
-    "    \"0414000032\",\n",
-    "    \"0720000165\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "86fcc2e9-e7d2-413e-bf0f-a133f9e1d628",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nine_sample_projects = (nonshopp[nonshopp.ct_project_id.isin(nine_projects_id)].reset_index(drop=True))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7fbba442-b295-4a9b-b94d-68dc41c0131f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Subset sb1_geo to only districts these 9 projects are located in\n",
-    "sb1_geo3 = sb1_geo2[sb1_geo2[\"ct_districts\"].str.contains(('05|07|04|08'))].reset_index(drop = True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02d7a5b9-36fd-463d-8bb8-710335d9c752",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "sb1_geo3.explore()"
    ]
   },
   {

--- a/project_prioritization/add_tircp.ipynb
+++ b/project_prioritization/add_tircp.ipynb
@@ -10,19 +10,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c2bbe80b-66c4-44d6-9888-93b8ae4f8ab2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:123: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import _utils\n",
     "import numpy as np\n",
@@ -32,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "85238cd5-f743-480b-968e-c9b4dae07d66",
    "metadata": {},
    "outputs": [],
@@ -44,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "d9ae83e2-c80f-4ea9-a125-bf5d5695fbb7",
    "metadata": {},
    "outputs": [],
@@ -63,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "fd66609e-464a-4bd0-b430-848e2dfcd895",
    "metadata": {},
    "outputs": [],
@@ -76,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "51fc1e91-cd82-4eca-a6cc-78267acfc8fb",
    "metadata": {},
    "outputs": [],
@@ -86,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "ce97edf3-0cb5-4008-8e18-287fe7bdc372",
    "metadata": {},
    "outputs": [],
@@ -113,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "cd738aa0-e3da-4aca-860e-d6eca9ce2226",
    "metadata": {},
    "outputs": [],
@@ -124,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "15004a48-f44b-4342-8e93-9ead6ab1fc6e",
    "metadata": {},
    "outputs": [],
@@ -134,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "6a609e26-856b-47af-997e-0d92e6ccb43b",
    "metadata": {},
    "outputs": [],
@@ -160,22 +151,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "72b8f0e8-574b-4ab3-8f01-98fb375d135c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.9/site-packages/pandas/core/generic.py:5516: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Lowercase previous caltrans nominations\n",
     "atp_shopp2.previous_caltrans_nominations = (\n",
@@ -185,22 +164,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "861271c5-7843-4f05-85b9-bc7b6f384c33",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_3783/2101408362.py:3: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Clean ATP\n",
     "atp_shopp2 = organization_cleaning(atp_shopp2, \"lead_agency\")"
@@ -208,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "f6b4f1d5-8576-4551-8ce3-8ab77a8f9e63",
    "metadata": {
     "scrolled": true,
@@ -230,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "b58732d7-ca56-46ed-b7d1-0d41b4d9ff84",
    "metadata": {},
    "outputs": [],
@@ -245,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "91556902-a9f6-4d19-921c-6c8f7de6d370",
    "metadata": {},
    "outputs": [],
@@ -255,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "d9f48b3b-2a22-4108-a525-3eb2fcbf6f1f",
    "metadata": {},
    "outputs": [],
@@ -279,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "d772cd9a-c59f-4d37-920c-2ad1f7f64265",
    "metadata": {},
    "outputs": [],
@@ -289,22 +256,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "5782e128-b6f7-451f-8cad-af9c0115e98c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_3783/2189071234.py:2: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create a column with cycle + tircp for previous CT nominations\n",
     "tircp2[\"previous_caltrans_nominations\"] = (\n",
@@ -314,22 +269,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "682a34c6-76d6-4fcb-8a9e-ef1437469533",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_3783/2212343423.py:2: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create column for unmet needs\n",
     "tircp2[\"total_unfunded_need__$1,000\"] = tircp2[\"total__cost\"] - tircp2[\"tircp\"]"
@@ -337,22 +280,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "9910645c-7b2a-4d6d-9dac-a1113786ffca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_3783/2822305151.py:3: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Perhaps to narrow down projects\n",
     "# Figure out which TIRCP projects' total cost are completely covered by TIRCP requested\n",
@@ -361,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "972a6e04-7d07-42a6-9ae3-764051f14ee3",
    "metadata": {
     "scrolled": true,
@@ -374,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "7eb933ed-977f-430d-88c3-6d46293403d6",
    "metadata": {},
    "outputs": [],
@@ -385,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "003abcb7-2179-4edf-831a-0cd5bba49bad",
    "metadata": {},
    "outputs": [],
@@ -396,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "c44b9a50-d0eb-4658-bebc-799264b50262",
    "metadata": {},
    "outputs": [],
@@ -406,21 +337,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "206297b2-cdc8-446d-8f7c-3407105fab95",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(93, 12)"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tircp2.shape"
    ]
@@ -435,18 +355,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "5deb8193-f0b8-4244-9e6b-614d05830ead",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_3783/3824326962.py:2: FutureWarning: Inferring datetime64[ns] from data containing strings is deprecated and will be removed in a future version. To retain the old behavior explicitly pass Series(data, dtype={value.dtype})\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "allocation = to_snakecase(\n",
     "    pd.read_excel(\n",
@@ -458,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "0bfc76f9-5eec-4f27-bea4-b8f0f8a5c753",
    "metadata": {},
    "outputs": [],
@@ -468,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "4ecb04a7-9cec-45b6-ba7a-1b05906137e5",
    "metadata": {},
    "outputs": [],
@@ -479,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "ff78feda-20e1-4ba9-a791-cf4cd04c99a3",
    "metadata": {},
    "outputs": [],
@@ -492,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "1f8d4abd-9e4d-4b07-80b5-7bebacd3e70c",
    "metadata": {},
    "outputs": [],
@@ -505,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "65e0b008-3fa4-4cc4-ac11-9e15bce5edb1",
    "metadata": {},
    "outputs": [],
@@ -516,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "35c43b35-1e9b-46c4-932f-6aa0e2f00feb",
    "metadata": {},
    "outputs": [],
@@ -532,21 +444,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "e81d13c1-adc5-4e6c-b756-40fc308e9335",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "93"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(tircp2)"
    ]
@@ -562,28 +463,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "e7d3bc6f-3660-45f5-97ca-1171b25a6b41",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(242, 814)"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "atp_shopp2.previous_caltrans_nominations.nunique(), len(atp_shopp2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "d6155648-fe73-4d3c-a4a7-c95f9d682410",
    "metadata": {
     "scrolled": true,
@@ -600,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "86db0fc2-43c1-4ada-a304-b1fed8014368",
    "metadata": {},
    "outputs": [],
@@ -611,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "8aa7dac1-bec7-404d-8929-02c7fbd314af",
    "metadata": {},
    "outputs": [],
@@ -626,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "c61b5e48-e4d9-4338-a1dc-1171c1e87ce5",
    "metadata": {},
    "outputs": [],
@@ -642,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "84bf700b-c053-4a05-a8ef-a738814945a7",
    "metadata": {},
    "outputs": [],
@@ -652,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "8046f854-af91-4cde-bd3a-b7d3b0708147",
    "metadata": {},
    "outputs": [],
@@ -667,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "75035054-4c67-417c-91ab-810cb81e75a9",
    "metadata": {},
    "outputs": [],
@@ -677,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "3a354c4e-f069-40e7-9af5-7f4a2312b196",
    "metadata": {},
    "outputs": [],
@@ -688,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "e8b8da34-2011-49e1-a4bf-f7f9f5625fd3",
    "metadata": {},
    "outputs": [],
@@ -708,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "7919d1b1-9e22-43b0-ab92-d46ea3e87bcb",
    "metadata": {},
    "outputs": [],
@@ -718,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "566af02a-aea5-41b8-b0a7-06b27a9175b4",
    "metadata": {},
    "outputs": [],
@@ -728,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "b892dc7e-10b5-4f47-a306-6895a1384af9",
    "metadata": {},
    "outputs": [],
@@ -739,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "9f2edd46-937c-47a2-9a2c-506acb677126",
    "metadata": {},
    "outputs": [],
@@ -750,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "fd71f573-2fe6-4a79-823a-e27690e44544",
    "metadata": {},
    "outputs": [],
@@ -772,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "e93416a9-6bad-4c23-9f9b-d0150da4f404",
    "metadata": {},
    "outputs": [],
@@ -800,7 +690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "e18a2ae0-f833-40d8-9ba3-0ad63c5f5304",
    "metadata": {},
    "outputs": [],
@@ -811,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "b7a6d4b5-6f10-459a-8b81-53a0a5bee8c6",
    "metadata": {},
    "outputs": [],
@@ -822,7 +712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "8664892c-1858-45f7-850c-c0c55aee2efb",
    "metadata": {},
    "outputs": [],
@@ -832,7 +722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "id": "0dee73f8-f072-4362-b78b-a8180d2896f7",
    "metadata": {},
    "outputs": [],
@@ -843,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "id": "9bb2b535-ed53-4ee7-a0d2-5ed36d816cad",
    "metadata": {},
    "outputs": [],
@@ -854,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "id": "081af521-a523-4bfd-9ef5-6e55ab6bf413",
    "metadata": {},
    "outputs": [],
@@ -864,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "id": "3b716695-f3b9-455c-afa1-e543de6657a2",
    "metadata": {},
    "outputs": [],
@@ -875,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "3d8741cd-40a2-49ad-8dc7-e922903f278d",
    "metadata": {},
    "outputs": [],
@@ -885,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "afdd6d7f-ca92-4314-9009-23a736d274c5",
    "metadata": {},
    "outputs": [],
@@ -895,7 +785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "5cd991f8-8dea-4eee-a56f-bb6908f8df70",
    "metadata": {},
    "outputs": [],
@@ -919,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "1884f7bf-ab50-4a98-81c0-e3de3429169d",
    "metadata": {},
    "outputs": [],
@@ -932,164 +822,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "87384c4a-6815-4cc2-9120-1ed1509916bd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>district</th>\n",
-       "      <th>description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>59</th>\n",
-       "      <td>District 7: Los Angeles</td>\n",
-       "      <td>Construction of a 1.6-mile electrically powered automated people mover (APM) system and three new stations in the City of Inglewood. The project will create a new connection for passengers directly from the LA Metro Crenshaw/LAX Line’s Downtown Inglewood Station to new housing and employment centers, and regionally serving sports and entertainment including the Los Angeles Sports and Entertainment District (LASED) at Hollywood Park/SoFi Stadium and the proposed Inglewood Basketball and Entertainment Center (IBEC) Project. The project will connect the City of Inglewood’s high growth areas with LA Metro’s regional rail system.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>91</th>\n",
-       "      <td>District 6: Fresno / Bakersfield</td>\n",
-       "      <td>Extends ACE from Ceres to Turlock, which is an interim phase of the Ceres to Merced extension. Includes a new Turlock Station and layover track, and provides a direct connection with Turlock Transit</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                            district  \\\n",
-       "59           District 7: Los Angeles   \n",
-       "91  District 6: Fresno / Bakersfield   \n",
-       "\n",
-       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 description  \n",
-       "59  Construction of a 1.6-mile electrically powered automated people mover (APM) system and three new stations in the City of Inglewood. The project will create a new connection for passengers directly from the LA Metro Crenshaw/LAX Line’s Downtown Inglewood Station to new housing and employment centers, and regionally serving sports and entertainment including the Los Angeles Sports and Entertainment District (LASED) at Hollywood Park/SoFi Stadium and the proposed Inglewood Basketball and Entertainment Center (IBEC) Project. The project will connect the City of Inglewood’s high growth areas with LA Metro’s regional rail system.  \n",
-       "91                                                                                                                                                                                                                                                                                                                                                                                                                                                    Extends ACE from Ceres to Turlock, which is an interim phase of the Ceres to Merced extension. Includes a new Turlock Station and layover track, and provides a direct connection with Turlock Transit  "
-      ]
-     },
-     "execution_count": 61,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tircp.loc[tircp.title.isin(tircp_already_entered)][['district','description']]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "8e02f629-88c7-4f2f-b4a7-67b2708de360",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>project_name</th>\n",
-       "      <th>district</th>\n",
-       "      <th>project_description</th>\n",
-       "      <th>primary_mode</th>\n",
-       "      <th>previous_caltrans_nominations</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Los Angeles Metro Light Rail Capital, Operational And Rehabilitation Enhancements (Core) Capacity &amp; System Integration Project</td>\n",
-       "      <td>7</td>\n",
-       "      <td>The project will eliminate a two-car capacity constraint on the integrated Crenshaw/LAX and Green (C) light rail lines, which operate within the congested I-405 and I-105 corridors and the area around Los Angeles International Airport (LAX), by:\\n1) Extending the aerial platforms at four Green Line stations (Redondo Beach, Douglas, Mariposa, and Aviation/LAX)\\n2) State of good repair work and station improvements at all of those four stations plus El Segundo Station\\n3) Adding two new traction power substations (TPSS) on the Crenshaw/LAX Line in the cities of Inglewood and Los Angeles</td>\n",
-       "      <td>Rail (Passenger)</td>\n",
-       "      <td>sccp cycle 3 priority 13 of 14\\nnot awarded tircp</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>Inglewood Transit Connector (Itc) Project</td>\n",
-       "      <td>7</td>\n",
-       "      <td>The Project consists of an approximately 1.6-mile fully elevated transit system in the City of Inglewood with three transit station connecting passengers from the Metro Crenshaw/LAX (K) Line to the City's new housing and employment centers and sports and entertainment venues. The Project is primarily located along Market Street, Manchester Boulevard and Prairie Avenue and includes a fully elevated guideway and supporting infrastructure, automated trains, a maintenance and storage facility, power distribution substations, and new public parking lots.</td>\n",
-       "      <td>Transit</td>\n",
-       "      <td>tircp award was downscaled\\nsccp cycle 3 priority 05 of 14\\nawarded raise 2022 (not caltrans)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>Fresno Subdivision (Ceres To Turlock) Double Tracking</td>\n",
-       "      <td>10</td>\n",
-       "      <td>Construct double tracking of 8.1 miles of existing single-track UPRR mainline rail corridor to alleviate congestion, increase capacity, improve safety, and allow for more efficient freight rail movement. A secondary benefit is the project is also necessary for the extension of Altamont Corridor Express (ACE) passenger rail services from Ceres to Turlock.</td>\n",
-       "      <td>Rail (Freight)</td>\n",
-       "      <td>tircp 2021  application - pending award\\ninfra 2022 application - pending award\\ntcep cycle 3 priority 04 of 24\\nmpdg los 2022 signed</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                                                                                     project_name  \\\n",
-       "4  Los Angeles Metro Light Rail Capital, Operational And Rehabilitation Enhancements (Core) Capacity & System Integration Project   \n",
-       "6                                                                                       Inglewood Transit Connector (Itc) Project   \n",
-       "7                                                                           Fresno Subdivision (Ceres To Turlock) Double Tracking   \n",
-       "\n",
-       "   district  \\\n",
-       "4         7   \n",
-       "6         7   \n",
-       "7        10   \n",
-       "\n",
-       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               project_description  \\\n",
-       "4  The project will eliminate a two-car capacity constraint on the integrated Crenshaw/LAX and Green (C) light rail lines, which operate within the congested I-405 and I-105 corridors and the area around Los Angeles International Airport (LAX), by:\\n1) Extending the aerial platforms at four Green Line stations (Redondo Beach, Douglas, Mariposa, and Aviation/LAX)\\n2) State of good repair work and station improvements at all of those four stations plus El Segundo Station\\n3) Adding two new traction power substations (TPSS) on the Crenshaw/LAX Line in the cities of Inglewood and Los Angeles   \n",
-       "6                                      The Project consists of an approximately 1.6-mile fully elevated transit system in the City of Inglewood with three transit station connecting passengers from the Metro Crenshaw/LAX (K) Line to the City's new housing and employment centers and sports and entertainment venues. The Project is primarily located along Market Street, Manchester Boulevard and Prairie Avenue and includes a fully elevated guideway and supporting infrastructure, automated trains, a maintenance and storage facility, power distribution substations, and new public parking lots.   \n",
-       "7                                                                                                                                                                                                                                             Construct double tracking of 8.1 miles of existing single-track UPRR mainline rail corridor to alleviate congestion, increase capacity, improve safety, and allow for more efficient freight rail movement. A secondary benefit is the project is also necessary for the extension of Altamont Corridor Express (ACE) passenger rail services from Ceres to Turlock.   \n",
-       "\n",
-       "       primary_mode  \\\n",
-       "4  Rail (Passenger)   \n",
-       "6           Transit   \n",
-       "7    Rail (Freight)   \n",
-       "\n",
-       "                                                                                                           previous_caltrans_nominations  \n",
-       "4                                                                                      sccp cycle 3 priority 13 of 14\\nnot awarded tircp  \n",
-       "6                                          tircp award was downscaled\\nsccp cycle 3 priority 05 of 14\\nawarded raise 2022 (not caltrans)  \n",
-       "7  tircp 2021  application - pending award\\ninfra 2022 application - pending award\\ntcep cycle 3 priority 04 of 24\\nmpdg los 2022 signed  "
-      ]
-     },
-     "execution_count": 62,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Projects with only TIRCP in the previous nomination.\n",
     "atp_shopp_drmt[atp_shopp_drmt[\"previous_caltrans_nominations\"].str.contains((\"tircp\"))][['project_name','district','project_description','primary_mode','previous_caltrans_nominations']]"
@@ -1097,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "bc85ae55-080c-4c06-a38c-80dcedb7f463",
    "metadata": {
     "scrolled": true,
@@ -1115,28 +861,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "ed2fe568-d816-4b68-862c-916a1d174b65",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "91"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(tircp2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "27b67771-a209-4feb-acb2-7b5edd04bc0a",
    "metadata": {
     "scrolled": true,
@@ -1157,7 +892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "id": "a3d51990-832b-4085-b272-669174c5a9d3",
    "metadata": {},
    "outputs": [],
@@ -1167,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "id": "b60d9694-cd93-4089-bc51-1b853ed8b44f",
    "metadata": {},
    "outputs": [],
@@ -1177,7 +912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "id": "13a0beb2-fb7a-40b6-8725-ae7dfe043221",
    "metadata": {},
    "outputs": [],
@@ -1187,7 +922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "id": "77698d2e-ed0f-4a50-80a2-8e6651fc86cf",
    "metadata": {},
    "outputs": [],
@@ -1197,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "id": "771563fd-ef89-400c-87fd-4ea22ba8e170",
    "metadata": {
     "scrolled": true,
@@ -1210,7 +945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "id": "07c7c782-2091-4fa8-bb17-461210bda2ed",
    "metadata": {},
    "outputs": [],
@@ -1221,7 +956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "id": "1cadc113-4e40-47bc-a9fe-fa9c7a236225",
    "metadata": {},
    "outputs": [],
@@ -1231,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "id": "d339dafd-9b46-485d-830f-f03b9fcf9457",
    "metadata": {
     "scrolled": true,
@@ -1244,7 +979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "id": "79fcc908-95b4-4c5d-8d49-69e9684f36d5",
    "metadata": {
     "scrolled": true,
@@ -1268,7 +1003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "id": "97a0a86a-936c-4f16-927f-f8da313bd310",
    "metadata": {},
    "outputs": [],
@@ -1295,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "id": "f51fea69-60b9-4599-b637-69acf0e76aa1",
    "metadata": {},
    "outputs": [],
@@ -1306,7 +1041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "id": "3db3e68b-022b-4f33-ac76-3ac7dca1ea69",
    "metadata": {},
    "outputs": [],
@@ -1316,7 +1051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "id": "7a4526d9-62c4-4881-aaf5-fc2ecf94b964",
    "metadata": {},
    "outputs": [],
@@ -1329,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "id": "a9884e76-7190-4cee-9cec-b7eee80c3541",
    "metadata": {
     "scrolled": true,
@@ -1342,7 +1077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "id": "2d28b9a4-9b71-40f0-a9d3-82ce21c28d84",
    "metadata": {},
    "outputs": [],
@@ -1353,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "id": "acc8ca9b-7107-4662-8e5d-d29a45e58028",
    "metadata": {},
    "outputs": [],
@@ -1363,7 +1098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "id": "13b5a594-6899-403f-a5f0-be142c494d4c",
    "metadata": {},
    "outputs": [],
@@ -1385,7 +1120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "id": "3f3c562f-4131-4728-b53d-e82c0b80a888",
    "metadata": {},
    "outputs": [],
@@ -1396,7 +1131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "id": "3202dc48-927d-44ae-848e-57ed50a8fc74",
    "metadata": {},
    "outputs": [],
@@ -1406,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "id": "69917da4-acf0-47bc-bb6e-0cc72701594e",
    "metadata": {},
    "outputs": [],
@@ -1416,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "id": "012bfea4-ecb2-437c-90c9-b786c896d16d",
    "metadata": {},
    "outputs": [],
@@ -1427,7 +1162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "id": "1601987f-a5cd-4efb-a289-c7ed8ec67b94",
    "metadata": {},
    "outputs": [],
@@ -1437,7 +1172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "id": "b19fbf47-b654-4a65-b312-7d2deb2c862e",
    "metadata": {
     "scrolled": true,
@@ -1458,7 +1193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "id": "5e65c7ff-803d-4ff7-8d89-b2f1f733089a",
    "metadata": {},
    "outputs": [],
@@ -1480,7 +1215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "id": "f8a12de2-d619-4087-97e7-b336d3741685",
    "metadata": {},
    "outputs": [],
@@ -1490,7 +1225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "id": "645d746d-6595-47c0-9271-0a51d925cfa8",
    "metadata": {},
    "outputs": [],
@@ -1500,7 +1235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "id": "f29b32b0-8dd8-47dc-ac9b-f6c4c20acd6f",
    "metadata": {},
    "outputs": [],
@@ -1510,367 +1245,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "id": "e29fc0fe-3bab-47d8-b626-6673c56360c4",
    "metadata": {
     "scrolled": true,
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Rail Project Id</th>\n",
-       "      <th>10 Year Plan</th>\n",
-       "      <th>Ct Project Id</th>\n",
-       "      <th>Ea</th>\n",
-       "      <th>Ppno</th>\n",
-       "      <th>Project Name</th>\n",
-       "      <th>District</th>\n",
-       "      <th>County</th>\n",
-       "      <th>Route</th>\n",
-       "      <th>Project Description</th>\n",
-       "      <th>Current Phase</th>\n",
-       "      <th>Con Existing Source S  Of Funds</th>\n",
-       "      <th>Con Anticipated Source Of Funds</th>\n",
-       "      <th>Target Opening Year</th>\n",
-       "      <th>Beg Pm</th>\n",
-       "      <th>End Pm</th>\n",
-       "      <th>Primary Mode</th>\n",
-       "      <th>Previous Caltrans Nominations</th>\n",
-       "      <th>Urban Rural</th>\n",
-       "      <th>Notes</th>\n",
-       "      <th>Lead Agency</th>\n",
-       "      <th>Pid Approval Date  M010</th>\n",
-       "      <th>Target Pa Ed  M200</th>\n",
-       "      <th>Rtl Date  M460</th>\n",
-       "      <th>Con Start Date  M500</th>\n",
-       "      <th>Funding Need Phase S</th>\n",
-       "      <th>Pa Ed Cost  $1,000</th>\n",
-       "      <th>Ps E Cost  $1,000</th>\n",
-       "      <th>Row Cost  $1,000</th>\n",
-       "      <th>Con Support Cost  $1,000</th>\n",
-       "      <th>Non Infrastructure   Plan Cost  $1,000</th>\n",
-       "      <th>Total Unfunded Need  $1,000</th>\n",
-       "      <th>Previous Funding Request Phase</th>\n",
-       "      <th>Last Scored</th>\n",
-       "      <th>Csis Alignment</th>\n",
-       "      <th>Csis Total Score  Out Of 45</th>\n",
-       "      <th>Mode Shift  Csis  Score</th>\n",
-       "      <th>Mode Shift  Csis  Comment</th>\n",
-       "      <th>Vmt  Csis  Score</th>\n",
-       "      <th>Vmt  Csis  Comment</th>\n",
-       "      <th>Public Engagement  Csis  Score</th>\n",
-       "      <th>Public Engagement  Csis  Comment</th>\n",
-       "      <th>Dac Local Community Needs  Csis  Score</th>\n",
-       "      <th>Dac Local Community Needs  Csis  Comment</th>\n",
-       "      <th>Safety  Csis  Score</th>\n",
-       "      <th>Safety  Csis  Comment</th>\n",
-       "      <th>Zev  Csis  Score</th>\n",
-       "      <th>Zev  Csis  Comment</th>\n",
-       "      <th>Climate Resiliency  Csis  Score</th>\n",
-       "      <th>Climate Resiliency  Csis  Comment</th>\n",
-       "      <th>Natural Resources And Ecosystems  Csis  Score</th>\n",
-       "      <th>Natural Resources And Ecosystems  Csis  Comment</th>\n",
-       "      <th>Infill Development And Land Use  Csis  Score</th>\n",
-       "      <th>Infill Development And Land Use  Csis  Comment</th>\n",
-       "      <th>Benefits To Dac And Advancing Equity  Atp  Score</th>\n",
-       "      <th>Community Need  Atp  Score</th>\n",
-       "      <th>Safety  Atp  Score</th>\n",
-       "      <th>Public Participation  Atp  Score</th>\n",
-       "      <th>Community Feedback  Atp  Score</th>\n",
-       "      <th>Continued Engagement  Atp  Score</th>\n",
-       "      <th>Context Sensitive And Innovation  Atp  Score</th>\n",
-       "      <th>Transformative  Atp  Score</th>\n",
-       "      <th>Atp Total Score  Out Of 100</th>\n",
-       "      <th>Atp Alignment</th>\n",
-       "      <th>Access Alignment</th>\n",
-       "      <th>2023</th>\n",
-       "      <th>2024</th>\n",
-       "      <th>2025</th>\n",
-       "      <th>2026</th>\n",
-       "      <th>2027</th>\n",
-       "      <th>2028</th>\n",
-       "      <th>2029</th>\n",
-       "      <th>2030</th>\n",
-       "      <th>2031</th>\n",
-       "      <th>2032</th>\n",
-       "      <th>2033</th>\n",
-       "      <th>Previous Funding Request</th>\n",
-       "      <th>Purpose   Need</th>\n",
-       "      <th>Parcel Counts</th>\n",
-       "      <th>Total Project Cost  $1,000</th>\n",
-       "      <th>Con Capital Cost  $1,000</th>\n",
-       "      <th>Hq Priority</th>\n",
-       "      <th>District Priority</th>\n",
-       "      <th>Potential Funding Program S</th>\n",
-       "      <th>Located In Dac</th>\n",
-       "      <th>Shs Capacity Increase Detail</th>\n",
-       "      <th>Secondary Mode S</th>\n",
-       "      <th>Full County Name</th>\n",
-       "      <th>Abbrev</th>\n",
-       "      <th>District Full Name</th>\n",
-       "      <th>Ppno1</th>\n",
-       "      <th>Total Project Cost  $1,000 1</th>\n",
-       "      <th>Pa Ed Cost  $1,000 1</th>\n",
-       "      <th>Ps E Cost  $1,000 1</th>\n",
-       "      <th>Non Infrastructure   Plan Cost  $1,000 1</th>\n",
-       "      <th>Detailed Project Title</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0120000130</td>\n",
-       "      <td>0K660</td>\n",
-       "      <td>3204</td>\n",
-       "      <td>Lucerne Complete Streets</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LAK</td>\n",
-       "      <td>020</td>\n",
-       "      <td>Develop complete streets improvements to connect Lucerne's downtown to their waterfront. Including: sidewalk, crosswalks, buffered bike lanes, flashing beacons bulbouts, two pedestrian bridges.</td>\n",
-       "      <td>PID</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>16.74</td>\n",
-       "      <td>18.02</td>\n",
-       "      <td>Complete Streets</td>\n",
-       "      <td>FY 21-22 Non-SHOPP PID Nomination (Carryover)</td>\n",
-       "      <td>Rural</td>\n",
-       "      <td>PID Completed</td>\n",
-       "      <td>Caltrans</td>\n",
-       "      <td>datetime64[ns]</td>\n",
-       "      <td>None</td>\n",
-       "      <td>datetime64[ns]</td>\n",
-       "      <td>datetime64[ns]</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>Not Well-Aligned</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>Not Well-Aligned</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>None</td>\n",
-       "      <td>31268.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>Atp\\nActive Transportation Infrastructure Investment Program\\nPid Non-Shopp\\nRaise\\nRural</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Bike/Pedestrian\\nBridge</td>\n",
-       "      <td>Lake</td>\n",
-       "      <td>LAK</td>\n",
-       "      <td>01 - Eureka</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>District 1-Lucerne Complete Streets</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Rail Project Id  10 Year Plan Ct Project Id     Ea  Ppno  \\\n",
-       "24            None           0.0    0120000130  0K660  3204   \n",
-       "\n",
-       "                Project Name  District County Route  \\\n",
-       "24  Lucerne Complete Streets         1    LAK   020   \n",
-       "\n",
-       "                                                                                                                                                                                  Project Description  \\\n",
-       "24  Develop complete streets improvements to connect Lucerne's downtown to their waterfront. Including: sidewalk, crosswalks, buffered bike lanes, flashing beacons bulbouts, two pedestrian bridges.   \n",
-       "\n",
-       "   Current Phase Con Existing Source S  Of Funds  \\\n",
-       "24           PID                            None   \n",
-       "\n",
-       "   Con Anticipated Source Of Funds Target Opening Year Beg Pm End Pm  \\\n",
-       "24                            None                None  16.74  18.02   \n",
-       "\n",
-       "        Primary Mode                  Previous Caltrans Nominations  \\\n",
-       "24  Complete Streets  FY 21-22 Non-SHOPP PID Nomination (Carryover)   \n",
-       "\n",
-       "   Urban Rural          Notes Lead Agency Pid Approval Date  M010  \\\n",
-       "24       Rural  PID Completed    Caltrans          datetime64[ns]   \n",
-       "\n",
-       "   Target Pa Ed  M200  Rtl Date  M460 Con Start Date  M500  \\\n",
-       "24               None  datetime64[ns]       datetime64[ns]   \n",
-       "\n",
-       "    Funding Need Phase S  Pa Ed Cost  $1,000  Ps E Cost  $1,000  \\\n",
-       "24                   0.0                 0.0                0.0   \n",
-       "\n",
-       "    Row Cost  $1,000  Con Support Cost  $1,000  \\\n",
-       "24               0.0                       0.0   \n",
-       "\n",
-       "    Non Infrastructure   Plan Cost  $1,000  Total Unfunded Need  $1,000  \\\n",
-       "24                                     0.0                          0.0   \n",
-       "\n",
-       "   Previous Funding Request Phase  Last Scored    Csis Alignment  \\\n",
-       "24                           None          0.0  Not Well-Aligned   \n",
-       "\n",
-       "    Csis Total Score  Out Of 45  Mode Shift  Csis  Score  \\\n",
-       "24                          0.0                      0.0   \n",
-       "\n",
-       "   Mode Shift  Csis  Comment  Vmt  Csis  Score Vmt  Csis  Comment  \\\n",
-       "24                      None               0.0               None   \n",
-       "\n",
-       "    Public Engagement  Csis  Score Public Engagement  Csis  Comment  \\\n",
-       "24                             0.0                             None   \n",
-       "\n",
-       "    Dac Local Community Needs  Csis  Score  \\\n",
-       "24                                     0.0   \n",
-       "\n",
-       "    Dac Local Community Needs  Csis  Comment  Safety  Csis  Score  \\\n",
-       "24                                       0.0                  0.0   \n",
-       "\n",
-       "   Safety  Csis  Comment  Zev  Csis  Score Zev  Csis  Comment  \\\n",
-       "24                  None               0.0               None   \n",
-       "\n",
-       "    Climate Resiliency  Csis  Score Climate Resiliency  Csis  Comment  \\\n",
-       "24                              0.0                              None   \n",
-       "\n",
-       "    Natural Resources And Ecosystems  Csis  Score  \\\n",
-       "24                                            0.0   \n",
-       "\n",
-       "   Natural Resources And Ecosystems  Csis  Comment  \\\n",
-       "24                                            None   \n",
-       "\n",
-       "    Infill Development And Land Use  Csis  Score  \\\n",
-       "24                                           0.0   \n",
-       "\n",
-       "   Infill Development And Land Use  Csis  Comment  \\\n",
-       "24                                           None   \n",
-       "\n",
-       "    Benefits To Dac And Advancing Equity  Atp  Score  \\\n",
-       "24                                               0.0   \n",
-       "\n",
-       "    Community Need  Atp  Score  Safety  Atp  Score  \\\n",
-       "24                         0.0                 0.0   \n",
-       "\n",
-       "    Public Participation  Atp  Score  Community Feedback  Atp  Score  \\\n",
-       "24                               0.0                             0.0   \n",
-       "\n",
-       "    Continued Engagement  Atp  Score  \\\n",
-       "24                               0.0   \n",
-       "\n",
-       "    Context Sensitive And Innovation  Atp  Score  Transformative  Atp  Score  \\\n",
-       "24                                           0.0                         0.0   \n",
-       "\n",
-       "    Atp Total Score  Out Of 100     Atp Alignment Access Alignment  2023  \\\n",
-       "24                          0.0  Not Well-Aligned             None  None   \n",
-       "\n",
-       "    2024  2025  2026  2027  2028  2029  2030  2031  2032  2033  \\\n",
-       "24  None   0.0  None   0.0   0.0   0.0   0.0   0.0   0.0   0.0   \n",
-       "\n",
-       "   Previous Funding Request  Purpose   Need Parcel Counts  \\\n",
-       "24                     None             0.0          None   \n",
-       "\n",
-       "    Total Project Cost  $1,000  Con Capital Cost  $1,000  Hq Priority  \\\n",
-       "24                     31268.0                       0.0          0.0   \n",
-       "\n",
-       "    District Priority  \\\n",
-       "24                0.0   \n",
-       "\n",
-       "                                                                  Potential Funding Program S  \\\n",
-       "24  Atp\\nActive Transportation Infrastructure Investment Program\\nPid Non-Shopp\\nRaise\\nRural   \n",
-       "\n",
-       "   Located In Dac Shs Capacity Increase Detail         Secondary Mode S  \\\n",
-       "24           None                         None  Bike/Pedestrian\\nBridge   \n",
-       "\n",
-       "   Full County Name Abbrev District Full Name Ppno1  \\\n",
-       "24             Lake    LAK        01 - Eureka  None   \n",
-       "\n",
-       "    Total Project Cost  $1,000 1  Pa Ed Cost  $1,000 1  Ps E Cost  $1,000 1  \\\n",
-       "24                           0.0                   0.0                  0.0   \n",
-       "\n",
-       "    Non Infrastructure   Plan Cost  $1,000 1  \\\n",
-       "24                                       0.0   \n",
-       "\n",
-       "                 Detailed Project Title  \n",
-       "24  District 1-Lucerne Complete Streets  "
-      ]
-     },
-     "execution_count": 94,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "smartsheet.sample()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "id": "efe382f8-fa6c-44f8-ae77-4e283ce35872",
    "metadata": {},
    "outputs": [],
@@ -1890,7 +1278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "id": "463b63a9-b6c9-47c7-b360-efdd7b2d877e",
    "metadata": {},
    "outputs": [],
@@ -1901,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "id": "d0d9d487-0c50-40fd-9939-2fade126f157",
    "metadata": {},
    "outputs": [],
@@ -1923,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "id": "daf39ccc-dff0-4e00-8396-11baaa609673",
    "metadata": {
     "scrolled": true,
@@ -1938,7 +1326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "id": "8d1fd041-7156-46f2-9fce-b4abaf181912",
    "metadata": {
     "scrolled": true,
@@ -1961,7 +1349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "id": "b2afcb56-2a22-4134-bb7f-9619dee3b79b",
    "metadata": {},
    "outputs": [],
@@ -1978,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "id": "e0d9eeb7-6c95-4c17-83d4-c8c83ae36740",
    "metadata": {
     "tags": []
@@ -1991,7 +1379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "id": "bddf88d4-1f28-402f-b2e5-dc1e00d2b4e5",
    "metadata": {},
    "outputs": [],
@@ -2004,7 +1392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "id": "1e5e936a-1995-4e5d-a640-d1f3fccb518a",
    "metadata": {},
    "outputs": [],
@@ -2017,7 +1405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "id": "968df76b-7a4e-4919-8112-96579926ee12",
    "metadata": {
     "scrolled": true,
@@ -2031,21 +1419,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "id": "c0f8d02a-b4f5-4dfd-be5e-b71091dbf413",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "120"
-      ]
-     },
-     "execution_count": 105,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# D4 only projects\n",
     "len(concat1.loc[concat1[\"district\"] == 4])"
@@ -2053,7 +1430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "id": "9570caef-7cbf-41fd-a6f2-7dbde15eefc7",
    "metadata": {},
    "outputs": [],
@@ -2077,7 +1454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": null,
    "id": "416b79a8-2d71-494b-9f18-0c50989f0e25",
    "metadata": {
     "scrolled": true,
@@ -2103,7 +1480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "id": "2d2bbea0-6092-4cf1-944c-8bdebe2391b8",
    "metadata": {},
    "outputs": [],
@@ -2114,7 +1491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "id": "bd5eeab8-e023-443f-9559-f72c679a1225",
    "metadata": {},
    "outputs": [],
@@ -2130,7 +1507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "id": "730dee9c-ed2f-43b1-ac98-a8624a90ded2",
    "metadata": {},
    "outputs": [],
@@ -2140,7 +1517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "id": "a7312173-49e2-40d7-8ad7-37f120e8098f",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
- Read in layers from SB1 map directly from the server to get geographic information for the Non SHOPP projects. 
- Cleaned up the layers data. Namely, for certain programs, the project titles were located in the "pop up" column while other programs did not have a column for project titles. Had to merge these datasets together and extract the project titles from the popup. 
- Attached geometries for the 9 sample non shopp projects, if the projects had any.
- Merged as many projects as possible based on project titles, still testing out merges based on project descriptions. 
