### PR TITLE
Demo hqta lines

### DIFF
--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -171,7 +171,7 @@ def get_metrolink_feed_key(selected_date: Union[str, datetime.date], get_df: boo
         tbls.mart_gtfs.fct_daily_schedule_feeds()
         >> filter(_.date == selected_date)
         >> inner_join(_, metrolink_in_airtable, on=["gtfs_dataset_key", "gtfs_dataset_name"])
-        >> rename(name = _.gtfs_dataset_name)
+        >> rename(name=_.gtfs_dataset_name)
         >> subset_cols(["feed_key", "name"])
         >> collect()
     )

--- a/high_quality_transit_areas/corridors-as-lines.ipynb
+++ b/high_quality_transit_areas/corridors-as-lines.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "84ddd66a-b745-4a0a-b004-ea9e778bc186",
+   "metadata": {},
+   "source": [
+    "# Demo: backing out HQ transit corridors as lines\n",
+    "\n",
+    "Conservation Biology Institute working with Governor's Office of Planning and Research to develop a CEQA Site Check.\n",
+    "\n",
+    "**Main hurdle**: Screening parcels using two different buffer ranges (1/2-mile and 1/4-mile) specific to HQ corridors, rather than the single buffer range in your CA HQ Transit Areas dataset (polygons). We do this because they filter parcels into different qualification zones depending on the particular CEQA exemption for streamlining of housing development.\n",
+    "<br>**What they have**: an existing modeling workflow to buffer and build out rest of the separate layers.\n",
+    "<br>**What they want**: linestrings they can buffer themselves.\n",
+    "<br>**Solution**: demo how to get linestrings for HQ areas (polygons) using only open data portal products.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "82c736ae-5311-4c1f-b41e-f9bc36e31fc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/geopandas/_compat.py:124: UserWarning: The Shapely GEOS version (3.11.1-CAPI-1.17.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n",
+      "/tmp/ipykernel_1752/1565847299.py:1: DeprecationWarning: Shapely 2.0 is installed, but because PyGEOS is also installed, GeoPandas still uses PyGEOS by default. However, starting with version 0.14, the default will switch to Shapely. To force to use Shapely 2.0 now, you can either uninstall PyGEOS or set the environment variable USE_PYGEOS=0. You can do this before starting the Python process, or in your code before importing geopandas:\n",
+      "\n",
+      "import os\n",
+      "os.environ['USE_PYGEOS'] = '0'\n",
+      "import geopandas\n",
+      "\n",
+      "In the next release, GeoPandas will switch to using Shapely by default, even if PyGEOS is installed. If you only have PyGEOS installed to get speed-ups, this switch should be smooth. However, if you are using PyGEOS directly (calling PyGEOS functions on geometries from GeoPandas), this will then stop working and you are encouraged to migrate from PyGEOS to Shapely 2.0 (https://shapely.readthedocs.io/en/latest/migration_pygeos.html).\n",
+      "  import geopandas as gpd\n"
+     ]
+    }
+   ],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fba41ad-74bd-479e-8c99-989fd4f0e991",
+   "metadata": {},
+   "source": [
+    "Use open data portal products: `ca_hq_transit_areas` and `ca_transit_routes`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a89a0575-d2e4-4ffa-b6b8-21a03e631716",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HQTA_URL = (\"https://gis.data.ca.gov/datasets/\"\n",
+    "            \"863e61eacbf3463ab239beb3cee4a2c3_0.geojson\")\n",
+    "ROUTES_URL = (\"https://gis.data.ca.gov/datasets/\"\n",
+    "              \"dd7cb74665a14859a59b8c31d3bc5a3e_0.geojson\")\n",
+    "\n",
+    "hq_areas = gpd.read_file(HQTA_URL)\n",
+    "\n",
+    "routes = gpd.read_file(ROUTES_URL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51528fd1-79b2-4f54-944e-732a8b6ad371",
+   "metadata": {},
+   "source": [
+    "While the file is called `CA Transit Routes`, it's important to note that transit routes have different variations, the most basic variation being that a route usually travels in 2 directions. But, depending on the service the operator provides, there can be more variations (the same `route_id` has different `shape_id` values).\n",
+    "\n",
+    "We can clip the `routes` by HQTA areas (polygons) and get a much smaller set of routes.\n",
+    "\n",
+    "On this much smaller `routes` file, we should definitely dissolve and get combine all the variations (`shape_id`) for a given route.\n",
+    "\n",
+    "Note: clipping and dissolving can be swapped. But the clip throws away the portion that is outside the HQTA areas, making the dissolve much quicker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "73f0b0cd-872e-454e-8413-1bfa26be372e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "routes2 = routes.clip(hq_areas)\n",
+    "\n",
+    "# Now that it's clipped, get rid of shape variations, \n",
+    "# and dissolve to routes\n",
+    "routes2 = routes2.drop(\n",
+    "    # we don't need these columns later in the analysis\n",
+    "    columns = [\"shape_id\", \"n_trips\", \"uri\"]\n",
+    ").dissolve(\n",
+    "    # dissolve by a set of identifiers that uniquely identifes routes\n",
+    "    by=[\"org_id\", \"agency\", \"route_id\", \n",
+    "        \"route_type\", \"route_name\", \n",
+    "        \"base64_url\"]\n",
+    ").reset_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7826964-e8dd-4b84-8446-8c7a151f62e9",
+   "metadata": {},
+   "source": [
+    "One more check. Is it possible that a lot more routes are present in `CA Transit Routes` than are included in HQTAs? Yes.\n",
+    "\n",
+    "Let's get rid of those."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9d508a4a-f2c4-4ed2-8b80-efbc18cb0c9c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# routes in transit routes: 2209\n",
+      "# routes in hqtas: 2139\n"
+     ]
+    }
+   ],
+   "source": [
+    "routes_in_transit_routes = routes2[[\"org_id\", \"route_id\"]].drop_duplicates()\n",
+    "routes_in_hqta = hq_areas[[\"org_id_primary\", \"route_id\"]\n",
+    "        ].drop_duplicates()\n",
+    "\n",
+    "print(f\"# routes in transit routes: {len(routes_in_transit_routes)}\")\n",
+    "print(f\"# routes in hqtas: {len(routes_in_hqta)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0725d3e3-6b60-4c62-b683-da442a9720c5",
+   "metadata": {},
+   "source": [
+    "Merge in the clipped/dissolved routes (with linestrings) with hq areas.\n",
+    "\n",
+    "Putting it on the left means we make linestrings the primary geometry, \n",
+    "not the polygon (in fact, we drop the polygon geometry from hqta areas)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8d0043e8-0bb4-434e-9c7c-72c6fa6f8b5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "routes_in_hq_areas = pd.merge(\n",
+    "    routes2[[\"org_id\", \"route_id\", \"geometry\"]],\n",
+    "    hq_areas.rename(columns = {\"org_id_primary\": \"org_id\"}\n",
+    "                   ).drop(columns = [\"Shape_Length\", \"Shape_Area\", \"geometry\"]),\n",
+    "    on = [\"org_id\", \"route_id\"],\n",
+    "    how = \"inner\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "669fc07f-6060-4fa2-ac58-09621e7f8367",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>org_id</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>OBJECTID</th>\n",
+       "      <th>agency_primary</th>\n",
+       "      <th>agency_secondary</th>\n",
+       "      <th>hqta_type</th>\n",
+       "      <th>hqta_details</th>\n",
+       "      <th>base64_url_primary</th>\n",
+       "      <th>base64_url_secondary</th>\n",
+       "      <th>org_id_secondary</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "      <td>RouteA-Red</td>\n",
+       "      <td>MULTILINESTRING ((-118.19941 33.92756, -118.19...</td>\n",
+       "      <td>492</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td></td>\n",
+       "      <td>hq_corridor_bus</td>\n",
+       "      <td>stop_along_hq_bus_corridor_single_operator</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "      <td>RouteA-Red</td>\n",
+       "      <td>MULTILINESTRING ((-118.19941 33.92756, -118.19...</td>\n",
+       "      <td>7965</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>major_stop_bus</td>\n",
+       "      <td>intersection_2_bus_routes_same_operator</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "      <td>RouteA-Red</td>\n",
+       "      <td>MULTILINESTRING ((-118.19941 33.92756, -118.19...</td>\n",
+       "      <td>7966</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>major_stop_bus</td>\n",
+       "      <td>intersection_2_bus_routes_same_operator</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "      <td>RouteA-Red</td>\n",
+       "      <td>MULTILINESTRING ((-118.19941 33.92756, -118.19...</td>\n",
+       "      <td>7967</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>major_stop_bus</td>\n",
+       "      <td>intersection_2_bus_routes_same_operator</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "      <td>RouteA-Red</td>\n",
+       "      <td>MULTILINESTRING ((-118.19941 33.92756, -118.19...</td>\n",
+       "      <td>7968</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>City of Lynwood</td>\n",
+       "      <td>major_stop_bus</td>\n",
+       "      <td>intersection_2_bus_routes_same_operator</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...</td>\n",
+       "      <td>rec0FfOvKIMZu1Qjs</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              org_id    route_id  \\\n",
+       "0  rec0FfOvKIMZu1Qjs  RouteA-Red   \n",
+       "1  rec0FfOvKIMZu1Qjs  RouteA-Red   \n",
+       "2  rec0FfOvKIMZu1Qjs  RouteA-Red   \n",
+       "3  rec0FfOvKIMZu1Qjs  RouteA-Red   \n",
+       "4  rec0FfOvKIMZu1Qjs  RouteA-Red   \n",
+       "\n",
+       "                                            geometry  OBJECTID  \\\n",
+       "0  MULTILINESTRING ((-118.19941 33.92756, -118.19...       492   \n",
+       "1  MULTILINESTRING ((-118.19941 33.92756, -118.19...      7965   \n",
+       "2  MULTILINESTRING ((-118.19941 33.92756, -118.19...      7966   \n",
+       "3  MULTILINESTRING ((-118.19941 33.92756, -118.19...      7967   \n",
+       "4  MULTILINESTRING ((-118.19941 33.92756, -118.19...      7968   \n",
+       "\n",
+       "    agency_primary agency_secondary        hqta_type  \\\n",
+       "0  City of Lynwood                   hq_corridor_bus   \n",
+       "1  City of Lynwood  City of Lynwood   major_stop_bus   \n",
+       "2  City of Lynwood  City of Lynwood   major_stop_bus   \n",
+       "3  City of Lynwood  City of Lynwood   major_stop_bus   \n",
+       "4  City of Lynwood  City of Lynwood   major_stop_bus   \n",
+       "\n",
+       "                                 hqta_details  \\\n",
+       "0  stop_along_hq_bus_corridor_single_operator   \n",
+       "1     intersection_2_bus_routes_same_operator   \n",
+       "2     intersection_2_bus_routes_same_operator   \n",
+       "3     intersection_2_bus_routes_same_operator   \n",
+       "4     intersection_2_bus_routes_same_operator   \n",
+       "\n",
+       "                                  base64_url_primary  \\\n",
+       "0  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...   \n",
+       "1  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...   \n",
+       "2  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...   \n",
+       "3  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...   \n",
+       "4  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...   \n",
+       "\n",
+       "                                base64_url_secondary   org_id_secondary  \n",
+       "0                                                                        \n",
+       "1  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...  rec0FfOvKIMZu1Qjs  \n",
+       "2  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...  rec0FfOvKIMZu1Qjs  \n",
+       "3  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...  rec0FfOvKIMZu1Qjs  \n",
+       "4  aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZW...  rec0FfOvKIMZu1Qjs  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "routes_in_hq_areas.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e975832-96cc-43e7-aec1-3732eb84a4b7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
* Demonstrate how to back out HQTA areas as lines instead of polygons using only open data portal products
* Use clip, dissolve, merge...all should be possible within ArcGIS modeling workflows

Email thread from Justin Heyerdahl:

I think the main hurdle for us being able to use CalTrans data for Site Check is that we need to provide both the raw, unbuffered data for users to explore in the tool interface (existing major stops, HQ stops, and HQ corridor lines) as well as the buffered versions as separate datasets that are used to screen parcels. We include two different buffer ranges (1/2-mile and 1/4-mile) specific to HQ corridors, rather than the single buffer range in your [CA HQ Transit Areas](https://gis.data.ca.gov/datasets/863e61eacbf3463ab239beb3cee4a2c3_0/explore?location=38.761332*2C-119.345050*2C6.69__;JSU!!LWi6xHDyrA!76UqRs2bJGlqWUixDJ85NPj7Djttq4EHb27XAZUYUFNVSK7i-PxJxEVujHcrO-bcjXRw2wkhRlKQXI23GI8PkeBtvZ2hG9jE0A$) dataset. We do this because they filter parcels into different qualification zones depending on the particular CEQA exemption for streamlining of housing development.

I would love to integrate the raw, unbuffered CalTrans datasets as our inputs, and then we already have modeling workflows to buffer and build out the rest as separate layers. However, we can't use the [CA HQ Transit Areas](https://gis.data.ca.gov/datasets/863e61eacbf3463ab239beb3cee4a2c3_0/explore?location=38.761332*2C-119.345050*2C6.69__;JSU!!LWi6xHDyrA!76UqRs2bJGlqWUixDJ85NPj7Djttq4EHb27XAZUYUFNVSK7i-PxJxEVujHcrO-bcjXRw2wkhRlKQXI23GI8PkeBtvZ2hG9jE0A$) alone as we would need the corridor lines for both visualization purposes for our users and to create our secondary buffer range. If that could be produced and provided it would be greatly appreciated. Several Municipal Planning Organizations (MPOs) produce the line features for their jurisdictions, but having broader statewide corridor coverage from a sole source with standardized methodology would be ideal.
