### PR TITLE
refactor bottlenecks, sjoin and cutting special segments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,7 @@ install_env:
 	#cd bus_service_increase/ && make setup_bus_service_utils && cd ..
 	#cd rt_delay/ && make setup_rt_analysis && cd ..    
 	cd rt_segment_speeds && pip install -r requirements.txt && cd ..
+
+# Create .egg to upload to dask cloud cluster
+egg_modules:
+	cd ~/data-analyses/rt_segment_speeds && python setup.py bdist_egg && cd ..

--- a/_shared_utils/shared_utils/dask_utils.py
+++ b/_shared_utils/shared_utils/dask_utils.py
@@ -96,17 +96,11 @@ def concatenate_list_of_files(
     with pandas or geopandas. Use dask.delayed to loop through and
     assemble a concatenated pandas or geopandas dataframe.
     """
-    dfs = []
-
     if file_type == "df":
-        for f in list_of_filepaths:
-            indiv_df = delayed(pd.read_parquet)(f)
-            dfs.append(indiv_df)
+        dfs = [delayed(pd.read_parquet)(f) for f in list_of_filepaths]
 
     elif file_type == "gdf":
-        for f in list_of_filepaths:
-            indiv_df = delayed(gpd.read_parquet)(f)
-            dfs.append(indiv_df)
+        dfs = [delayed(gpd.read_parquet)(f) for f in list_of_filepaths]
 
     results = [compute(i)[0] for i in dfs]
     full_df = pd.concat(results, axis=0).reset_index(drop=True)

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -169,7 +169,7 @@ def get_metrolink_feed_key(selected_date: Union[str, datetime.date], get_df: boo
 
     metrolink_feed = (
         tbls.mart_gtfs.fct_daily_schedule_feeds()
-        >> filter(_.date == selected_date, _.is_future == False)
+        >> filter(_.date == selected_date)
         >> inner_join(_, metrolink_in_airtable, on="gtfs_dataset_key")
         >> subset_cols(["feed_key", "name"])
         >> collect()

--- a/open_data/logs/download_data.log
+++ b/open_data/logs/download_data.log
@@ -6216,3 +6216,18 @@
 2023-05-18 09:06:45.814 | INFO     | __main__:<module>:33 - # operators to run: 158
 2023-05-18 09:06:45.815 | INFO     | __main__:<module>:37 - *********** Download st data ***********
 2023-05-18 09:09:01.946 | INFO     | __main__:<module>:66 - execution time: 0:02:17.484357
+2023-05-31 16:09:26.157 | INFO     | __main__:<module>:49 - Analysis date: 2023-04-12
+2023-05-31 16:09:28.746 | INFO     | __main__:<module>:56 - # operators to run: 201
+2023-05-31 16:09:28.747 | INFO     | __main__:<module>:59 - *********** Download trips data ***********
+2023-05-31 16:18:58.486 | INFO     | __main__:<module>:49 - Analysis date: 2023-04-12
+2023-05-31 16:19:00.349 | INFO     | __main__:<module>:56 - # operators to run: 201
+2023-05-31 16:19:00.351 | INFO     | __main__:<module>:59 - *********** Download trips data ***********
+2023-05-31 16:19:26.201 | INFO     | __main__:<module>:87 - execution time: 0:00:27.714166
+2023-05-31 16:21:50.716 | INFO     | __main__:<module>:49 - Analysis date: 2023-03-15
+2023-05-31 16:21:52.439 | INFO     | __main__:<module>:56 - # operators to run: 202
+2023-05-31 16:21:52.440 | INFO     | __main__:<module>:59 - *********** Download trips data ***********
+2023-05-31 16:22:17.726 | INFO     | __main__:<module>:87 - execution time: 0:00:27.009313
+2023-05-31 16:24:03.293 | INFO     | __main__:<module>:49 - Analysis date: 2023-02-15
+2023-05-31 16:24:04.974 | INFO     | __main__:<module>:56 - # operators to run: 196
+2023-05-31 16:24:04.975 | INFO     | __main__:<module>:59 - *********** Download trips data ***********
+2023-05-31 16:24:30.056 | INFO     | __main__:<module>:87 - execution time: 0:00:26.762197

--- a/rt_segment_speeds/logs/cut_stop_segments.log
+++ b/rt_segment_speeds/logs/cut_stop_segments.log
@@ -38,3 +38,7 @@
 2023-05-19 16:59:20.971 | INFO     | __main__:<module>:265 - Analysis date: 2023-04-12
 2023-05-19 16:59:22.251 | INFO     | __main__:<module>:299 - Cut special stop segments: 0:00:01.274668
 2023-05-19 18:27:38.239 | INFO     | __main__:<module>:319 - Export results: 1:28:15.988022
+2023-05-31 14:06:27.162 | INFO     | __main__:<module>:268 - Analysis date: 2023-04-12
+2023-05-31 14:46:10.347 | INFO     | __main__:<module>:313 - Cut special stop segments: 0:39:43.179497
+2023-05-31 14:46:12.143 | INFO     | __main__:<module>:332 - export results: 0:00:01.795914
+2023-05-31 14:46:12.144 | INFO     | __main__:<module>:333 - execution time: 0:39:44.975411

--- a/rt_segment_speeds/logs/sjoin_vp_segments.log
+++ b/rt_segment_speeds/logs/sjoin_vp_segments.log
@@ -59,5 +59,7 @@
 2023-05-26 19:47:05.557 | INFO     | __main__:<module>:191 - execution time: 1:48:46.162546
 2023-05-26 21:24:22.480 | INFO     | __main__:<module>:111 - Analysis date: 2023-04-12
 2023-05-26 23:14:16.971 | INFO     | __main__:<module>:202 - execution time: 1:49:54.490501
-2023-05-27 08:17:09.183 | INFO     | __main__:<module>:111 - Analysis date: 2023-04-12
-2023-05-27 09:06:12.351 | INFO     | __main__:<module>:205 - execution time: 0:49:03.167444
+2023-05-30 11:09:47.568 | INFO     | __main__:<module>:286 - Analysis date: 2023-04-12
+2023-05-30 11:58:29.934 | INFO     | __main__:<module>:298 - attach vp to stop-to-stop segments: 0:48:42.364791
+2023-05-30 12:00:23.165 | INFO     | __main__:<module>:308 - compiled parquets: 0:01:53.231698
+2023-05-30 12:00:23.166 | INFO     | __main__:<module>:309 - execution time: 0:50:35.596489

--- a/rt_segment_speeds/logs/sjoin_vp_segments.log
+++ b/rt_segment_speeds/logs/sjoin_vp_segments.log
@@ -49,9 +49,15 @@
 2023-05-15 14:11:43.758 | INFO     | __main__:<module>:280 - Analysis date: 2023-03-15
 2023-05-15 16:09:03.504 | INFO     | __main__:<module>:313 - attach vp to stop-to-stop segments: 1:57:19.737088
 2023-05-15 16:09:03.505 | INFO     | __main__:<module>:316 - execution time: 1:57:19.745243
-2023-05-19 18:40:22.816 | INFO     | __main__:<module>:278 - Analysis date: 2023-04-12
-2023-05-19 18:44:49.439 | INFO     | __main__:<module>:278 - Analysis date: 2023-04-12
 2023-05-19 18:46:21.102 | INFO     | __main__:<module>:278 - Analysis date: 2023-04-12
 2023-05-19 20:18:23.376 | INFO     | __main__:<module>:296 - attach vp to stop-to-stop segments: 1:32:02.273276
 2023-05-19 20:19:56.588 | INFO     | __main__:<module>:306 - compiled partitioned parquets: 0:01:33.211730
 2023-05-19 20:19:56.589 | INFO     | __main__:<module>:307 - execution time: 1:33:35.485006
+2023-05-26 17:58:19.393 | INFO     | __main__:<module>:111 - Analysis date: 2023-04-12
+2023-05-26 18:01:16.079 | INFO     | __main__:<module>:176 - delayed results: 0:02:56.684602
+2023-05-26 19:46:57.454 | INFO     | __main__:<module>:182 - stack arrays: 1:45:41.374605
+2023-05-26 19:47:05.557 | INFO     | __main__:<module>:191 - execution time: 1:48:46.162546
+2023-05-26 21:24:22.480 | INFO     | __main__:<module>:111 - Analysis date: 2023-04-12
+2023-05-26 23:14:16.971 | INFO     | __main__:<module>:202 - execution time: 1:49:54.490501
+2023-05-27 08:17:09.183 | INFO     | __main__:<module>:111 - Analysis date: 2023-04-12
+2023-05-27 09:06:12.351 | INFO     | __main__:<module>:205 - execution time: 0:49:03.167444

--- a/rt_segment_speeds/scripts/A1_sjoin_vp_segments.py
+++ b/rt_segment_speeds/scripts/A1_sjoin_vp_segments.py
@@ -96,6 +96,14 @@ def sjoin_vp_to_segment(
     vp: pd.DataFrame,
     segment: gpd.GeoDataFrame,
 ) -> np.ndarray: 
+    """
+    Convert vehicle positions from tabular to spatial.
+    Sjoin vehicle positions to segments.
+    Only keep vp_idx and seg_idx, the sjoin pairing, in our results 
+    and save as numpy array.
+    """
+    #if isinstance(segment, Delayed):
+    #    segment = compute(segment)[0]
     
     vp_gdf = gpd.GeoDataFrame(
         vp, 
@@ -145,11 +153,13 @@ def sjoin_vp_to_segments(
         TRIP_GROUPING_COLS
     )
           
-    segments = delayed(import_segments_and_buffer)(
+    segments = import_segments_and_buffer(
         f"{SEGMENT_FILE}_{analysis_date}",
         BUFFER_METERS,
         SEGMENT_IDENTIFIER_COLS
-    ).persist()
+    )
+    
+    segments = delayed(segments).persist()
     
     RT_OPERATORS = vp_trips.gtfs_dataset_key.unique()
     
@@ -169,7 +179,7 @@ def sjoin_vp_to_segments(
             how = "inner"
         )
         
-        vp = delayed(vp).persist()    
+        vp = delayed(vp).persist() 
         
         all_shapes = vp_trips[vp_trips.gtfs_dataset_key==rt_dataset_key
                              ].shape_array_key.unique().tolist()

--- a/rt_segment_speeds/scripts/Makefile
+++ b/rt_segment_speeds/scripts/Makefile
@@ -1,7 +1,7 @@
 # Cut segments
 segmentize:
-	#python prep_stop_segments.py
-	#python cut_normal_stop_segments.py
+	python prep_stop_segments.py
+	python cut_normal_stop_segments.py
 	python cut_special_stop_segments.py
 	python concatenate_stop_segments.py
       

--- a/rt_segment_speeds/scripts/concatenate_stop_segments.py
+++ b/rt_segment_speeds/scripts/concatenate_stop_segments.py
@@ -24,8 +24,12 @@ def finalize_stop_segments(
         stop_segments, 
         analysis_date, 
         ["feed_key", "shape_array_key"]
-    )
+    ).reset_index(drop=True)
 
+    stop_segments_with_rt_key = stop_segments_with_rt_key.assign(
+        seg_idx = stop_segments_with_rt_key.index
+    )
+    
     return stop_segments_with_rt_key
 
 

--- a/rt_segment_speeds/segment_speed_utils/array_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/array_utils.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from numba import jit
+#from numba import jit
 
-@jit(parallel=True)
+#@jit(parallel=True)
 def get_index(array: np.ndarray, item) -> int:
     """
     Find the index for a certain value in an array.
@@ -13,7 +13,7 @@ def get_index(array: np.ndarray, item) -> int:
             return idx[0]
 
         
-@jit(parallel=True)
+#@jit(parallel=True)
 def subset_array_by_indices(
     array: np.ndarray, 
     start_end_tuple: tuple

--- a/rt_segment_speeds/segment_speed_utils/sched_rt_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/sched_rt_utils.py
@@ -81,3 +81,28 @@ def add_rt_keys_to_segments(
     )
     
     return segments_with_crosswalk 
+
+
+def get_trip_time_buckets(analysis_date: str) -> pd.DataFrame:
+    """
+    Assign trips to time-of-day.
+    """
+    keep_trip_cols = [
+        "feed_key", "trip_id", 
+        "service_hours", 
+        "trip_first_departure_datetime_pacific"
+    ]
+    
+    trips = crosswalk_scheduled_trip_grouping_with_rt_key(
+        analysis_date, 
+        keep_trip_cols
+    )                 
+                      
+    trips = trips.assign(
+        time_of_day = trips.apply(
+            lambda x: rt_utils.categorize_time_of_day(
+                x.trip_first_departure_datetime_pacific), axis=1), 
+        service_minutes = trips.service_hours * 60
+    )
+    
+    return trips

--- a/rt_segment_speeds/segment_speed_utils/wrangle_shapes.py
+++ b/rt_segment_speeds/segment_speed_utils/wrangle_shapes.py
@@ -32,11 +32,11 @@ def project_list_of_coords(
     if use_shapely_coords:
         # https://stackoverflow.com/questions/49330030/remove-a-duplicate-point-from-polygon-in-shapely
         # use simplify(0) to remove any points that might be duplicates
-        return np.array(
+        return np.asarray(
             [shape_geometry.project(shapely.geometry.Point(p))
             for p in shape_geometry.simplify(0).coords])
     else:
-        return np.array(
+        return np.asarray(
             [shape_geometry.project(i) for i in point_geom_list])
 
     


### PR DESCRIPTION
## segment speeds
* current bottlenecks are when special stop segments are cut and where spatial join occurs 
* explore using `dask client`, but uploading `segment_speed_utils` is a little tricky.
   * it loses its directory structure when uploaded. tried uploading the `.egg`, but then we need to upload `shared_utils`. 
   * `shared_utils` is more problematic to upload because there are some BQ dependencies and an error occurs.
* `dask` client not worth the effort. explored using `multiprocessing` module, but same issue. `starmap`, `starmap_async` are easily implemented.
* special stop segments, only 1/6 of the segments, take about double the time compared to normal segments
   * remove the dask delayed. we're not freeing up the space...probably because GIL is in place. 
   * instead just work on `geopandas` and apply row-wise. add columns to make sure every row has the information it needs. this ends up being faster because we're dealing with only about 60k rows and doing the `shapely` stuff on it isn't bad.
   * from 1.5 hrs -> 40 min
* sjoin refactored to output numpy array.
   * all we need is which vp joins to what segment. adjust vp and segments to both have a single column identifier.
   * save out 2 columns as array instead of pandas df or dask df or partitioned parquets. 
   * turn array back into df in the end. 
   * from 1.5 hrs --> 50 min
* tweak "averaging" of speeds to give all day averages and peak period averages
* re-download scheduled trips (`open_data/download_trips.py`) for feb, mar, apr 2023 because we have extra columns for timezones. use the pacific time columns to do time-of-day buckets (recommended in dbt docs)
* #762 