### PR TITLE
download caltrans LRS all roads with esridump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # Run this in data-analyses
 # To specify different Makefile: make build_parallel_corridors -f Makefile
 build_competitive_corridors:
-	pip install -r portfolio/requirements.txt
 	#cd bus_service_increase/ && make setup_bus_service_utils && cd ..
 	git rm portfolio/competitive_corridors/ -rf
 	#need git rm because otherwise, just local removal, but git change is untracked
@@ -14,7 +13,6 @@ build_competitive_corridors:
 
 
 build_100_recs:
-	#pip install -r portfolio/requirements.txt
 	#cd bus_service_increase/ && make setup_bus_service_utils && cd ..
 	#git rm portfolio/one_hundred_recs/ -rf
 	#python portfolio/portfolio.py clean one_hundred_recs
@@ -24,7 +22,6 @@ build_100_recs:
 
 
 build_test_100_recs:
-	#pip install -r portfolio/requirements.txt
 	#git rm portfolio/test_one_hundred_recs/ -rf
 	python one_hundred_recs/deploy_portfolio_yaml.py   
 	python portfolio/portfolio.py clean test_one_hundred_recs
@@ -34,7 +31,6 @@ build_test_100_recs:
 
 
 build_dla_reports:
-	#pip install -r portfolio/requirements.txt
 	#cd dla/ && pip install -r requirements.txt && cd ..
 	#git rm portfolio/dla/ -rf
 	python portfolio/portfolio.py build dla --deploy 
@@ -42,7 +38,6 @@ build_dla_reports:
 	git add portfolio/sites/dla.yml
     
 build_quarterly_performance_metrics:
-	pip install -r portfolio/requirements.txt
 	cd bus_service_increase/ && make setup_bus_service_utils && cd ..
 	git rm portfolio/quarterly_performance_metrics/ -rf
 	python portfolio/portfolio.py clean quarterly_performance_metrics
@@ -51,7 +46,6 @@ build_quarterly_performance_metrics:
 	git add portfolio/sites/ 
     
 build_hqta:
-	#pip install -r portfolio/requirements.txt
 	#git rm portfolio/hqta/ -rf
 	python portfolio/portfolio.py clean hqta
 	python portfolio/portfolio.py build hqta --deploy 
@@ -59,7 +53,6 @@ build_hqta:
 	git add portfolio/sites/ 
     
 build_segment_speeds:
-	#pip install -r portfolio/requirements.txt
 	#git rm portfolio/segment_speeds/ -rf
 	python portfolio/portfolio.py clean segment_speeds
 	python portfolio/portfolio.py build segment_speeds --deploy 
@@ -67,7 +60,6 @@ build_segment_speeds:
 	git add portfolio/sites/ 
     
 build_stop_segment_speeds:
-	#pip install -r portfolio/requirements.txt
 	#git rm portfolio/stop_segment_speeds/ -rf
 	cd rt_segment_speeds && python deploy_portfolio_yaml.py && cd ../ 
 	python portfolio/portfolio.py clean stop_segment_speeds
@@ -89,5 +81,4 @@ install_env:
 	cd ~/data-analyses/_shared_utils && make setup_env && cd ..
 	#cd bus_service_increase/ && make setup_bus_service_utils && cd ..
 	#cd rt_delay/ && make setup_rt_analysis && cd ..    
-	#pip install -r portfolio/requirements.txt
 	cd rt_segment_speeds && pip install -r requirements.txt && cd ..

--- a/_shared_utils/Makefile
+++ b/_shared_utils/Makefile
@@ -1,3 +1,2 @@
 setup_env:
 	pip install -r requirements.txt
-	conda install --yes -c conda-forge --file conda-requirements.txt

--- a/_shared_utils/conda-requirements.txt
+++ b/_shared_utils/conda-requirements.txt
@@ -1,2 +1,0 @@
-vega-cli
-vega-lite-cli

--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -1,5 +1,1 @@
 -e .
-cpi==1.0.5
-xmltodict==0.13.0
-loguru==0.6.0
-mapclassify==2.4.3

--- a/portfolio/requirements.txt
+++ b/portfolio/requirements.txt
@@ -1,8 +1,0 @@
-nbformat==5.1.3
-papermill==2.3.4
-typer==0.4.1
-jupyter-book==0.12.2
-python-slugify==6.1.1
-pyaml==21.10.1
-humanize==4.2.3
-pydantic>=1.9.1

--- a/portfolio/requirements.txt
+++ b/portfolio/requirements.txt
@@ -1,0 +1,8 @@
+nbformat==5.1.3
+papermill==2.3.4
+typer==0.4.1
+jupyter-book==0.12.2
+python-slugify==6.1.1
+pyaml==21.10.1
+humanize==4.2.3
+pydantic>=1.9.1

--- a/rt_segment_speeds/scripts/Makefile
+++ b/rt_segment_speeds/scripts/Makefile
@@ -10,3 +10,8 @@ get_speeds_by_segment:
 	python A3_speeds_by_segment_trip.py
 	python B1_rt_trip_diagnostics.py
 	python C1_calculate_stop_delay.py
+    
+download_roads:
+	#pip install esridump
+	#esri2geojson https://geo.dot.gov/server/rest/services/Hosted/California_2018_PR/FeatureServer/0 ca_roads.geojson
+	python download_all_roads.py

--- a/rt_segment_speeds/scripts/download_all_roads.py
+++ b/rt_segment_speeds/scripts/download_all_roads.py
@@ -1,0 +1,31 @@
+#https://github.com/openaddresses/pyesridump
+
+#pip install esridump
+import geopandas as gpd
+from calitp_data.storage import get_fs
+from shared_utils import utils
+
+fs = get_fs()
+GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/shared_data/"
+
+# In terminal:
+'''
+esri2geojson https://geo.dot.gov/server/rest/services/Hosted/California_2018_PR/FeatureServer/0 ca_roads.geojson
+'''
+
+if __name__ == "__main__":
+    gdf = gpd.read_file("./ca_roads.geojson")
+    
+    
+    utils.geojson_gcs_export(
+        gdf,
+        gcs_file_path = GCS_FILE_PATH,
+        file_name =  "caltrans_all_roads_lrs",
+        geojson_type = "geojson",
+    )
+    
+    utils.geoparquet_gcs_export(
+        gdf,
+        GCS_FILE_PATH,
+        "caltrans_all_roads_lrs"
+    )


### PR DESCRIPTION
## daskify segment speeds
* download the Caltrans Linear Referencing Service maintained, for FHWA, of all roads and highways. See if this works for our needs.
* Quick map looks like a lot of major roads are missing, and we might still need to go back to Census TIGER roads.
* use `esridump` CLI tool to loop through every 2,000 entries in ESRI feature server and append together in geojson
* cc #605 

## shared_utils
* remove packages that have been moved into Hub image: https://github.com/cal-itp/data-infra/pull/2418