### PR TITLE
More metadata

### DIFF
--- a/open_data/arcgis_pro_script.py
+++ b/open_data/arcgis_pro_script.py
@@ -171,6 +171,10 @@ for f in in_features:
 
 ## (7) Move from file gdb to enterprise gdb
 # License Select must be set to Advanced for this to work
+# Exit and restart ArcPro to clear locks on layers in overwriting
+# If we don't exit, the layer will be locked because it shows we're already using it 
+# staging to open_data), and it will prevent writing from open_data to the enterprise gdb.
+
 ENTERPRISE_DATABASE = "Database Connections/HQrail(edit)@sv03tmcsqlprd1.sde"
 
 for f in in_features:

--- a/open_data/check_exported_data.ipynb
+++ b/open_data/check_exported_data.ipynb
@@ -32,6 +32,7 @@
     "def print_stats(gdf):\n",
     "    print(f\"CRS: {gdf.crs.to_epsg()}\")\n",
     "    print(f\"{gdf.columns}\")\n",
+    "    print(gdf.dtypes)\n",
     "    print(f\"# rows: {len(gdf)}\")"
    ]
   },

--- a/open_data/cleanup.py
+++ b/open_data/cleanup.py
@@ -21,8 +21,8 @@ def delete_old_xml_check_in_new_xml(open_data_dict: dict):
     for key, value in open_data_dict.items():
         file_path = value["path"]
         file_name = os.path.basename(file_path)
-        os.replace(f"./metadata_xml/run_in_esri/{file_name}",
-            f"./metadata_xml/{file_name}")
+        os.replace(f"./xml/run_in_esri/{file_name}",
+            f"./xml/{file_name}")
         
 
 

--- a/open_data/metadata_hqta.py
+++ b/open_data/metadata_hqta.py
@@ -1,6 +1,9 @@
+"""
+HQTA transit areas and stops metadata elements
+"""
 from gcs_to_esri import open_data_dates
+from update_vars import ESRI_BASE_URL
 
-# HQTA transit areas and transit stops data dictionary
 KEYWORDS = [
     'Transportation',
     'Land Use',
@@ -9,20 +12,16 @@ KEYWORDS = [
     'High Quality Transit'
 ]
 
-PURPOSE_AREAS = ('''
-    Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2.
-    '''
-)
+PURPOSE_AREAS = "Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2."
 
-PURPOSE_STOPS = ('''
-    Estimated stops along High Quality Transit Corridors, plus major transit stops for bus rapid transit, ferry, rail modes as described in Public Resources Code 21155, 21064.3, 21060.2
-    '''
-)
+
+PURPOSE_STOPS = "Estimated stops along High Quality Transit Corridors, plus major transit stops for bus rapid transit, ferry, rail modes as described in Public Resources Code 21155, 21064.3, 21060.2."
+
+ABSTRACT = "Use GTFS schedule trips, stop_times, shapes, and stops to estimate whether corridor segments have scheduled frequencies of 15 minutes or less."
 
 METHODOLOGY = "This data was estimated using a spatial process derived from General Transit Feed Specification (GTFS) schedule data. To find high-quality bus corridors, we split each corridor into 1,500 meter segments and counted frequencies at the stop within that segment with the highest number of transit trips. If that stop saw at least 4 trips per hour for at least one hour in the morning, and again for at least one hour in the afternoon, we consider that segment a high-quality bus corridor. Segments without a stop are not considered high-quality corridors. Major transit stops were identified as either the intersection of two high-quality corridors from the previous step, a rail or bus rapid transit station, or a ferry terminal with bus service. Note that the definition of `bus rapid transit` in Public Resources Code 21060.2 includes features not captured by available data sources, these features were captured manually using information from transit agency sources and imagery. We believe this data to be broadly accurate, and fit for purposes including overall dashboards, locating facilities in relation to high quality transit areas, and assessing community transit coverage. However, the spatial determination of high-quality transit areas from GTFS data necessarily involves some assumptions as described above. Any critical determinations of whether a specific parcel is located within a high-quality transit area should be made in conjunction with local sources, such as transit agency timetables.  Notes: Null values may be present. The `hqta_details` columns defines which part of the Public Resources Code definition the HQTA classification was based on. If `hqta_details` references a single operator, then `agency_secondary` and `base64_url_secondary` are null. If `hqta_details` references the same operator, then `agency_secondary` and `base64_url_secondary` are the same as `agency_primary` and `base64_url_primary`. Refer to https://github.com/cal-itp/data-analyses/blob/main/high_quality_transit_areas/README.md for more details."
 
 
-ESRI_BASE_URL = "https://gisdata.dot.ca.gov/arcgis/rest/services/CHrailroad/"
 DATA_DICT_AREAS_URL = f"{ESRI_BASE_URL}CA_HQ_Transit_Areas/FeatureServer"
 DATA_DICT_STOPS_URL = f"{ESRI_BASE_URL}CA_HQ_Transit_Stops/FeatureServer"
 
@@ -30,8 +29,8 @@ HQTA_TRANSIT_AREAS_DICT = {
     "dataset_name": "ca_hq_transit_areas", 
     "publish_entity": "Data & Digital Services / California Integrated Travel Project", 
 
-    "abstract": "Public. EPSG: 4326",
     "purpose": PURPOSE_AREAS, 
+    "abstract": ABSTRACT,
 
     "creation_date": "2022-02-08",
     "beginning_date": open_data_dates()[0],

--- a/open_data/metadata_speeds.py
+++ b/open_data/metadata_speeds.py
@@ -1,7 +1,9 @@
+"""
+Speeds datasets metadata elements
+"""
 from gcs_to_esri import open_data_dates
-from metadata_hqta import ESRI_BASE_URL
+from update_vars import ESRI_BASE_URL
 
-# Speeds data dictionary
 KEYWORDS = [
     'Transportation',
     'Transit',
@@ -13,24 +15,19 @@ KEYWORDS = [
 ]
 
 
-SEGMENT_PURPOSE = "All day and peak transit 20th, 50th, and 80th percentile speeds on stop segments estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data."
+SEGMENT_PURPOSE = "All day and peak transit speeds by segments for all CA operators that provide GTFS real-time vehicle positions data."
 
-SEGMENT_METHODOLOGY = (
-    '''
-    This data was estimated by combining GTFS real-time vehicle positions to GTFS scheduled trips, shapes, stops, and stop times tables. GTFS shapes provides the route alignment path. Multiple trips may share the same shape, with a route typically associated with multiple shapes. Shapes are cut into segments at stop positions (stop_id-stop_sequence combination). A `stop segment` refers to the portion of shapes between the prior stop and the current stop. Vehicle positions are spatially joined to 35 meter buffered segments. Within each segment-trip, the first and last vehicle position observed are used to calculate the speed. Since multiple trips may occur over a segment each day, the multiple trip speeds provide a distribution. From this distribution, the 20th percentile, 50th percentile (median), and 80th percentile speeds are calculated. For all day speed metrics, all trips are used. For peak speed metrics, only trips with start times between 7 - 9:59 AM and 4 - 7:59 PM are used to find the 20th, 50th, and 80th percentile metrics.
-    Data processing notes: (a) GTFS RT trips whose vehicle position timestamps span 10 minutes or less are dropped. Incomplete data would lead to unreliable estimates of speed at the granularity we need. (b) Segment-trip speeds of over 70 mph are excluded. These are erroneously calculated as transit does not typically reach those speeds. (c) Other missing or erroneous calculations, either arising from only one vehicle position found in a segment (change in time or change in distance cannot be calculated).
-    '''
-)
+SEGMENT_ABSTRACT = "All day and peak transit 20th, 50th, and 80th percentile speeds on stop segments estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data."
 
-ROUTE_PURPOSE = "Average transit speeds by route-direction by time-of-day estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data."
+SEGMENT_METHODOLOGY = "This data was estimated by combining GTFS real-time vehicle positions to GTFS scheduled trips, shapes, stops, and stop times tables. GTFS shapes provides the route alignment path. Multiple trips may share the same shape, with a route typically associated with multiple shapes. Shapes are cut into segments at stop positions (stop_id-stop_sequence combination). A `stop segment` refers to the portion of shapes between the prior stop and the current stop. Vehicle positions are spatially joined to 35 meter buffered segments. Within each segment-trip, the first and last vehicle position observed are used to calculate the speed. Since multiple trips may occur over a segment each day, the multiple trip speeds provide a distribution. From this distribution, the 20th percentile, 50th percentile (median), and 80th percentile speeds are calculated. For all day speed metrics, all trips are used. For peak speed metrics, only trips with start times between 7 - 9:59 AM and 4 - 7:59 PM are used to find the 20th, 50th, and 80th percentile metrics. Data processing notes: (a) GTFS RT trips whose vehicle position timestamps span 10 minutes or less are dropped. Incomplete data would lead to unreliable estimates of speed at the granularity we need. (b) Segment-trip speeds of over 70 mph are excluded. These are erroneously calculated as transit does not typically reach those speeds. (c) Other missing or erroneous calculations, either arising from only one vehicle position found in a segment (change in time or change in distance cannot be calculated)."
 
-ROUTE_METHODOLOGY = (
-    '''
-    This data was estimated by combining GTFS real-time vehicle positions with GTFS scheduled trips and shapes. 
-    GTFS real-time (RT) vehicle positions are spatially joined to GTFS scheduled shapes, so only vehicle positions traveling along the route alignment path are kept. A sample of five vehicle positions are selected (min, 25th percentile, 50th percentile, 75th percentile, max). The trip speed is calculated using these five vehicle positions. Each trip is categorized into a time-of-day. The average speed for a route-direction-time_of_day is calculated. Additional metrics are stored, such as the number of trips observed, the average scheduled service minutes, and the average RT observed service minutes. For convenience, we also provide a singular shape (common_shape_id) to associate with a route-direction. This is the shape that had the most number of trips for a given route-direction. 
-    Time-of-day is determined by the GTFS scheduled trip start time. The trip start hour (military time) is categorized based on the following: Owl (0-3), Early AM (4-6), AM Peak (7-9), Midday (10-14), PM Peak (15-19), and Evening (20-23). The start and end hours are inclusive (e.g., 4-6 refers to 4am, 5am, and 6am).
-    '''
-)
+
+ROUTE_PURPOSE = "Average transit speeds by route-direction and time-of-day estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data."
+
+ROUTE_ABSTRACT = "Provide average transit speeds, number of trips, and metrics related to scheduled annd real-time service minutes by route-direction and time-of-day."
+
+ROUTE_METHODOLOGY = "This data was estimated by combining GTFS real-time vehicle positions with GTFS scheduled trips and shapes. GTFS real-time (RT) vehicle positions are spatially joined to GTFS scheduled shapes, so only vehicle positions traveling along the route alignment path are kept. A sample of five vehicle positions are selected (min, 25th percentile, 50th percentile, 75th percentile, max). The trip speed is calculated using these five vehicle positions. Each trip is categorized into a time-of-day. The average speed for a route-direction-time_of_day is calculated. Additional metrics are stored, such as the number of trips observed, the average scheduled service minutes, and the average RT observed service minutes. For convenience, we also provide a singular shape (common_shape_id) to associate with a route-direction. This is the shape that had the most number of trips for a given route-direction. Time-of-day is determined by the GTFS scheduled trip start time. The trip start hour (military time) is categorized based on the following: Owl (0-3), Early AM (4-6), AM Peak (7-9), Midday (10-14), PM Peak (15-19), and Evening (20-23). The start and end hours are inclusive (e.g., 4-6 refers to 4am, 5am, and 6am)."
+
 
 DATA_DICT_SPEEDS_URL = f"{ESRI_BASE_URL}Speeds_By_Stop_Segments/FeatureServer"
 DATA_DICT_ROUTE_SPEEDS_URL = f"{ESRI_BASE_URL}Speeds_By_Route_Time_of_Day/FeatureServer"
@@ -39,8 +36,8 @@ SPEEDS_STOP_SEG_DICT = {
     "dataset_name": "speeds_by_stop_segments", 
     "publish_entity": "Data & Digital Services / California Integrated Travel Project", 
 
-    "abstract": "Public. EPSG: 4326",
     "purpose": SEGMENT_PURPOSE, 
+    "abstract": SEGMENT_ABSTRACT,
 
     "creation_date": "2023-06-14",
     "beginning_date": open_data_dates()[0],
@@ -69,8 +66,8 @@ ROUTE_SPEEDS_DICT = {
     "dataset_name": "speeds_by_route_time_of_day", 
     "publish_entity": "Data & Digital Services / California Integrated Travel Project", 
 
-    "abstract": "Public. EPSG: 4326",
     "purpose": ROUTE_PURPOSE, 
+    "abstract": ROUTE_ABSTRACT,
 
     "creation_date": "2023-06-14",
     "beginning_date": open_data_dates()[0],

--- a/open_data/metadata_traffic_ops.py
+++ b/open_data/metadata_traffic_ops.py
@@ -1,5 +1,9 @@
+"""
+Traffic Ops request for geospatial routes and stops 
+metadata elements
+"""
 from gcs_to_esri import open_data_dates
-from metadata_hqta import ESRI_BASE_URL
+from update_vars import ESRI_BASE_URL
 
 # Traffic Ops routes and stops data dictionary
 KEYWORDS = [
@@ -13,6 +17,8 @@ KEYWORDS = [
 
 PURPOSE = "Provide all CA transit stops and routes (geospatial) from all transit operators."
 
+ABSTRACT = "Provide compiled GTFS schedule data in geospatial format. Transit routes associates route information to shapes. Transit stops associates route information to stops."
+
 METHODOLOGY = "This data was assembled from the General Transit Feed Specification (GTFS) schedule data. GTFS tables are text files, but these have been compiled for all operators and transformed into geospatial data, with minimal data processing. The transit routes dataset is assembled from two tables: (1) `shapes.txt`, which defines the route alignment path, and (2) `trips.txt` and `stops.txt`, for routes not found in `shapes.txt`. `shapes.txt` is an optional GTFS table with richer information than just transit stop longitude and latitude. The transit stops dataset is assembled from `stops.txt`, which contains information about the route, stop sequence, and stop longitude and latitude. References: https://gtfs.org/. https://gtfs.org/schedule/reference/#shapestxt. https://gtfs.org/schedule/reference/#stopstxt. https://gtfs.org/schedule/reference/#tripstxt."
 
 DATA_DICT_ROUTES_URL = f"{ESRI_BASE_URL}CA_Transit_Routes/FeatureServer"
@@ -22,9 +28,9 @@ ROUTES_DICT = {
     "dataset_name": "ca_transit_routes", 
     "publish_entity": "California Integrated Travel Project", 
 
-    "abstract": "Public. EPSG: 4326",
     "purpose": PURPOSE, 
-
+    "abstract": ABSTRACT,
+    
     "creation_date": "2022-02-08",
     "beginning_date": open_data_dates()[0],
     "end_date": open_data_dates()[1],

--- a/open_data/metadata_update_pro.py
+++ b/open_data/metadata_update_pro.py
@@ -13,8 +13,9 @@ from pydantic import BaseModel
 from typing import Literal
 
 import validation_pro
+from update_vars import DEFAULT_XML_TEMPLATE
 
-METADATA_FOLDER = "metadata_xml/"
+METADATA_FOLDER = "./xml/"
 
 # This prefix keeps coming up, but xmltodict has trouble processing or replacing it
 x = "ns0:"
@@ -60,8 +61,7 @@ def lift_necessary_dataset_elements(metadata_json: dict) -> dict:
 
 
 def overwrite_default_with_dataset_elements(metadata_json: dict) -> dict:
-    DEFAULT_XML = f"./{METADATA_FOLDER}default_pro.xml"
-    default_template = xml_to_json(DEFAULT_XML)
+    default_template = xml_to_json(f"{METADATA_FOLDER}{DEFAULT_XML_TEMPLATE}")
     
     # Grab the necessary elements from my dataset
     necessary_elements = lift_necessary_dataset_elements(metadata_json[main])
@@ -83,8 +83,9 @@ def overwrite_default_with_dataset_elements(metadata_json: dict) -> dict:
 class metadata_input(BaseModel):
     dataset_name: str
     publish_entity: str = "Data & Digital Services / California Integrated Travel Project"
-    abstract: str
     purpose: str
+    abstract: str
+    public_access: Literal["Public", "Restricted"] = "Public"
     creation_date: str
     beginning_date: str
     end_date: str
@@ -107,9 +108,8 @@ class metadata_input(BaseModel):
     contact_email: str = "hello@calitp.org"
     horiz_accuracy: str = "4 meters"
     #edition: str
-    boilerplate_license: str = (
-        '''Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.''')
+    boilerplate_desc: str = "The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein."
+    boilerplate_license: str = "License - Creative Commons 4.0 Attribution."
     
 
 def fix_values_in_validated_dict(d: dict) -> dict:
@@ -183,13 +183,15 @@ def overwrite_id_info(metadata: dict, dataset_info: dict) -> dict:
     maint_info = overwrite_contact_info(maint_info, d)
         
     (id_info[f"{x}resourceConstraints"][0][f"{x}MD_Constraints"]
-     [f"{x}useLimitation"][key]) = d["boilerplate_license"]
+     [f"{x}useLimitation"][key]) = d["public_access"]   
     (id_info[f"{x}resourceConstraints"][1][f"{x}MD_LegalConstraints"]
-     [f"{x}useLimitation"][key]) = d["boilerplate_license"]
-    (id_info[f"{x}resourceConstraints"][1][f"{x}MD_LegalConstraints"]
+     [f"{x}useLimitation"][key]) = d["boilerplate_desc"]
+    (id_info[f"{x}resourceConstraints"][2][f"{x}MD_LegalConstraints"]
+     [f"{x}useLimitation"][key]) = d["boilerplate_license"]   
+    (id_info[f"{x}resourceConstraints"][2][f"{x}MD_LegalConstraints"]
      [f"{x}useConstraints"][f"{x}MD_RestrictionCode"][enum]) = "license"
-    (id_info[f"{x}resourceConstraints"][1][f"{x}MD_LegalConstraints"]
-     [f"{x}useConstraints"][f"{x}MD_RestrictionCode"][t]) = "license"     
+    (id_info[f"{x}resourceConstraints"][2][f"{x}MD_LegalConstraints"]
+     [f"{x}useConstraints"][f"{x}MD_RestrictionCode"][t]) = "license"    
 
     return metadata
     

--- a/open_data/open_data.py
+++ b/open_data/open_data.py
@@ -10,29 +10,31 @@ import metadata_hqta
 import metadata_traffic_ops
 import metadata_speeds
 
+FOLDER = metadata_update_pro.METADATA_FOLDER
+
 OPEN_DATA = {
     "hqta_areas": {
-        "path": "./metadata_xml/ca_hq_transit_areas.xml", 
+        "path": f"{FOLDER}/ca_hq_transit_areas.xml", 
         "metadata_dict": metadata_hqta.HQTA_TRANSIT_AREAS_DICT,
     },
     "hqta_stops": {
-        "path": "./metadata_xml/ca_hq_transit_stops.xml",
+        "path": f"{FOLDER}ca_hq_transit_stops.xml",
         "metadata_dict": metadata_hqta.HQTA_TRANSIT_STOPS_DICT,
     },
     "transit_stops": {
-        "path": "./metadata_xml/ca_transit_stops.xml",
+        "path": f"{FOLDER}ca_transit_stops.xml",
         "metadata_dict": metadata_traffic_ops.STOPS_DICT,
     },
     "transit_routes": {
-        "path": "./metadata_xml/ca_transit_routes.xml",
+        "path": f"{FOLDER}ca_transit_routes.xml",
         "metadata_dict": metadata_traffic_ops.ROUTES_DICT,
     },
     "speeds_stop_segments": {
-        "path": "./metadata_xml/speeds_by_stop_segments.xml",
+        "path": f"{FOLDER}speeds_by_stop_segments.xml",
         "metadata_dict": metadata_speeds.SPEEDS_STOP_SEG_DICT,
     },
     "speeds_route_time_of_day": {
-        "path": "./metadata_xml/speeds_by_route_time_of_day.xml",
+        "path": f"{FOLDER}speeds_by_route_time_of_day.xml",
         "metadata_dict": metadata_speeds.ROUTE_SPEEDS_DICT
     },
 }

--- a/open_data/update_vars.py
+++ b/open_data/update_vars.py
@@ -7,3 +7,6 @@ COMPILED_CACHED_VIEWS = f"{GCS_FILE_PATH}rt_delay/compiled_cached_views/"
 TRAFFIC_OPS_GCS = f"{GCS_FILE_PATH}traffic_ops/"
 HQTA_GCS = f"{GCS_FILE_PATH}high_quality_transit_areas/"
 SEGMENT_GCS = f"{GCS_FILE_PATH}rt_segment_speeds/"
+
+ESRI_BASE_URL = "https://gisdata.dot.ca.gov/arcgis/rest/services/CHrailroad/"
+DEFAULT_XML_TEMPLATE = "default_pro.xml"

--- a/open_data/xml/ca_hq_transit_areas.xml
+++ b/open_data/xml/ca_hq_transit_areas.xml
@@ -38,8 +38,8 @@
 			<ns0:geometricObjects>
 				<ns0:MD_GeometricObjects>
 					<ns0:geometricObjectType>
-						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="point" codeSpace="ISOTC211/19115">
-							<text>point</text>
+						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="composite" codeSpace="ISOTC211/19115">
+							<text>composite</text>
 						</ns0:MD_GeometricObjectTypeCode>
 					</ns0:geometricObjectType>
 				</ns0:MD_GeometricObjects>
@@ -68,7 +68,7 @@
 			<ns0:citation>
 				<ns0:CI_Citation>
 					<ns0:title>
-						<ns1:CharacterString>ca_hq_transit_stops</ns1:CharacterString>
+						<ns1:CharacterString>ca_hq_transit_areas</ns1:CharacterString>
 					</ns0:title>
 					<ns0:date>
 						<ns0:CI_Date>
@@ -131,12 +131,10 @@
 				</ns0:CI_Citation>
 			</ns0:citation>
 			<ns0:abstract>
-				<ns1:CharacterString>Public. EPSG: 4326</ns1:CharacterString>
+				<ns1:CharacterString>Use GTFS schedule trips, stop_times, shapes, and stops to estimate whether corridor segments have scheduled frequencies of 15 minutes or less.</ns1:CharacterString>
 			</ns0:abstract>
 			<ns0:purpose>
-				<ns1:CharacterString>
-    Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2.
-    </ns1:CharacterString>
+				<ns1:CharacterString>Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2.</ns1:CharacterString>
 			</ns0:purpose>
 			<ns0:status>
 				<ns0:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" codeSpace="ISOTC211/19115">
@@ -207,16 +205,21 @@
 			<ns0:resourceConstraints>
 				<ns0:MD_Constraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>Public</ns1:CharacterString>
 					</ns0:useLimitation>
 				</ns0:MD_Constraints>
 			</ns0:resourceConstraints>
 			<ns0:resourceConstraints>
 				<ns0:MD_LegalConstraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+					</ns0:useLimitation>
+				</ns0:MD_LegalConstraints>
+			</ns0:resourceConstraints>
+			<ns0:resourceConstraints>
+				<ns0:MD_LegalConstraints>
+					<ns0:useLimitation>
+						<ns1:CharacterString>License - Creative Commons 4.0 Attribution.</ns1:CharacterString>
 					</ns0:useLimitation>
 					<ns0:useConstraints>
 						<ns0:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">

--- a/open_data/xml/ca_hq_transit_stops.xml
+++ b/open_data/xml/ca_hq_transit_stops.xml
@@ -38,8 +38,8 @@
 			<ns0:geometricObjects>
 				<ns0:MD_GeometricObjects>
 					<ns0:geometricObjectType>
-						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="composite" codeSpace="ISOTC211/19115">
-							<text>composite</text>
+						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="point" codeSpace="ISOTC211/19115">
+							<text>point</text>
 						</ns0:MD_GeometricObjectTypeCode>
 					</ns0:geometricObjectType>
 				</ns0:MD_GeometricObjects>
@@ -68,12 +68,12 @@
 			<ns0:citation>
 				<ns0:CI_Citation>
 					<ns0:title>
-						<ns1:CharacterString>speeds_by_route_time_of_day</ns1:CharacterString>
+						<ns1:CharacterString>ca_hq_transit_stops</ns1:CharacterString>
 					</ns0:title>
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-06-14</ns1:Date>
+								<ns1:Date>2022-02-08</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" codeSpace="ISOTC211/19115">
@@ -97,7 +97,7 @@
 					<ns0:citedResponsibleParty>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
+								<ns1:CharacterString>Eric Dasmalchi</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
@@ -110,7 +110,7 @@
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -131,10 +131,10 @@
 				</ns0:CI_Citation>
 			</ns0:citation>
 			<ns0:abstract>
-				<ns1:CharacterString>Public. EPSG: 4326</ns1:CharacterString>
+				<ns1:CharacterString>Use GTFS schedule trips, stop_times, shapes, and stops to estimate whether corridor segments have scheduled frequencies of 15 minutes or less.</ns1:CharacterString>
 			</ns0:abstract>
 			<ns0:purpose>
-				<ns1:CharacterString>Average transit speeds by route-direction by time-of-day estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data.</ns1:CharacterString>
+				<ns1:CharacterString>Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2.</ns1:CharacterString>
 			</ns0:purpose>
 			<ns0:status>
 				<ns0:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" codeSpace="ISOTC211/19115">
@@ -154,7 +154,7 @@
 					<ns0:contact>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
+								<ns1:CharacterString>Eric Dasmalchi</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
@@ -167,7 +167,7 @@
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -185,7 +185,7 @@
 			<ns0:descriptiveKeywords>
 				<ns0:MD_Keywords>
 					<ns0:keyword>
-						<ns1:CharacterString>Transportation, Transit, GTFS, GTFS RT, real time, speeds, vehicle positions</ns1:CharacterString>
+						<ns1:CharacterString>Transportation, Land Use, Transit-Oriented Development, TOD, High Quality Transit</ns1:CharacterString>
 					</ns0:keyword>
 					<ns0:type>
 						<ns0:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" codeSpace="ISOTC211/19115">
@@ -205,16 +205,21 @@
 			<ns0:resourceConstraints>
 				<ns0:MD_Constraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>Public</ns1:CharacterString>
 					</ns0:useLimitation>
 				</ns0:MD_Constraints>
 			</ns0:resourceConstraints>
 			<ns0:resourceConstraints>
 				<ns0:MD_LegalConstraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+					</ns0:useLimitation>
+				</ns0:MD_LegalConstraints>
+			</ns0:resourceConstraints>
+			<ns0:resourceConstraints>
+				<ns0:MD_LegalConstraints>
+					<ns0:useLimitation>
+						<ns1:CharacterString>License - Creative Commons 4.0 Attribution.</ns1:CharacterString>
 					</ns0:useLimitation>
 					<ns0:useConstraints>
 						<ns0:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">
@@ -289,11 +294,7 @@
 					<ns0:processStep>
 						<ns0:LI_ProcessStep>
 							<ns0:description>
-								<ns1:CharacterString>
-    This data was estimated by combining GTFS real-time vehicle positions with GTFS scheduled trips and shapes. 
-    GTFS real-time (RT) vehicle positions are spatially joined to GTFS scheduled shapes, so only vehicle positions traveling along the route alignment path are kept. A sample of five vehicle positions are selected (min, 25th percentile, 50th percentile, 75th percentile, max). The trip speed is calculated using these five vehicle positions. Each trip is categorized into a time-of-day. The average speed for a route-direction-time_of_day is calculated. Additional metrics are stored, such as the number of trips observed, the average scheduled service minutes, and the average RT observed service minutes. For convenience, we also provide a singular shape (common_shape_id) to associate with a route-direction. This is the shape that had the most number of trips for a given route-direction. 
-    Time-of-day is determined by the GTFS scheduled trip start time. The trip start hour (military time) is categorized based on the following: Owl (0-3), Early AM (4-6), AM Peak (7-9), Midday (10-14), PM Peak (15-19), and Evening (20-23). The start and end hours are inclusive (e.g., 4-6 refers to 4am, 5am, and 6am).
-    </ns1:CharacterString>
+								<ns1:CharacterString>This data was estimated using a spatial process derived from General Transit Feed Specification (GTFS) schedule data. To find high-quality bus corridors, we split each corridor into 1,500 meter segments and counted frequencies at the stop within that segment with the highest number of transit trips. If that stop saw at least 4 trips per hour for at least one hour in the morning, and again for at least one hour in the afternoon, we consider that segment a high-quality bus corridor. Segments without a stop are not considered high-quality corridors. Major transit stops were identified as either the intersection of two high-quality corridors from the previous step, a rail or bus rapid transit station, or a ferry terminal with bus service. Note that the definition of `bus rapid transit` in Public Resources Code 21060.2 includes features not captured by available data sources, these features were captured manually using information from transit agency sources and imagery. We believe this data to be broadly accurate, and fit for purposes including overall dashboards, locating facilities in relation to high quality transit areas, and assessing community transit coverage. However, the spatial determination of high-quality transit areas from GTFS data necessarily involves some assumptions as described above. Any critical determinations of whether a specific parcel is located within a high-quality transit area should be made in conjunction with local sources, such as transit agency timetables.  Notes: Null values may be present. The `hqta_details` columns defines which part of the Public Resources Code definition the HQTA classification was based on. If `hqta_details` references a single operator, then `agency_secondary` and `base64_url_secondary` are null. If `hqta_details` references the same operator, then `agency_secondary` and `base64_url_secondary` are the same as `agency_primary` and `base64_url_primary`. Refer to https://github.com/cal-itp/data-analyses/blob/main/high_quality_transit_areas/README.md for more details.</ns1:CharacterString>
 							</ns0:description>
 						</ns0:LI_ProcessStep>
 					</ns0:processStep>

--- a/open_data/xml/ca_transit_routes.xml
+++ b/open_data/xml/ca_transit_routes.xml
@@ -38,8 +38,8 @@
 			<ns0:geometricObjects>
 				<ns0:MD_GeometricObjects>
 					<ns0:geometricObjectType>
-						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="point" codeSpace="ISOTC211/19115">
-							<text>point</text>
+						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="composite" codeSpace="ISOTC211/19115">
+							<text>composite</text>
 						</ns0:MD_GeometricObjectTypeCode>
 					</ns0:geometricObjectType>
 				</ns0:MD_GeometricObjects>
@@ -68,7 +68,7 @@
 			<ns0:citation>
 				<ns0:CI_Citation>
 					<ns0:title>
-						<ns1:CharacterString>ca_transit_stops</ns1:CharacterString>
+						<ns1:CharacterString>ca_transit_routes</ns1:CharacterString>
 					</ns0:title>
 					<ns0:date>
 						<ns0:CI_Date>
@@ -131,7 +131,7 @@
 				</ns0:CI_Citation>
 			</ns0:citation>
 			<ns0:abstract>
-				<ns1:CharacterString>Public. EPSG: 4326</ns1:CharacterString>
+				<ns1:CharacterString>Provide compiled GTFS schedule data in geospatial format. Transit routes associates route information to shapes. Transit stops associates route information to stops.</ns1:CharacterString>
 			</ns0:abstract>
 			<ns0:purpose>
 				<ns1:CharacterString>Provide all CA transit stops and routes (geospatial) from all transit operators.</ns1:CharacterString>
@@ -205,16 +205,21 @@
 			<ns0:resourceConstraints>
 				<ns0:MD_Constraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>Public</ns1:CharacterString>
 					</ns0:useLimitation>
 				</ns0:MD_Constraints>
 			</ns0:resourceConstraints>
 			<ns0:resourceConstraints>
 				<ns0:MD_LegalConstraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+					</ns0:useLimitation>
+				</ns0:MD_LegalConstraints>
+			</ns0:resourceConstraints>
+			<ns0:resourceConstraints>
+				<ns0:MD_LegalConstraints>
+					<ns0:useLimitation>
+						<ns1:CharacterString>License - Creative Commons 4.0 Attribution.</ns1:CharacterString>
 					</ns0:useLimitation>
 					<ns0:useConstraints>
 						<ns0:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">

--- a/open_data/xml/ca_transit_stops.xml
+++ b/open_data/xml/ca_transit_stops.xml
@@ -38,8 +38,8 @@
 			<ns0:geometricObjects>
 				<ns0:MD_GeometricObjects>
 					<ns0:geometricObjectType>
-						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="composite" codeSpace="ISOTC211/19115">
-							<text>composite</text>
+						<ns0:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="point" codeSpace="ISOTC211/19115">
+							<text>point</text>
 						</ns0:MD_GeometricObjectTypeCode>
 					</ns0:geometricObjectType>
 				</ns0:MD_GeometricObjects>
@@ -68,12 +68,12 @@
 			<ns0:citation>
 				<ns0:CI_Citation>
 					<ns0:title>
-						<ns1:CharacterString>speeds_by_stop_segments</ns1:CharacterString>
+						<ns1:CharacterString>ca_transit_stops</ns1:CharacterString>
 					</ns0:title>
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-06-14</ns1:Date>
+								<ns1:Date>2022-02-08</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" codeSpace="ISOTC211/19115">
@@ -97,20 +97,20 @@
 					<ns0:citedResponsibleParty>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
+								<ns1:CharacterString>Tiffany Ku</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
 							</ns0:organisationName>
 							<ns0:positionName>
-								<ns1:CharacterString>Data &amp; Digital Services / California Integrated Travel Project</ns1:CharacterString>
+								<ns1:CharacterString>California Integrated Travel Project</ns1:CharacterString>
 							</ns0:positionName>
 							<ns0:contactInfo>
 								<ns0:CI_Contact>
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>tiffany.ku@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -131,10 +131,10 @@
 				</ns0:CI_Citation>
 			</ns0:citation>
 			<ns0:abstract>
-				<ns1:CharacterString>Public. EPSG: 4326</ns1:CharacterString>
+				<ns1:CharacterString>Provide compiled GTFS schedule data in geospatial format. Transit routes associates route information to shapes. Transit stops associates route information to stops.</ns1:CharacterString>
 			</ns0:abstract>
 			<ns0:purpose>
-				<ns1:CharacterString>All day and peak transit 20th, 50th, and 80th percentile speeds on stop segments estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data.</ns1:CharacterString>
+				<ns1:CharacterString>Provide all CA transit stops and routes (geospatial) from all transit operators.</ns1:CharacterString>
 			</ns0:purpose>
 			<ns0:status>
 				<ns0:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" codeSpace="ISOTC211/19115">
@@ -154,20 +154,20 @@
 					<ns0:contact>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
+								<ns1:CharacterString>Tiffany Ku</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
 							</ns0:organisationName>
 							<ns0:positionName>
-								<ns1:CharacterString>Data &amp; Digital Services / California Integrated Travel Project</ns1:CharacterString>
+								<ns1:CharacterString>California Integrated Travel Project</ns1:CharacterString>
 							</ns0:positionName>
 							<ns0:contactInfo>
 								<ns0:CI_Contact>
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>tiffany.ku@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -185,7 +185,7 @@
 			<ns0:descriptiveKeywords>
 				<ns0:MD_Keywords>
 					<ns0:keyword>
-						<ns1:CharacterString>Transportation, Transit, GTFS, GTFS RT, real time, speeds, vehicle positions</ns1:CharacterString>
+						<ns1:CharacterString>Transportation, GTFS, Transit routes, Transit stops, Transit</ns1:CharacterString>
 					</ns0:keyword>
 					<ns0:type>
 						<ns0:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" codeSpace="ISOTC211/19115">
@@ -205,16 +205,21 @@
 			<ns0:resourceConstraints>
 				<ns0:MD_Constraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>Public</ns1:CharacterString>
 					</ns0:useLimitation>
 				</ns0:MD_Constraints>
 			</ns0:resourceConstraints>
 			<ns0:resourceConstraints>
 				<ns0:MD_LegalConstraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+					</ns0:useLimitation>
+				</ns0:MD_LegalConstraints>
+			</ns0:resourceConstraints>
+			<ns0:resourceConstraints>
+				<ns0:MD_LegalConstraints>
+					<ns0:useLimitation>
+						<ns1:CharacterString>License - Creative Commons 4.0 Attribution.</ns1:CharacterString>
 					</ns0:useLimitation>
 					<ns0:useConstraints>
 						<ns0:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">
@@ -289,10 +294,7 @@
 					<ns0:processStep>
 						<ns0:LI_ProcessStep>
 							<ns0:description>
-								<ns1:CharacterString>
-    This data was estimated by combining GTFS real-time vehicle positions to GTFS scheduled trips, shapes, stops, and stop times tables. GTFS shapes provides the route alignment path. Multiple trips may share the same shape, with a route typically associated with multiple shapes. Shapes are cut into segments at stop positions (stop_id-stop_sequence combination). A `stop segment` refers to the portion of shapes between the prior stop and the current stop. Vehicle positions are spatially joined to 35 meter buffered segments. Within each segment-trip, the first and last vehicle position observed are used to calculate the speed. Since multiple trips may occur over a segment each day, the multiple trip speeds provide a distribution. From this distribution, the 20th percentile, 50th percentile (median), and 80th percentile speeds are calculated. For all day speed metrics, all trips are used. For peak speed metrics, only trips with start times between 7 - 9:59 AM and 4 - 7:59 PM are used to find the 20th, 50th, and 80th percentile metrics.
-    Data processing notes: (a) GTFS RT trips whose vehicle position timestamps span 10 minutes or less are dropped. Incomplete data would lead to unreliable estimates of speed at the granularity we need. (b) Segment-trip speeds of over 70 mph are excluded. These are erroneously calculated as transit does not typically reach those speeds. (c) Other missing or erroneous calculations, either arising from only one vehicle position found in a segment (change in time or change in distance cannot be calculated).
-    </ns1:CharacterString>
+								<ns1:CharacterString>This data was assembled from the General Transit Feed Specification (GTFS) schedule data. GTFS tables are text files, but these have been compiled for all operators and transformed into geospatial data, with minimal data processing. The transit routes dataset is assembled from two tables: (1) `shapes.txt`, which defines the route alignment path, and (2) `trips.txt` and `stops.txt`, for routes not found in `shapes.txt`. `shapes.txt` is an optional GTFS table with richer information than just transit stop longitude and latitude. The transit stops dataset is assembled from `stops.txt`, which contains information about the route, stop sequence, and stop longitude and latitude. References: https://gtfs.org/. https://gtfs.org/schedule/reference/#shapestxt. https://gtfs.org/schedule/reference/#stopstxt. https://gtfs.org/schedule/reference/#tripstxt.</ns1:CharacterString>
 							</ns0:description>
 						</ns0:LI_ProcessStep>
 					</ns0:processStep>

--- a/open_data/xml/default_pro.xml
+++ b/open_data/xml/default_pro.xml
@@ -15,7 +15,7 @@
 <contact gco:nilReason="missing">
 </contact>
 <dateStamp>
-<gco:Date>2023-07-07</gco:Date>
+<gco:Date>2023-07-18</gco:Date>
 </dateStamp>
 <metadataStandardName>
 <gco:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</gco:CharacterString>
@@ -33,6 +33,9 @@
 <geometricObjectType>
 <MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="composite" codeSpace="ISOTC211/19115">composite</MD_GeometricObjectTypeCode>
 </geometricObjectType>
+<geometricObjectCount>
+<gco:Integer>21100</gco:Integer>
+</geometricObjectCount>
 </MD_GeometricObjects>
 </geometricObjects>
 </MD_VectorSpatialRepresentation>
@@ -59,12 +62,12 @@
 <citation>
 <CI_Citation>
 <title>
-<gco:CharacterString>speeds_by_stop_segments</gco:CharacterString>
+<gco:CharacterString>ca_hq_transit_areas</gco:CharacterString>
 </title>
 <date>
 <CI_Date>
 <date>
-<gco:Date>2023-01-01</gco:Date>
+<gco:Date>2022-02-08</gco:Date>
 </date>
 <dateType>
 <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" codeSpace="ISOTC211/19115">creation</CI_DateTypeCode>
@@ -74,7 +77,7 @@
 <date>
 <CI_Date>
 <date>
-<gco:Date>2023-07-01</gco:Date>
+<gco:Date>2023-07-12</gco:Date>
 </date>
 <dateType>
 <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">revision</CI_DateTypeCode>
@@ -97,7 +100,7 @@
 <address>
 <CI_Address>
 <electronicMailAddress>
-<gco:CharacterString>hello@calitp.org</gco:CharacterString>
+<gco:CharacterString>eric.dasmalchi@dot.ca.gov</gco:CharacterString>
 </electronicMailAddress>
 </CI_Address>
 </address>
@@ -114,10 +117,11 @@
 </CI_Citation>
 </citation>
 <abstract>
-<gco:CharacterString>Description here.</gco:CharacterString>
+<gco:CharacterString>Abstract.</gco:CharacterString>
 </abstract>
 <purpose>
-<gco:CharacterString>Summary and purpose statement.</gco:CharacterString>
+<gco:CharacterString>Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2.
+    </gco:CharacterString>
 </purpose>
 <status>
 <MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" codeSpace="ISOTC211/19115">completed</MD_ProgressCode>
@@ -128,7 +132,7 @@
 <MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="monthly" codeSpace="ISOTC211/19115">monthly</MD_MaintenanceFrequencyCode>
 </maintenanceAndUpdateFrequency>
 <dateOfNextUpdate>
-<gco:Date>2023-08-01</gco:Date>
+<gco:Date>2023-08-12</gco:Date>
 </dateOfNextUpdate>
 <contact>
 <CI_ResponsibleParty>
@@ -146,7 +150,7 @@
 <address>
 <CI_Address>
 <electronicMailAddress>
-<gco:CharacterString>hello@calitp.org</gco:CharacterString>
+<gco:CharacterString>eric.dasmalchi@dot.ca.gov</gco:CharacterString>
 </electronicMailAddress>
 </CI_Address>
 </address>
@@ -162,7 +166,7 @@
 <descriptiveKeywords>
 <MD_Keywords>
 <keyword>
-<gco:CharacterString>keyword1, keyword2, keyword3, keyword4, keyword5</gco:CharacterString>
+<gco:CharacterString>Transportation, Land Use, Transit-Oriented Development, TOD, High Quality Transit</gco:CharacterString>
 </keyword>
 <type>
 <MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" codeSpace="ISOTC211/19115">theme</MD_KeywordTypeCode>
@@ -179,17 +183,16 @@
 </MD_Keywords>
 </descriptiveKeywords>
 <resourceConstraints>
-<MD_Constraints>
+<MD_LegalConstraints>
 <useLimitation>
-<gco:CharacterString>Public. License - Creative Commons 4.0 Attribution.  Boilerplate.</gco:CharacterString>
+<gco:CharacterString>The data are made available to the public solely for informational purposes. Information provided is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warranty the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. Caltrans is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</gco:CharacterString>
 </useLimitation>
-</MD_Constraints>
+</MD_LegalConstraints>
 </resourceConstraints>
 <resourceConstraints>
 <MD_LegalConstraints>
 <useLimitation>
-<gco:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.
-License - Creative Commons 4.0 Attribution</gco:CharacterString>
+<gco:CharacterString>License - Creative Commons 4.0 Attribution</gco:CharacterString>
 </useLimitation>
 <useConstraints>
 <MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">license</MD_RestrictionCode>
@@ -216,6 +219,29 @@ License - Creative Commons 4.0 Attribution</gco:CharacterString>
 <description>
 <gco:CharacterString>California</gco:CharacterString>
 </description>
+</EX_Extent>
+</extent>
+<extent>
+<EX_Extent>
+<geographicElement>
+<EX_GeographicBoundingBox>
+<extentTypeCode>
+<gco:Boolean>true</gco:Boolean>
+</extentTypeCode>
+<westBoundLongitude>
+<gco:Decimal>-124.22499</gco:Decimal>
+</westBoundLongitude>
+<eastBoundLongitude>
+<gco:Decimal>-73.977155</gco:Decimal>
+</eastBoundLongitude>
+<southBoundLatitude>
+<gco:Decimal>25.78275</gco:Decimal>
+</southBoundLatitude>
+<northBoundLatitude>
+<gco:Decimal>41.88659</gco:Decimal>
+</northBoundLatitude>
+</EX_GeographicBoundingBox>
+</geographicElement>
 </EX_Extent>
 </extent>
 </MD_DataIdentification>
@@ -256,7 +282,7 @@ License - Creative Commons 4.0 Attribution</gco:CharacterString>
 <processStep>
 <LI_ProcessStep>
 <description>
-<gco:CharacterString>Detailed methodology here.</gco:CharacterString>
+<gco:CharacterString>This data was estimated using a spatial process derived from General Transit Feed Specification (GTFS) schedule data. To find high-quality bus corridors, we split each corridor into 1,500 meter segments and counted frequencies at the stop within that segment with the highest number of transit trips. If that stop saw at least 4 trips per hour for at least one hour in the morning, and again for at least one hour in the afternoon, we consider that segment a high-quality bus corridor. Segments without a stop are not considered high-quality corridors. Major transit stops were identified as either the intersection of two high-quality corridors from the previous step, a rail or bus rapid transit station, or a ferry terminal with bus service. Note that the definition of `bus rapid transit` in Public Resources Code 21060.2 includes features not captured by available data sources, these features were captured manually using information from transit agency sources and imagery. We believe this data to be broadly accurate, and fit for purposes including overall dashboards, locating facilities in relation to high quality transit areas, and assessing community transit coverage. However, the spatial determination of high-quality transit areas from GTFS data necessarily involves some assumptions as described above. Any critical determinations of whether a specific parcel is located within a high-quality transit area should be made in conjunction with local sources, such as transit agency timetables.  Notes: Null values may be present. The `hqta_details` columns defines which part of the Public Resources Code definition the HQTA classification was based on. If `hqta_details` references a single operator, then `agency_secondary` and `base64_url_secondary` are null. If `hqta_details` references the same operator, then `agency_secondary` and `base64_url_secondary` are the same as `agency_primary` and `base64_url_primary`. Refer to https://github.com/cal-itp/data-analyses/blob/main/high_quality_transit_areas/README.md for more details.</gco:CharacterString>
 </description>
 </LI_ProcessStep>
 </processStep>

--- a/open_data/xml/speeds_by_route_time_of_day.xml
+++ b/open_data/xml/speeds_by_route_time_of_day.xml
@@ -68,12 +68,12 @@
 			<ns0:citation>
 				<ns0:CI_Citation>
 					<ns0:title>
-						<ns1:CharacterString>ca_hq_transit_areas</ns1:CharacterString>
+						<ns1:CharacterString>speeds_by_route_time_of_day</ns1:CharacterString>
 					</ns0:title>
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2022-02-08</ns1:Date>
+								<ns1:Date>2023-06-14</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" codeSpace="ISOTC211/19115">
@@ -97,7 +97,7 @@
 					<ns0:citedResponsibleParty>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Eric Dasmalchi</ns1:CharacterString>
+								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
@@ -110,7 +110,7 @@
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -131,12 +131,10 @@
 				</ns0:CI_Citation>
 			</ns0:citation>
 			<ns0:abstract>
-				<ns1:CharacterString>Public. EPSG: 4326</ns1:CharacterString>
+				<ns1:CharacterString>Provide average transit speeds, number of trips, and metrics related to scheduled annd real-time service minutes by route-direction and time-of-day.</ns1:CharacterString>
 			</ns0:abstract>
 			<ns0:purpose>
-				<ns1:CharacterString>
-    Estimated High Quality Transit Areas as described in Public Resources Code 21155, 21064.3, 21060.2.
-    </ns1:CharacterString>
+				<ns1:CharacterString>Average transit speeds by route-direction and time-of-day estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data.</ns1:CharacterString>
 			</ns0:purpose>
 			<ns0:status>
 				<ns0:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" codeSpace="ISOTC211/19115">
@@ -156,7 +154,7 @@
 					<ns0:contact>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Eric Dasmalchi</ns1:CharacterString>
+								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
@@ -169,7 +167,7 @@
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -187,7 +185,7 @@
 			<ns0:descriptiveKeywords>
 				<ns0:MD_Keywords>
 					<ns0:keyword>
-						<ns1:CharacterString>Transportation, Land Use, Transit-Oriented Development, TOD, High Quality Transit</ns1:CharacterString>
+						<ns1:CharacterString>Transportation, Transit, GTFS, GTFS RT, real time, speeds, vehicle positions</ns1:CharacterString>
 					</ns0:keyword>
 					<ns0:type>
 						<ns0:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" codeSpace="ISOTC211/19115">
@@ -207,16 +205,21 @@
 			<ns0:resourceConstraints>
 				<ns0:MD_Constraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>Public</ns1:CharacterString>
 					</ns0:useLimitation>
 				</ns0:MD_Constraints>
 			</ns0:resourceConstraints>
 			<ns0:resourceConstraints>
 				<ns0:MD_LegalConstraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+					</ns0:useLimitation>
+				</ns0:MD_LegalConstraints>
+			</ns0:resourceConstraints>
+			<ns0:resourceConstraints>
+				<ns0:MD_LegalConstraints>
+					<ns0:useLimitation>
+						<ns1:CharacterString>License - Creative Commons 4.0 Attribution.</ns1:CharacterString>
 					</ns0:useLimitation>
 					<ns0:useConstraints>
 						<ns0:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">
@@ -291,7 +294,7 @@
 					<ns0:processStep>
 						<ns0:LI_ProcessStep>
 							<ns0:description>
-								<ns1:CharacterString>This data was estimated using a spatial process derived from General Transit Feed Specification (GTFS) schedule data. To find high-quality bus corridors, we split each corridor into 1,500 meter segments and counted frequencies at the stop within that segment with the highest number of transit trips. If that stop saw at least 4 trips per hour for at least one hour in the morning, and again for at least one hour in the afternoon, we consider that segment a high-quality bus corridor. Segments without a stop are not considered high-quality corridors. Major transit stops were identified as either the intersection of two high-quality corridors from the previous step, a rail or bus rapid transit station, or a ferry terminal with bus service. Note that the definition of `bus rapid transit` in Public Resources Code 21060.2 includes features not captured by available data sources, these features were captured manually using information from transit agency sources and imagery. We believe this data to be broadly accurate, and fit for purposes including overall dashboards, locating facilities in relation to high quality transit areas, and assessing community transit coverage. However, the spatial determination of high-quality transit areas from GTFS data necessarily involves some assumptions as described above. Any critical determinations of whether a specific parcel is located within a high-quality transit area should be made in conjunction with local sources, such as transit agency timetables.  Notes: Null values may be present. The `hqta_details` columns defines which part of the Public Resources Code definition the HQTA classification was based on. If `hqta_details` references a single operator, then `agency_secondary` and `base64_url_secondary` are null. If `hqta_details` references the same operator, then `agency_secondary` and `base64_url_secondary` are the same as `agency_primary` and `base64_url_primary`. Refer to https://github.com/cal-itp/data-analyses/blob/main/high_quality_transit_areas/README.md for more details.</ns1:CharacterString>
+								<ns1:CharacterString>This data was estimated by combining GTFS real-time vehicle positions with GTFS scheduled trips and shapes. GTFS real-time (RT) vehicle positions are spatially joined to GTFS scheduled shapes, so only vehicle positions traveling along the route alignment path are kept. A sample of five vehicle positions are selected (min, 25th percentile, 50th percentile, 75th percentile, max). The trip speed is calculated using these five vehicle positions. Each trip is categorized into a time-of-day. The average speed for a route-direction-time_of_day is calculated. Additional metrics are stored, such as the number of trips observed, the average scheduled service minutes, and the average RT observed service minutes. For convenience, we also provide a singular shape (common_shape_id) to associate with a route-direction. This is the shape that had the most number of trips for a given route-direction. Time-of-day is determined by the GTFS scheduled trip start time. The trip start hour (military time) is categorized based on the following: Owl (0-3), Early AM (4-6), AM Peak (7-9), Midday (10-14), PM Peak (15-19), and Evening (20-23). The start and end hours are inclusive (e.g., 4-6 refers to 4am, 5am, and 6am).</ns1:CharacterString>
 							</ns0:description>
 						</ns0:LI_ProcessStep>
 					</ns0:processStep>

--- a/open_data/xml/speeds_by_stop_segments.xml
+++ b/open_data/xml/speeds_by_stop_segments.xml
@@ -68,12 +68,12 @@
 			<ns0:citation>
 				<ns0:CI_Citation>
 					<ns0:title>
-						<ns1:CharacterString>ca_transit_routes</ns1:CharacterString>
+						<ns1:CharacterString>speeds_by_stop_segments</ns1:CharacterString>
 					</ns0:title>
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2022-02-08</ns1:Date>
+								<ns1:Date>2023-06-14</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" codeSpace="ISOTC211/19115">
@@ -97,20 +97,20 @@
 					<ns0:citedResponsibleParty>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Tiffany Ku</ns1:CharacterString>
+								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
 							</ns0:organisationName>
 							<ns0:positionName>
-								<ns1:CharacterString>California Integrated Travel Project</ns1:CharacterString>
+								<ns1:CharacterString>Data &amp; Digital Services / California Integrated Travel Project</ns1:CharacterString>
 							</ns0:positionName>
 							<ns0:contactInfo>
 								<ns0:CI_Contact>
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>tiffany.ku@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -131,10 +131,10 @@
 				</ns0:CI_Citation>
 			</ns0:citation>
 			<ns0:abstract>
-				<ns1:CharacterString>Public. EPSG: 4326</ns1:CharacterString>
+				<ns1:CharacterString>All day and peak transit 20th, 50th, and 80th percentile speeds on stop segments estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data.</ns1:CharacterString>
 			</ns0:abstract>
 			<ns0:purpose>
-				<ns1:CharacterString>Provide all CA transit stops and routes (geospatial) from all transit operators.</ns1:CharacterString>
+				<ns1:CharacterString>All day and peak transit speeds by segments for all CA operators that provide GTFS real-time vehicle positions data.</ns1:CharacterString>
 			</ns0:purpose>
 			<ns0:status>
 				<ns0:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed" codeSpace="ISOTC211/19115">
@@ -154,20 +154,20 @@
 					<ns0:contact>
 						<ns0:CI_ResponsibleParty>
 							<ns0:individualName>
-								<ns1:CharacterString>Tiffany Ku</ns1:CharacterString>
+								<ns1:CharacterString>Tiffany Ku; Eric Dasmalchi</ns1:CharacterString>
 							</ns0:individualName>
 							<ns0:organisationName>
 								<ns1:CharacterString>Caltrans</ns1:CharacterString>
 							</ns0:organisationName>
 							<ns0:positionName>
-								<ns1:CharacterString>California Integrated Travel Project</ns1:CharacterString>
+								<ns1:CharacterString>Data &amp; Digital Services / California Integrated Travel Project</ns1:CharacterString>
 							</ns0:positionName>
 							<ns0:contactInfo>
 								<ns0:CI_Contact>
 									<ns0:address>
 										<ns0:CI_Address>
 											<ns0:electronicMailAddress>
-												<ns1:CharacterString>tiffany.ku@dot.ca.gov</ns1:CharacterString>
+												<ns1:CharacterString>tiffany.ku@dot.ca.gov; eric.dasmalchi@dot.ca.gov</ns1:CharacterString>
 											</ns0:electronicMailAddress>
 										</ns0:CI_Address>
 									</ns0:address>
@@ -185,7 +185,7 @@
 			<ns0:descriptiveKeywords>
 				<ns0:MD_Keywords>
 					<ns0:keyword>
-						<ns1:CharacterString>Transportation, GTFS, Transit routes, Transit stops, Transit</ns1:CharacterString>
+						<ns1:CharacterString>Transportation, Transit, GTFS, GTFS RT, real time, speeds, vehicle positions</ns1:CharacterString>
 					</ns0:keyword>
 					<ns0:type>
 						<ns0:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" codeSpace="ISOTC211/19115">
@@ -205,16 +205,21 @@
 			<ns0:resourceConstraints>
 				<ns0:MD_Constraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>Public</ns1:CharacterString>
 					</ns0:useLimitation>
 				</ns0:MD_Constraints>
 			</ns0:resourceConstraints>
 			<ns0:resourceConstraints>
 				<ns0:MD_LegalConstraints>
 					<ns0:useLimitation>
-						<ns1:CharacterString>Public. License - Creative Commons 4.0 Attribution. 
-        The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an "as is" and an "as available" basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+						<ns1:CharacterString>The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information Use Limitation - The data are made available to the public solely for informational purposes. Information provided in the Caltrans GIS Data Library is accurate to the best of our knowledge and is subject to change on a regular basis, without notice. While Caltrans makes every effort to provide useful and accurate information, we do not warrant the information to be authoritative, complete, factual, or timely. Information is provided on an 'as is' and an 'as available' basis. The Department of Transportation is not liable to any party for any cost or damages, including any direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the access or use of, or the inability to access or use, the Site or any of the Materials or Services described herein.</ns1:CharacterString>
+					</ns0:useLimitation>
+				</ns0:MD_LegalConstraints>
+			</ns0:resourceConstraints>
+			<ns0:resourceConstraints>
+				<ns0:MD_LegalConstraints>
+					<ns0:useLimitation>
+						<ns1:CharacterString>License - Creative Commons 4.0 Attribution.</ns1:CharacterString>
 					</ns0:useLimitation>
 					<ns0:useConstraints>
 						<ns0:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license" codeSpace="ISOTC211/19115">
@@ -289,7 +294,7 @@
 					<ns0:processStep>
 						<ns0:LI_ProcessStep>
 							<ns0:description>
-								<ns1:CharacterString>This data was assembled from the General Transit Feed Specification (GTFS) schedule data. GTFS tables are text files, but these have been compiled for all operators and transformed into geospatial data, with minimal data processing. The transit routes dataset is assembled from two tables: (1) `shapes.txt`, which defines the route alignment path, and (2) `trips.txt` and `stops.txt`, for routes not found in `shapes.txt`. `shapes.txt` is an optional GTFS table with richer information than just transit stop longitude and latitude. The transit stops dataset is assembled from `stops.txt`, which contains information about the route, stop sequence, and stop longitude and latitude. References: https://gtfs.org/. https://gtfs.org/schedule/reference/#shapestxt. https://gtfs.org/schedule/reference/#stopstxt. https://gtfs.org/schedule/reference/#tripstxt.</ns1:CharacterString>
+								<ns1:CharacterString>This data was estimated by combining GTFS real-time vehicle positions to GTFS scheduled trips, shapes, stops, and stop times tables. GTFS shapes provides the route alignment path. Multiple trips may share the same shape, with a route typically associated with multiple shapes. Shapes are cut into segments at stop positions (stop_id-stop_sequence combination). A `stop segment` refers to the portion of shapes between the prior stop and the current stop. Vehicle positions are spatially joined to 35 meter buffered segments. Within each segment-trip, the first and last vehicle position observed are used to calculate the speed. Since multiple trips may occur over a segment each day, the multiple trip speeds provide a distribution. From this distribution, the 20th percentile, 50th percentile (median), and 80th percentile speeds are calculated. For all day speed metrics, all trips are used. For peak speed metrics, only trips with start times between 7 - 9:59 AM and 4 - 7:59 PM are used to find the 20th, 50th, and 80th percentile metrics. Data processing notes: (a) GTFS RT trips whose vehicle position timestamps span 10 minutes or less are dropped. Incomplete data would lead to unreliable estimates of speed at the granularity we need. (b) Segment-trip speeds of over 70 mph are excluded. These are erroneously calculated as transit does not typically reach those speeds. (c) Other missing or erroneous calculations, either arising from only one vehicle position found in a segment (change in time or change in distance cannot be calculated).</ns1:CharacterString>
 							</ns0:description>
 						</ns0:LI_ProcessStep>
 					</ns0:processStep>


### PR DESCRIPTION
* DDP6 form has yet another updated template (v3.1), but DDP8 is v3.0 -- forms are [on data governance intranet](https://datagovernance.onramp.dot.ca.gov/guidance-and-templates)
* fix how the boilerplate license and use limitation must appear
* add public access
* change abstract to be more descriptive than summary, but less descriptive than methodology
* re-submit excel sheets to Emma, then submit open data portal request using form. Emma (?) or someone needs to approve to create Geoportal layer...otherwise, speed layers are sitting in the internal AGOL only
* continuing #808 and #761