### PR TITLE
Put shared_utils requirements back

### DIFF
--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -1,1 +1,5 @@
 -e .
+cpi==1.0.5
+xmltodict==0.13.0
+loguru>=0.6.0
+mapclassify>=2.4.3


### PR DESCRIPTION
* undo removing `shared_utils/requirements.txt` from #696 
* this https://github.com/cal-itp/data-infra/pull/2418 did not actually install those packages, so add it back in