### PR TITLE
remove call to old gtfs_utils

### DIFF
--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -476,19 +476,8 @@ def get_routelines(
         if not cached.empty:
             return cached
         else:
-            print("cached parquet empty, will try a fresh query")
-    else:
-        trip_df_setting = trips_cached(itp_id, date_str)
-
-        routelines = gtfs_utils.get_route_shapes(
-            selected_date=analysis_date,
-            itp_id_list=[itp_id],
-            get_df=True,
-            crs=geography_utils.CA_NAD83Albers,
-            trip_df=trip_df_setting,
-        )
-
-        utils.geoparquet_gcs_export(routelines, export_path, filename)
+            print("v1 cached parquet empty -- unable to generate")
+            return
 
         return routelines
 


### PR DESCRIPTION
Since `gtfs_utils` is going away and we no longer support fresh v1 rt_analysis data generation, remove remaining call to `gtfs_utils.get_route_shapes`