### PR TITLE
Change _shared_utils to import from calitp-data-analysis

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,5 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
-    #- uses: pre-commit/action@v3.0.0
-
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,28 @@
 files: _shared_utils
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.4.0
     hooks:
-      - id: flake8
-        args: ["--ignore=E501,W503,F403,F405,E731,E712"] # line too long and line before binary operator (black is ok with these), assign lambda expression OK, comparison to True with is (siuba uses ==)
-        types:
-          - python
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
         args: ["--unsafe"]
       - id: check-added-large-files
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: ["--ignore=E501,W503,F403,F405,E731,E712"] # line too long and line before binary operator (black is ok with these), assign lambda expression OK, comparison to True with is (siuba uses ==)
+        types:
+          - python
+        files: _shared_utils
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        args: ["--line-length", "120"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
-        args: ["--profile", "black"] 
+        args: ["--profile", "black", "--filter-files"]

--- a/_shared_utils/shared_utils/dask_utils.py
+++ b/_shared_utils/shared_utils/dask_utils.py
@@ -13,9 +13,7 @@ from shared_utils import utils
 fs = gcsfs.GCSFileSystem()
 
 
-def concat_and_export(
-    gcs_folder: str, file_name: str, filetype: Literal["df", "gdf"] = "df"
-):
+def concat_and_export(gcs_folder: str, file_name: str, filetype: Literal["df", "gdf"] = "df"):
     """
     Read in a folder of partitioned parquets and export as 1 parquet.
     In the filename, include the full GCS path.

--- a/_shared_utils/shared_utils/generate_rt_operators_catalog.py
+++ b/_shared_utils/shared_utils/generate_rt_operators_catalog.py
@@ -20,7 +20,6 @@ def grab_itp_id_and_date(filename: str):
 
 
 if __name__ == "__main__":
-
     GCS_RT_TRIPS = "gs://calitp-analytics-data/data-analyses/rt_delay/rt_trips/"
 
     YAML_FILE = "rt_trips_catalog.yaml"

--- a/_shared_utils/shared_utils/geography_utils.py
+++ b/_shared_utils/shared_utils/geography_utils.py
@@ -58,10 +58,7 @@ def aggregate_by_geography(
         agg_cols: list,
         aggregate_function: str,
     ):
-
-        agg_df = df.pivot_table(
-            index=group_cols, values=agg_cols, aggfunc=aggregate_function
-        ).reset_index()
+        agg_df = df.pivot_table(index=group_cols, values=agg_cols, aggfunc=aggregate_function).reset_index()
 
         # https://stackoverflow.com/questions/34049618/how-to-add-a-suffix-or-prefix-to-each-column-name
         # Why won't .add_prefix or .add_suffix work?
@@ -83,9 +80,7 @@ def aggregate_by_geography(
         final_df = aggregate_and_merge(df, final_df, group_cols, count_cols, "count")
 
     if len(nunique_cols) > 0:
-        final_df = aggregate_and_merge(
-            df, final_df, group_cols, nunique_cols, "nunique"
-        )
+        final_df = aggregate_and_merge(df, final_df, group_cols, nunique_cols, "nunique")
 
     return final_df.drop(columns="index")
 
@@ -119,9 +114,7 @@ def make_routes_gdf(
     shapes = ddf.compute()
 
     # convert to geopandas; re-project if needed
-    gdf = gpd.GeoDataFrame(
-        shapes.drop(columns="pt_array"), geometry="geometry", crs=WGS84
-    ).to_crs(crs)
+    gdf = gpd.GeoDataFrame(shapes.drop(columns="pt_array"), geometry="geometry", crs=WGS84).to_crs(crs)
 
     return gdf
 
@@ -146,9 +139,7 @@ def create_point_geometry(
     crs: str, coordinate reference system for point geometry
     """
     # Default CRS for stop_lon, stop_lat is WGS84
-    df = df.assign(
-        geometry=gpd.points_from_xy(df[longitude_col], df[latitude_col], crs=WGS84)
-    )
+    df = df.assign(geometry=gpd.points_from_xy(df[longitude_col], df[latitude_col], crs=WGS84))
 
     # ALlow projection to different CRS
     gdf = gpd.GeoDataFrame(df).to_crs(crs)
@@ -221,9 +212,7 @@ def cut_segments(
 
         segmented = pd.concat([segmented, to_append], axis=0, ignore_index=True)
 
-        segmented = segmented.assign(
-            temp_index=segmented.sort_values(group_cols).reset_index(drop=True).index
-        )
+        segmented = segmented.assign(temp_index=segmented.sort_values(group_cols).reset_index(drop=True).index)
 
     # Why would there be NaNs?
     # could this be coming from group_cols...one of the cols has a NaN in some rows?
@@ -231,9 +220,7 @@ def cut_segments(
 
     segmented = (
         segmented.assign(
-            segment_sequence=(
-                segmented.groupby(group_cols)["temp_index"].transform("rank") - 1
-            ).astype(int)
+            segment_sequence=(segmented.groupby(group_cols)["temp_index"].transform("rank") - 1).astype(int)
         )
         .sort_values(group_cols)
         .reset_index(drop=True)

--- a/_shared_utils/shared_utils/map_utils.py
+++ b/_shared_utils/shared_utils/map_utils.py
@@ -7,16 +7,12 @@ import pandas as pd
 # Centroids for various regions and zoom level
 def grab_region_centroids() -> dict:
     # This parquet is created in shared_utils/shared_data.py
-    df = pd.read_parquet(
-        "gs://calitp-analytics-data/data-analyses/shared_data/ca_county_centroids.parquet"
-    )
+    df = pd.read_parquet("gs://calitp-analytics-data/data-analyses/shared_data/ca_county_centroids.parquet")
 
     df = df.assign(centroid=df.centroid.apply(lambda x: x.tolist()))
 
     # Manipulate parquet file to be dictionary to use in map_utils
-    region_centroids = dict(
-        zip(df.county_name, df[["centroid", "zoom"]].to_dict(orient="records"))
-    )
+    region_centroids = dict(zip(df.county_name, df[["centroid", "zoom"]].to_dict(orient="records")))
 
     return region_centroids
 

--- a/_shared_utils/shared_utils/shared_data.py
+++ b/_shared_utils/shared_utils/shared_data.py
@@ -11,10 +11,7 @@ def make_county_centroids():
     """
     Find a county's centroids from county polygons.
     """
-    URL = (
-        "https://opendata.arcgis.com/datasets/"
-        "8713ced9b78a4abb97dc130a691a8695_0.geojson"
-    )
+    URL = "https://opendata.arcgis.com/datasets/" "8713ced9b78a4abb97dc130a691a8695_0.geojson"
 
     gdf = gpd.read_file(URL).to_crs(geography_utils.CA_StatePlane)
     gdf.columns = gdf.columns.str.lower()
@@ -61,10 +58,7 @@ def make_clean_state_highway_network():
     """
     Create State Highway Network dataset.
     """
-    HIGHWAY_URL = (
-        "https://opendata.arcgis.com/datasets/"
-        "77f2d7ba94e040a78bfbe36feb6279da_0.geojson"
-    )
+    HIGHWAY_URL = "https://opendata.arcgis.com/datasets/" "77f2d7ba94e040a78bfbe36feb6279da_0.geojson"
     gdf = gpd.read_file(HIGHWAY_URL)
 
     keep_cols = ["Route", "County", "District", "RouteType", "Direction", "geometry"]

--- a/_shared_utils/shared_utils/styleguide.py
+++ b/_shared_utils/shared_utils/styleguide.py
@@ -198,6 +198,7 @@ def calitp_theme(
 # Let's add in more top-level chart configuratinos
 # Need to add more since altair_saver will lose a lot of the theme applied
 
+
 # Apply top-level chart config but do not set properties (before hconcat, vconcat, etc)
 def apply_chart_config(chart: alt.Chart) -> alt.Chart:
     chart = (
@@ -268,18 +269,12 @@ def preset_plotnine_config(chart):
             panel_grid_major_y=element_line(color=axisColor, linetype="solid", size=1),
             panel_grid_major_x=element_blank(),
             figure_size=(7.0, 4.4),
-            title=element_text(
-                weight="bold", size=font_size, family=font, color=blackTitle
-            ),
+            title=element_text(weight="bold", size=font_size, family=font, color=blackTitle),
             axis_title=element_text(family=labelFont, size=12, color=guideTitleColor),
-            axis_text=element_text(
-                family=labelFont, size=10, color=guideLabelColor, margin={"r": 4}
-            ),
+            axis_text=element_text(family=labelFont, size=10, color=guideLabelColor, margin={"r": 4}),
             axis_title_x=element_text(margin={"t": 10}),
             axis_title_y=element_text(margin={"r": 10}),
-            legend_title=element_text(
-                font=labelFont, size=14, color=blackTitle, margin={"b": 10}
-            ),
+            legend_title=element_text(font=labelFont, size=14, color=blackTitle, margin={"b": 10}),
             legend_text=element_text(
                 font=labelFont,
                 size=11,

--- a/_shared_utils/shared_utils/utils.py
+++ b/_shared_utils/shared_utils/utils.py
@@ -10,7 +10,7 @@ from typing import Union
 import fsspec
 import geopandas as gpd
 import requests
-from calitp.storage import get_fs
+from calitp_data.storage import get_fs
 
 fs = get_fs()
 
@@ -42,9 +42,7 @@ def geoparquet_gcs_export(gdf: gpd.GeoDataFrame, gcs_file_path: str, file_name: 
     os.remove(f"./{file_name_sanitized}.parquet")
 
 
-def download_geoparquet(
-    gcs_file_path: str, file_name: str, save_locally: bool = False
-) -> gpd.GeoDataFrame:
+def download_geoparquet(gcs_file_path: str, file_name: str, save_locally: bool = False) -> gpd.GeoDataFrame:
     """
     Parameters:
     gcs_file_path: str

--- a/msd_dashboard_metric/create_coverage_data.py
+++ b/msd_dashboard_metric/create_coverage_data.py
@@ -7,7 +7,7 @@ import requests
 os.environ["CALITP_BQ_MAX_BYTES"] = str(100_000_000_000)
 
 from calitp.tables import tbl
-from calitp import query_sql
+from calitp_data_analysis.sql import query_sql
 from siuba import *
 
 import utils

--- a/rt_scheduled_v_ran/utils.py
+++ b/rt_scheduled_v_ran/utils.py
@@ -6,7 +6,7 @@ import os
 os.environ["CALITP_BQ_MAX_BYTES"] = str(800_000_000_000) ## 800GB?
 
 from calitp.tables import tbl
-from calitp import query_sql
+from calitp_data_analysis.sql import query_sql
 import calitp.magics
 import branca
 


### PR DESCRIPTION
Also fixes pre-commit and re-enables it in GitHub Actions. I did change black to use 120 line length but more than happy to change.

Merged right after https://github.com/cal-itp/data-infra/pull/2303 deploys.

I've tested by installing `_shared_utils` and importing it.

```
(.venv) ➜  data-analyses git:(calitp-import-change) pip install -e _shared_utils
Obtaining file:///Users/andrewvaccaro/go/src/github.com/cal-itp/data-analyses/_shared_utils
  Preparing metadata (setup.py) ... done
Installing collected packages: shared-utils
  Attempting uninstall: shared-utils
    Found existing installation: shared-utils 1.1.0
    Uninstalling shared-utils-1.1.0:
      Successfully uninstalled shared-utils-1.1.0
  Running setup.py develop for shared-utils
Successfully installed shared-utils-1.1.0

[notice] A new release of pip available: 22.3.1 -> 23.0.1
[notice] To update, run: pip install --upgrade pip
(.venv) ➜  data-analyses git:(calitp-import-change) python -c "import _shared_utils"
(.venv) ➜  data-analyses git:(calitp-import-change)
```

Very short migration guide for notebooks/other code:
1. `from calitp import query_sql` => `from calitp_data_analysis.sql import query_sql`
2. `from calitp.tables import tbls` => `from calitp_data_analysis.tables import tbls`
3. `from calitp.storage import get_fs` => `from calitp_data.storage import get_fs`
4. `import calitp.magics` => `import calitp_data_analysis.magics`