### PR TITLE
add new gtag to analytics site

### DIFF
--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -23,6 +23,7 @@ from slugify import slugify
 
 assert os.getcwd().endswith("data-analyses"), "this script must be run from the root of the data-analyses repo!"
 
+GOOGLE_ANALYTICS_TAG_ID = "G-JCX3Z8JZJC"
 PORTFOLIO_DIR = Path("./portfolio/")
 SITES_DIR = PORTFOLIO_DIR / Path("sites")
 
@@ -312,7 +313,7 @@ def index(
         fname = f"./portfolio/index/{template}"
         with open(fname, "w") as f:
             typer.echo(f"writing out to {fname}")
-            f.write(env.get_template(template).render(sites=sites))
+            f.write(env.get_template(template).render(sites=sites, google_analytics_id=GOOGLE_ANALYTICS_TAG_ID))
 
     args = [
         "netlify",
@@ -376,7 +377,7 @@ def build(
     fname = site_output_dir / Path("_config.yml")
     with open(fname, "w") as f:
         typer.secho(f"writing config to {fname}", fg=typer.colors.GREEN)
-        f.write(env.get_template("_config.yml").render(site=site))
+        f.write(env.get_template("_config.yml").render(site=site, google_analytics_id=GOOGLE_ANALYTICS_TAG_ID))
     fname = site_output_dir / Path("_toc.yml")
     with open(fname, "w") as f:
         typer.secho(f"writing toc to {fname}", fg=typer.colors.GREEN)

--- a/portfolio/requirements.txt
+++ b/portfolio/requirements.txt
@@ -5,4 +5,4 @@ jupyter-book==0.12.2
 python-slugify==6.1.1
 pyaml==21.10.1
 humanize==4.2.3
-pydantic>=1.9.1
+pydantic==1.10.5

--- a/portfolio/templates/_config.yml
+++ b/portfolio/templates/_config.yml
@@ -35,7 +35,7 @@ html:
   use_issues_button: true
   use_repository_button: true
   use_edit_page_button: true
-  google_analytics_id: G-SZB618VNBZ
+  google_analytics_id: G-JCX3Z8JZJC
 
 sphinx:
   config:

--- a/portfolio/templates/_config.yml
+++ b/portfolio/templates/_config.yml
@@ -35,7 +35,7 @@ html:
   use_issues_button: true
   use_repository_button: true
   use_edit_page_button: true
-  google_analytics_id: G-JCX3Z8JZJC
+  google_analytics_id: '{{ google_analytics_id }}'
 
 sphinx:
   config:

--- a/portfolio/templates/index.html
+++ b/portfolio/templates/index.html
@@ -18,6 +18,13 @@
             line-height: 1.2
         }
     </style>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=TAG_ID"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JCX3Z8JZJC');
+    </script>
 </head>
 <body style>
     <h1>Cal-ITP Data Analysis Portfolio</h1>

--- a/portfolio/templates/index.html
+++ b/portfolio/templates/index.html
@@ -23,7 +23,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-JCX3Z8JZJC');
+      gtag('config', '{{ google_analytics_id }}');
     </script>
 </head>
 <body style>


### PR DESCRIPTION
I dropped the ball on this; we've had an outdated google analytics tag configured for the analysis site.

Note: sites will need to be regenerated for this to take effect.