### PR TITLE
Interpolation debug for road segments

### DIFF
--- a/open_data/gcs_to_esri.py
+++ b/open_data/gcs_to_esri.py
@@ -12,6 +12,7 @@ import sys
 
 from loguru import logger
 
+import open_data
 from calitp_data_analysis import utils, geography_utils
 from update_vars import analysis_date
 
@@ -47,9 +48,10 @@ if __name__=="__main__":
                format="{time:YYYY-MM-DD at HH:mm:ss} | {level} | {message}", 
                level="INFO")
     
-    datasets = list(dict(catalog).keys())
+    #datasets = list(dict(catalog).keys())
+    datasets = open_data.RUN_ME 
     
-    for d in datasets:
+    for d in datasets :
         gdf = catalog[d].read().to_crs(geography_utils.WGS84)
         gdf = standardize_column_names(gdf)
 

--- a/open_data/intake_justification.md
+++ b/open_data/intake_justification.md
@@ -8,7 +8,7 @@ Document links, justification, for why datasets need to be made public. Submit t
     * Division / Program: `Rail and Mass Transportation`
     * Update or New: `Update existing service`
     * Enterprise Geodatabase Name: `HQ`
-    * Feature Class Name: `HQ.ca_hq_transit_stops, HQ.ca_hq_transit_areas, HQ.ca_transit_stops, HQ.ca_transit_routes`, `HQ.speeds_by_stop_segments`, `HQ.speeds_by_route_time_of_day`
+    * Feature Class Name: `HQ.ca_hq_transit_stops, HQ.ca_hq_transit_areas, HQ.ca_transit_stops, HQ.ca_transit_routes, HQ.speeds_by_stop_segments, HQ.speeds_by_route_time_of_day`
     
 1. [Open support ticket for GIS](https://forms.office.com/Pages/ResponsePage.aspx?id=ZAobYkAXzEONiEVA00h1VuRQZHWRcbdNm496kj4opnZUNkI2T0hGWElZMUcwTDRUOUNCU0VWMTUxWi4u)
 

--- a/open_data/xml/ca_hq_transit_areas.xml
+++ b/open_data/xml/ca_hq_transit_areas.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-10-13</ns1:Date>
+		<ns1:Date>2023-11-17</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>
@@ -85,7 +85,7 @@
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-10-11</ns1:Date>
+								<ns1:Date>2023-11-15</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">

--- a/open_data/xml/ca_hq_transit_areas_fgdc.xml
+++ b/open_data/xml/ca_hq_transit_areas_fgdc.xml
@@ -21,10 +21,10 @@
 		</status>
 		<spdom>
 			<bounding>
-				<westbc>-124.224990</westbc>
-				<eastbc>-73.976597</eastbc>
-				<northbc>41.886590</northbc>
-				<southbc>25.782065</southbc>
+				<westbc>-124.226978</westbc>
+				<eastbc>-71.041087</eastbc>
+				<northbc>42.367367</northbc>
+				<southbc>26.189064</southbc>
 			</bounding>
 		</spdom>
 		<keywords>
@@ -63,7 +63,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>GT-polygon composed of chains</sdtstype>
-				<ptvctcnt>23040</ptvctcnt>
+				<ptvctcnt>23406</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -146,7 +146,7 @@
 		</detailed>
 	</eainfo>
 	<metainfo>
-		<metd>20230905</metd>
+		<metd>20231013</metd>
 		<metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
 		<metstdv>FGDC-STD-001-1998</metstdv>
 		<mettc>local time</mettc>

--- a/open_data/xml/ca_hq_transit_stops.xml
+++ b/open_data/xml/ca_hq_transit_stops.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-10-13</ns1:Date>
+		<ns1:Date>2023-11-17</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>
@@ -85,7 +85,7 @@
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-10-11</ns1:Date>
+								<ns1:Date>2023-11-15</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">

--- a/open_data/xml/ca_hq_transit_stops_fgdc.xml
+++ b/open_data/xml/ca_hq_transit_stops_fgdc.xml
@@ -21,9 +21,9 @@
 		</status>
 		<spdom>
 			<bounding>
-				<westbc>-124.214491</westbc>
-				<eastbc>-114.588993</eastbc>
-				<northbc>41.769067</northbc>
+				<westbc>-124.216937</westbc>
+				<eastbc>-114.588971</eastbc>
+				<northbc>41.776307</northbc>
 				<southbc>32.542819</southbc>
 			</bounding>
 		</spdom>
@@ -63,7 +63,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>Entity point</sdtstype>
-				<ptvctcnt>66382</ptvctcnt>
+				<ptvctcnt>67038</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -139,7 +139,7 @@
 		</detailed>
 	</eainfo>
 	<metainfo>
-		<metd>20230831</metd>
+		<metd>20231013</metd>
 		<metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
 		<metstdv>FGDC-STD-001-1998</metstdv>
 		<mettc>local time</mettc>

--- a/open_data/xml/ca_transit_routes.xml
+++ b/open_data/xml/ca_transit_routes.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-10-13</ns1:Date>
+		<ns1:Date>2023-11-17</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>
@@ -85,7 +85,7 @@
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-10-11</ns1:Date>
+								<ns1:Date>2023-11-15</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">

--- a/open_data/xml/ca_transit_routes_fgdc.xml
+++ b/open_data/xml/ca_transit_routes_fgdc.xml
@@ -24,7 +24,7 @@
 				<westbc>-124.498056</westbc>
 				<eastbc>-68.805360</eastbc>
 				<northbc>49.273757</northbc>
-				<southbc>24.551930</southbc>
+				<southbc>24.551980</southbc>
 			</bounding>
 		</spdom>
 		<keywords>
@@ -63,7 +63,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>String</sdtstype>
-				<ptvctcnt>7245</ptvctcnt>
+				<ptvctcnt>7406</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -149,7 +149,7 @@
 		</detailed>
 	</eainfo>
 	<metainfo>
-		<metd>20230831</metd>
+		<metd>20231013</metd>
 		<metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
 		<metstdv>FGDC-STD-001-1998</metstdv>
 		<mettc>local time</mettc>

--- a/open_data/xml/ca_transit_stops.xml
+++ b/open_data/xml/ca_transit_stops.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-10-13</ns1:Date>
+		<ns1:Date>2023-11-17</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>
@@ -85,7 +85,7 @@
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-10-11</ns1:Date>
+								<ns1:Date>2023-11-15</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">

--- a/open_data/xml/ca_transit_stops_fgdc.xml
+++ b/open_data/xml/ca_transit_stops_fgdc.xml
@@ -63,7 +63,7 @@
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>Entity point</sdtstype>
-				<ptvctcnt>122468</ptvctcnt>
+				<ptvctcnt>124774</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -137,7 +137,7 @@
 		</detailed>
 	</eainfo>
 	<metainfo>
-		<metd>20230831</metd>
+		<metd>20231013</metd>
 		<metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
 		<metstdv>FGDC-STD-001-1998</metstdv>
 		<mettc>local time</mettc>

--- a/open_data/xml/speeds_by_route_time_of_day.xml
+++ b/open_data/xml/speeds_by_route_time_of_day.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-10-13</ns1:Date>
+		<ns1:Date>2023-11-17</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>
@@ -85,7 +85,7 @@
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-10-11</ns1:Date>
+								<ns1:Date>2023-11-15</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">

--- a/open_data/xml/speeds_by_route_time_of_day_fgdc.xml
+++ b/open_data/xml/speeds_by_route_time_of_day_fgdc.xml
@@ -5,42 +5,65 @@
 			<citeinfo>
 				<title>speeds_by_route_time_of_day</title>
 				<geoform>vector digital data</geoform>
+				<pubinfo>
+					<publish>Caltrans</publish>
+				</pubinfo>
+				<onlink>https://github.com/cal-itp/data-analyses/blob/main/rt_segment_speeds/README.md</onlink>
 			</citeinfo>
 		</citation>
 		<descript>
 			<abstract>Provide average transit speeds, number of trips, and metrics related to scheduled annd real-time service minutes by route-direction and time-of-day.</abstract>
 			<purpose>Average transit speeds by route-direction and time-of-day estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data.</purpose>
 		</descript>
+		<status>
+			<progress>Complete</progress>
+			<update>Monthly</update>
+		</status>
 		<spdom>
 			<bounding>
 				<westbc>-124.226362</westbc>
-				<eastbc>-116.471893</eastbc>
+				<eastbc>-114.562623</eastbc>
 				<northbc>41.957418</northbc>
-				<southbc>32.542093</southbc>
+				<southbc>32.542091</southbc>
 			</bounding>
 		</spdom>
 		<keywords>
 			<theme>
 				<themekt>None</themekt>
-				<themekey>Transportation</themekey>
-				<themekey>Transit</themekey>
-				<themekey>GTFS</themekey>
-				<themekey>GTFS RT</themekey>
-				<themekey>real time</themekey>
-				<themekey>speeds</themekey>
-				<themekey>vehicle positions</themekey>
+				<themekey>transportation</themekey>
+			</theme>
+			<theme>
+				<themekt>ISO 19115 Topic Categories</themekt>
+				<themekey>transportation</themekey>
 			</theme>
 		</keywords>
 		<accconst>None</accconst>
 		<useconst>Public.</useconst>
+		<ptcontac>
+			<cntinfo>
+				<cntorgp>
+					<cntorg>Caltrans</cntorg>
+					<cntper>Tiffany Ku</cntper>
+				</cntorgp>
+				<cntpos>Data &amp; Digital Services / California Integrated Travel Project</cntpos>
+				<cntemail>tiffany.ku@dot.ca.gov</cntemail>
+			</cntinfo>
+		</ptcontac>
 		<native>Esri ArcGIS 12.9.2.32739</native>
 	</idinfo>
+	<dataqual>
+		<lineage>
+			<procstep>
+				<procdesc>This data was estimated by combining GTFS real-time vehicle positions with GTFS scheduled trips and shapes. GTFS real-time (RT) vehicle positions are spatially joined to GTFS scheduled shapes, so only vehicle positions traveling along the route alignment path are kept. A sample of five vehicle positions are selected (min, 25th percentile, 50th percentile, 75th percentile, max). The trip speed is calculated using these five vehicle positions. Each trip is categorized into a time-of-day. The average speed for a route-direction-time_of_day is calculated. Additional metrics are stored, such as the number of trips observed, the average scheduled service minutes, and the average RT observed service minutes. For convenience, we also provide a singular shape (common_shape_id) to associate with a route-direction. This is the shape that had the most number of trips for a given route-direction. Time-of-day is determined by the GTFS scheduled trip start time. The trip start hour (military time) is categorized based on the following: Owl (0-3), Early AM (4-6), AM Peak (7-9), Midday (10-14), PM Peak (15-19), and Evening (20-23). The start and end hours are inclusive (e.g., 4-6 refers to 4am, 5am, and 6am).</procdesc>
+			</procstep>
+		</lineage>
+	</dataqual>
 	<spdoinfo>
 		<direct>Vector</direct>
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>String</sdtstype>
-				<ptvctcnt>10350</ptvctcnt>
+				<ptvctcnt>10595</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -134,7 +157,7 @@
 		</detailed>
 	</eainfo>
 	<metainfo>
-		<metd>20230831</metd>
+		<metd>20231013</metd>
 		<metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
 		<metstdv>FGDC-STD-001-1998</metstdv>
 		<mettc>local time</mettc>

--- a/open_data/xml/speeds_by_stop_segments.xml
+++ b/open_data/xml/speeds_by_stop_segments.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-11-17</ns1:Date>
+		<ns1:Date>2023-11-28</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>

--- a/open_data/xml/speeds_by_stop_segments.xml
+++ b/open_data/xml/speeds_by_stop_segments.xml
@@ -20,7 +20,7 @@
 	</ns0:hierarchyLevelName>
 	<ns0:contact ns1:nilReason="missing"></ns0:contact>
 	<ns0:dateStamp>
-		<ns1:Date>2023-10-13</ns1:Date>
+		<ns1:Date>2023-11-17</ns1:Date>
 	</ns0:dateStamp>
 	<ns0:metadataStandardName>
 		<ns1:CharacterString>ISO 19139 Geographic Information - Metadata - Implementation Specification</ns1:CharacterString>
@@ -85,7 +85,7 @@
 					<ns0:date>
 						<ns0:CI_Date>
 							<ns0:date>
-								<ns1:Date>2023-10-11</ns1:Date>
+								<ns1:Date>2023-11-15</ns1:Date>
 							</ns0:date>
 							<ns0:dateType>
 								<ns0:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" codeSpace="ISOTC211/19115">

--- a/open_data/xml/speeds_by_stop_segments_fgdc.xml
+++ b/open_data/xml/speeds_by_stop_segments_fgdc.xml
@@ -5,16 +5,24 @@
 			<citeinfo>
 				<title>speeds_by_stop_segments</title>
 				<geoform>vector digital data</geoform>
+				<pubinfo>
+					<publish>Caltrans</publish>
+				</pubinfo>
+				<onlink>https://github.com/cal-itp/data-analyses/blob/main/rt_segment_speeds/README.md</onlink>
 			</citeinfo>
 		</citation>
 		<descript>
 			<abstract>All day and peak transit 20th, 50th, and 80th percentile speeds on stop segments estimated on a single day for all CA transit operators that provide GTFS real-time vehicle positions data.</abstract>
 			<purpose>All day and peak transit speeds by segments for all CA operators that provide GTFS real-time vehicle positions data.</purpose>
 		</descript>
+		<status>
+			<progress>Complete</progress>
+			<update>Monthly</update>
+		</status>
 		<spdom>
 			<bounding>
 				<westbc>-124.226362</westbc>
-				<eastbc>-115.974529</eastbc>
+				<eastbc>-114.562623</eastbc>
 				<northbc>41.957893</northbc>
 				<southbc>32.542091</southbc>
 			</bounding>
@@ -22,25 +30,40 @@
 		<keywords>
 			<theme>
 				<themekt>None</themekt>
-				<themekey>Transportation</themekey>
-				<themekey>Transit</themekey>
-				<themekey>GTFS</themekey>
-				<themekey>GTFS RT</themekey>
-				<themekey>real time</themekey>
-				<themekey>speeds</themekey>
-				<themekey>vehicle positions</themekey>
+				<themekey>transportation</themekey>
+			</theme>
+			<theme>
+				<themekt>ISO 19115 Topic Categories</themekt>
+				<themekey>transportation</themekey>
 			</theme>
 		</keywords>
 		<accconst>None</accconst>
 		<useconst>Public.</useconst>
+		<ptcontac>
+			<cntinfo>
+				<cntorgp>
+					<cntorg>Caltrans</cntorg>
+					<cntper>Tiffany Ku / Eric Dasmalchi</cntper>
+				</cntorgp>
+				<cntpos>Data &amp; Digital Services / California Integrated Travel Project</cntpos>
+				<cntemail>tiffany.ku@dot.ca.gov / eric.dasmalchi@dot.ca.gov</cntemail>
+			</cntinfo>
+		</ptcontac>
 		<native>Esri ArcGIS 12.9.2.32739</native>
 	</idinfo>
+	<dataqual>
+		<lineage>
+			<procstep>
+				<procdesc>This data was estimated by combining GTFS real-time vehicle positions to GTFS scheduled trips, shapes, stops, and stop times tables. GTFS shapes provides the route alignment path. Multiple trips may share the same shape, with a route typically associated with multiple shapes. Shapes are cut into segments at stop positions (stop_id-stop_sequence combination). A `stop segment` refers to the portion of shapes between the prior stop and the current stop. Vehicle positions are spatially joined to 35 meter buffered segments. Within each segment-trip, the first and last vehicle position observed are used to calculate the speed. Since multiple trips may occur over a segment each day, the multiple trip speeds provide a distribution. From this distribution, the 20th percentile, 50th percentile (median), and 80th percentile speeds are calculated. For all day speed metrics, all trips are used. For peak speed metrics, only trips with start times between 7 - 9:59 AM and 4 - 7:59 PM are used to find the 20th, 50th, and 80th percentile metrics. Data processing notes: (a) GTFS RT trips whose vehicle position timestamps span 10 minutes or less are dropped. Incomplete data would lead to unreliable estimates of speed at the granularity we need. (b) Segment-trip speeds of over 70 mph are excluded. These are erroneously calculated as transit does not typically reach those speeds. (c) Other missing or erroneous calculations, either arising from only one vehicle position found in a segment (change in time or change in distance cannot be calculated).</procdesc>
+			</procstep>
+		</lineage>
+	</dataqual>
 	<spdoinfo>
 		<direct>Vector</direct>
 		<ptvctinf>
 			<sdtsterm>
 				<sdtstype>String</sdtstype>
-				<ptvctcnt>217821</ptvctcnt>
+				<ptvctcnt>275372</ptvctcnt>
 			</sdtsterm>
 		</ptvctinf>
 	</spdoinfo>
@@ -127,7 +150,7 @@
 		</detailed>
 	</eainfo>
 	<metainfo>
-		<metd>20230831</metd>
+		<metd>20231013</metd>
 		<metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
 		<metstdv>FGDC-STD-001-1998</metstdv>
 		<mettc>local time</mettc>

--- a/rt_segment_speeds/README.md
+++ b/rt_segment_speeds/README.md
@@ -10,6 +10,7 @@ Work related to using `dask` to produce speeds by segments from GTFS RT vehicle 
     * scripts run consecutively within each stage `A1`, `A2`, ...
 * exploratory notebooks: prefix with `00_`, `01_`, `02_`, etc.
 * [Exploratory epic](https://github.com/cal-itp/data-analyses/issues/592)
+* refer to [Makefile](./scripts/Makefile) and [config](./scripts/config.yml) for pipeline
 
 | warehouse         | gcs               | github             |
 |-------------------|-------------------|--------------------|
@@ -19,8 +20,3 @@ Work related to using `dask` to produce speeds by segments from GTFS RT vehicle 
 | rt_predictions    | rt_predictions    | rt_predictions     | 
 
 
-## Scripts
-1. cut segments (route segments or stop segments)
-1. spatial join vehicle positions to the segments  (`A3`)
-1. pare down vehicle positions to just enter/exit within a segment + placeholder for dropping unusable trips. should exclude trips with too little info or `trip_id is None` at the start, then pare down (`A4`)
-1. do linear referencing within segments to get `distance_elapsed` and `time_elapsed`, and calculate speeds. save as partitioned parquets (`A5`)

--- a/rt_segment_speeds/logs/avg_speeds.log
+++ b/rt_segment_speeds/logs/avg_speeds.log
@@ -44,3 +44,9 @@
 2023-11-16 10:32:18.445 | INFO     | __main__:<module>:249 - Analysis date: 2023-11-15
 2023-11-16 10:34:24.761 | INFO     | __main__:speeds_with_segment_geom:130 - segment averages execution time: 0:02:06.278055
 2023-11-16 10:34:35.014 | INFO     | __main__:avg_trip_speeds_with_time_of_day:231 - trip summary execution time: 0:00:10.128945
+2023-11-28 09:11:27.747 | INFO     | __main__:<module>:249 - Analysis date: 2023-10-11
+2023-11-28 09:13:34.200 | INFO     | __main__:speeds_with_segment_geom:130 - segment averages execution time: 0:02:06.452114
+2023-11-28 09:13:43.845 | INFO     | __main__:avg_trip_speeds_with_time_of_day:231 - trip summary execution time: 0:00:09.522839
+2023-11-28 09:13:43.860 | INFO     | __main__:<module>:249 - Analysis date: 2023-11-15
+2023-11-28 09:15:49.936 | INFO     | __main__:speeds_with_segment_geom:130 - segment averages execution time: 0:02:06.074704
+2023-11-28 09:15:59.701 | INFO     | __main__:avg_trip_speeds_with_time_of_day:231 - trip summary execution time: 0:00:09.603107

--- a/rt_segment_speeds/logs/cut_road_segments.log
+++ b/rt_segment_speeds/logs/cut_road_segments.log
@@ -20,3 +20,7 @@
 2023-11-07 15:11:26.416 | INFO     | __main__:monthly_local_linearids:90 - add local linearids for this month: 0:01:16.536574
 2023-11-07 15:12:05.511 | INFO     | __main__:concatenate_road_types:143 - concatenate road segments: 0:00:38.986941
 2023-11-07 15:12:05.569 | INFO     | __main__:<module>:166 - execution time: 0:01:55.689007
+2023-11-22 10:26:55.107 | INFO     | __main__:<module>:170 - Analysis date: 2023-10-11
+2023-11-22 10:28:51.151 | INFO     | __main__:monthly_local_linearids:90 - add local linearids for this month: 0:01:56.043036
+2023-11-22 10:29:30.006 | INFO     | __main__:concatenate_road_types:155 - concatenate road segments: 0:00:38.540339
+2023-11-22 10:29:30.375 | INFO     | __main__:<module>:178 - execution time: 0:02:35.266334

--- a/rt_segment_speeds/logs/cut_stop_segments.log
+++ b/rt_segment_speeds/logs/cut_stop_segments.log
@@ -66,3 +66,7 @@
 2023-11-16 09:48:41.884 | INFO     | __main__:<module>:312 - Cut special stop segments: 0:10:51.617766
 2023-11-16 09:48:43.209 | INFO     | __main__:<module>:333 - export results: 0:00:01.325571
 2023-11-16 09:48:43.211 | INFO     | __main__:<module>:334 - execution time: 0:10:52.943337
+2023-11-28 09:04:31.605 | INFO     | __main__:<module>:206 - Analysis date: 2023-11-15
+2023-11-28 09:10:12.038 | INFO     | __main__:<module>:231 - Cut normal stop segments: 0:05:40.432011
+2023-11-28 09:10:14.652 | INFO     | __main__:<module>:252 - export results: 0:00:02.614281
+2023-11-28 09:10:14.653 | INFO     | __main__:<module>:253 - execution time: 0:05:43.046292

--- a/rt_segment_speeds/logs/interpolate_stop_arrival.log
+++ b/rt_segment_speeds/logs/interpolate_stop_arrival.log
@@ -34,3 +34,10 @@
 2023-11-16 10:27:32.352 | INFO     | __main__:main:124 - set up df with nearest / subseq vp info: 0:01:39.235915
 2023-11-16 10:28:37.624 | INFO     | __main__:main:129 - interpolate stop arrival: 0:01:05.272069
 2023-11-16 10:28:47.210 | INFO     | __main__:main:135 - execution time: 0:02:54.093853
+2023-11-29 09:02:06.675 | INFO     | __main__:main:174 - road_segments: set up df with nearest / subseq vp info: 0:01:16.935557
+2023-11-29 09:02:18.901 | INFO     | __main__:main:180 - interpolate stop arrival: 0:00:12.225484
+2023-11-29 09:02:20.010 | INFO     | __main__:main:186 - execution time for road_segments: 0:01:30.269674
+2023-11-29 09:05:02.395 | INFO     | __main__:<module>:215 - Analysis date: 2023-10-11
+2023-11-29 09:06:55.591 | INFO     | __main__:main:184 - stop_segments: set up df with nearest / subseq vp info: 0:01:53.194948
+2023-11-29 09:07:52.341 | INFO     | __main__:main:190 - interpolate stop arrival: 0:00:56.750164
+2023-11-29 09:08:03.943 | INFO     | __main__:main:196 - execution time for stop_segments: 0:03:01.547292

--- a/rt_segment_speeds/scripts/Makefile
+++ b/rt_segment_speeds/scripts/Makefile
@@ -22,7 +22,7 @@ speeds_pipeline:
 	python handle_common_errors.py
 	python avg_speeds_by_segment.py  
 	python export.py
-    
+
     
 download_roads:
 	#pip install esridump

--- a/rt_segment_speeds/scripts/config.yml
+++ b/rt_segment_speeds/scripts/config.yml
@@ -14,6 +14,8 @@ stop_segments:
     max_speed: 80
 road_segments:
     stage1: "vp_usable"
+    stage2: "nearest_vp_roads"
+    stage3: "stop_arrivals_roads"
     stage4: "speeds_road_segments"
     stage5: "avg_speeds_road_segments"
     segments_file: "road_segments"

--- a/rt_segment_speeds/scripts/cut_normal_stop_segments.py
+++ b/rt_segment_speeds/scripts/cut_normal_stop_segments.py
@@ -120,7 +120,7 @@ def normal_project(
     # can get as close as possible to the stop
     subset_shape_dist_with_endpoints = np.concatenate([
         [origin_stop],
-        idx_shape_dist,
+        shape_projected_dist[idx_shape_dist],
         [destination_stop]
     ])
 
@@ -153,7 +153,11 @@ def find_normal_cases_and_setup_df(
             "prior_stop_sequence",
             "stop_primary_direction"
         ]
-    )
+    ).sort_values(
+        "st_trip_instance_key"
+    ).drop_duplicates(
+        subset=["shape_array_key", "stop_sequence"]
+    ).reset_index(drop=True)
     
     gdf_with_prior = get_prior_stop_info(gdf, "shape_meters")
     
@@ -226,8 +230,8 @@ if __name__ == "__main__":
     time1 = datetime.datetime.now()
     logger.info(f"Cut normal stop segments: {time1-start}")
     
-    keep_cols = [
-        "schedule_gtfs_dataset_key", 
+    keep_cols = [ 
+        "schedule_gtfs_dataset_key",
         "shape_array_key", "stop_segment_geometry", 
         "stop_id", "stop_sequence", "loop_or_inlining",
         "stop_primary_direction"

--- a/rt_segment_speeds/scripts/cut_special_stop_segments.py
+++ b/rt_segment_speeds/scripts/cut_special_stop_segments.py
@@ -241,7 +241,11 @@ def find_special_cases_and_setup_df(
             "prior_stop_sequence",
             "stop_primary_direction"
         ]
-    )
+    ).sort_values(
+        "st_trip_instance_key"
+    ).drop_duplicates(
+        subset=["shape_array_key", "stop_sequence"]
+    ).reset_index(drop=True)
     
     # Merge in prior stop sequence's stop geom
     gdf_with_prior = cut_normal_stop_segments.get_prior_stop_info(
@@ -311,8 +315,8 @@ if __name__ == "__main__":
     time1 = datetime.datetime.now()
     logger.info(f"Cut special stop segments: {time1-start}")
     
-    keep_cols = [
-        "schedule_gtfs_dataset_key", 
+    keep_cols = [ 
+        "schedule_gtfs_dataset_key",
         "shape_array_key", "stop_segment_geometry", 
         "stop_id", "stop_sequence", "loop_or_inlining",
         "stop_primary_direction"

--- a/rt_segment_speeds/scripts/interpolate-road-arrivals.ipynb
+++ b/rt_segment_speeds/scripts/interpolate-road-arrivals.ipynb
@@ -1,0 +1,390 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "587aceb5-de68-4b6f-9810-1adce8d7a60b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install shapely==2.0.2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5734f6b0-2fb6-40c3-99b5-14d5cb459511",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import shapely\n",
+    "\n",
+    "from segment_speed_utils import helpers, wrangle_shapes\n",
+    "from segment_speed_utils.project_vars import SEGMENT_GCS, analysis_date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "02429796-db0a-4a81-8807-a72d6535db0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vp_usable = dd.read_parquet(\n",
+    "    f\"{SEGMENT_GCS}vp_usable_{analysis_date}/\",\n",
+    "    columns = [\"vp_idx\",  \"location_timestamp_local\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ee326ded-177d-468c-9d45-94a48c3a988e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# shape_meters is here\n",
+    "vp_projected = pd.read_parquet(\n",
+    "    f\"{SEGMENT_GCS}projection/vp_projected_roads_{analysis_date}.parquet\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d88e260b-8829-4f16-a967-851b7ee7b334",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Index(['vp_idx', 'location_timestamp_local'], dtype='object'),\n",
+       " Index(['vp_idx', 'trip_instance_key', 'linearid', 'mtfcc', 'shape_meters'], dtype='object'))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vp_usable.columns, vp_projected.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fd51e987-0a02-4c70-b645-a79548f341d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vp_info = dd.merge(\n",
+    "    vp_usable,\n",
+    "    vp_projected,\n",
+    "    on = \"vp_idx\",\n",
+    "    how = \"inner\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1395a1db-8a62-430c-b13e-a07a106a6321",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vp_info = vp_info.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5307079a-ca4c-4291-9322-285032c24ea4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nearest_df = pd.read_parquet(\n",
+    "    f\"{SEGMENT_GCS}nearest_vp_roads_{analysis_date}.parquet\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "72224d18-35e0-4403-8b1e-842c808859d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vp_df = vp_info.compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "268bf12b-2d34-4833-a7ac-5f9ac1631beb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>vp_idx</th>\n",
+       "      <th>location_timestamp_local</th>\n",
+       "      <th>trip_instance_key</th>\n",
+       "      <th>linearid</th>\n",
+       "      <th>mtfcc</th>\n",
+       "      <th>shape_meters</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>68016</td>\n",
+       "      <td>2023-10-11 10:09:15</td>\n",
+       "      <td>f26f828162f83b19644fdebcabb2439c</td>\n",
+       "      <td>11010927740446</td>\n",
+       "      <td>S1200</td>\n",
+       "      <td>3109.907089</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>68017</td>\n",
+       "      <td>2023-10-11 10:09:30</td>\n",
+       "      <td>f26f828162f83b19644fdebcabb2439c</td>\n",
+       "      <td>11010927740446</td>\n",
+       "      <td>S1200</td>\n",
+       "      <td>3127.906806</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   vp_idx location_timestamp_local                 trip_instance_key  \\\n",
+       "0   68016      2023-10-11 10:09:15  f26f828162f83b19644fdebcabb2439c   \n",
+       "1   68017      2023-10-11 10:09:30  f26f828162f83b19644fdebcabb2439c   \n",
+       "\n",
+       "         linearid  mtfcc  shape_meters  \n",
+       "0  11010927740446  S1200   3109.907089  \n",
+       "1  11010927740446  S1200   3127.906806  "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vp_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "5ed1559f-7b6b-4247-8769-04383cbb01ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['linearid', 'mtfcc', 'segment_sequence', 'primary_direction',\n",
+       "       'road_meters', 'trip_instance_key', 'nearest_vp_idx', 'subseq_vp_idx'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nearest_df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "98310204-b9f0-4ee0-a51f-00599dd66746",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "road_id_cols = [\"linearid\", \"mtfcc\"]\n",
+    "\n",
+    "vp_with_nearest_info = pd.merge(\n",
+    "    nearest_df,\n",
+    "    vp_df.rename(columns = {\n",
+    "        \"vp_idx\": \"nearest_vp_idx\",\n",
+    "        \"location_timestamp_local\": \"nearest_location_timestamp_local\",\n",
+    "        \"shape_meters\": \"nearest_shape_meters\"\n",
+    "    }),\n",
+    "    on = road_id_cols + [\"trip_instance_key\", \"nearest_vp_idx\"],\n",
+    "    how = \"inner\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "6b57ae01-32d1-4bf4-93f7-ea0bbeb28d29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.merge(\n",
+    "    vp_with_nearest_info,\n",
+    "    vp_df.rename(columns = {\n",
+    "        \"vp_idx\": \"subseq_vp_idx\",\n",
+    "        \"location_timestamp_local\": \"subseq_location_timestamp_local\",\n",
+    "        \"shape_meters\": \"subseq_shape_meters\"\n",
+    "    }),    \n",
+    "    on = road_id_cols + [\"trip_instance_key\", \"subseq_vp_idx\"],\n",
+    "    how = \"inner\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "44977c15-1198-4c6a-ae5c-31e200d5181e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_stop_arrivals(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Apply np.interp to df.\n",
+    "    df must be set up so that a given stop is populated with its\n",
+    "    own stop_meters, as well as columns for nearest and subseq \n",
+    "    shape_meters / location_timestamp_local_sec.\n",
+    "    \"\"\"\n",
+    "    x_col = \"shape_meters\"\n",
+    "    y_col = \"location_timestamp_local\"\n",
+    "    \n",
+    "    stop_arrival_series = []\n",
+    "    for row in df.itertuples():\n",
+    "\n",
+    "        xp = np.asarray([\n",
+    "            getattr(row, f\"nearest_{x_col}\"), \n",
+    "            getattr(row, f\"subseq_{x_col}\")\n",
+    "        ])\n",
+    "\n",
+    "        yp = np.asarray([\n",
+    "            getattr(row, f\"nearest_{y_col}\"), \n",
+    "            getattr(row, f\"subseq_{y_col}\")\n",
+    "        ]).astype(\"datetime64[s]\").astype(\"float64\")\n",
+    "\n",
+    "        stop_position = getattr(row, \"road_meters\")\n",
+    "        interpolated_arrival = np.interp(stop_position, xp, yp)\n",
+    "        stop_arrival_series.append(interpolated_arrival)\n",
+    "        \n",
+    "    df = df.assign(\n",
+    "        arrival_time = stop_arrival_series,\n",
+    "    ).astype(\n",
+    "        {\"arrival_time\": \"datetime64[s]\"}\n",
+    "    ).sort_values(\n",
+    "        [\"trip_instance_key\", \n",
+    "        \"linearid\", \"mtfcc\", \"segment_sequence\"]\n",
+    "    ).reset_index(drop=True)\n",
+    "    \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "3b7304ba-6b69-4846-b41a-bc63330ef172",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stop_arrivals = get_stop_arrivals(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "1f3efa8d-3169-46e9-975a-141543b8a673",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "STOP_ARRIVALS_FILE = f\"stop_arrivals_roads_{analysis_date}\"\n",
+    "stop_arrivals.to_parquet(\n",
+    "        f\"{SEGMENT_GCS}{STOP_ARRIVALS_FILE}.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00d84c3d-262d-43e5-9fdd-a6bc0252d9ed",
+   "metadata": {},
+   "source": [
+    "References:\n",
+    "* https://gis.stackexchange.com/questions/416284/splitting-multiline-or-linestring-into-equal-segments-of-particular-length-using\n",
+    "* https://gis.stackexchange.com/questions/250784/splitting-line-shapefile-into-segments-of-equal-length-using-python/414888#414888\n",
+    "* https://gis.stackexchange.com/questions/464336/change-geopandas-geometry-from-geometrycollection-to-multipolygon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7f066be-b6cc-459c-969c-6760610d9857",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43320d0a-c515-465b-98ff-ed99e893ebad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33b9cb86-faa7-4b9c-8b16-20e8caa30eb7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rt_segment_speeds/scripts/interpolate_stop_arrival.py
+++ b/rt_segment_speeds/scripts/interpolate_stop_arrival.py
@@ -7,7 +7,9 @@ import numpy as np
 import pandas as pd
 import sys
 
+from dask import delayed, compute
 from loguru import logger
+from typing import Literal
 
 from segment_speed_utils import helpers
 from segment_speed_utils.project_vars import (SEGMENT_GCS, 
@@ -15,42 +17,63 @@ from segment_speed_utils.project_vars import (SEGMENT_GCS,
 
 
 def attach_vp_shape_meters_with_timestamp(
-    analysis_date: str, **kwargs
+    analysis_date: str, 
+    segment_type: Literal["stop_segments", "road_segments"],
 ) -> pd.DataFrame:
     """
+    Merge vp_usable (which has timestamp) with the projected vp
+    (shape_meters).
     """
-    # shape_meters is here
+    if segment_type == "stop_segments":
+        VP_PROJ_FILE = f"vp_projected_{analysis_date}"
+    
+    elif segment_type == "road_segments":
+        VP_PROJ_FILE = f"vp_projected_roads_{analysis_date}"
+    
     vp_projected = pd.read_parquet(
-        f"{SEGMENT_GCS}projection/vp_projected_{analysis_date}.parquet",
-        **kwargs
-    )
+        f"{SEGMENT_GCS}projection/{VP_PROJ_FILE}.parquet"
+    )    
     
     # location_timestamp_local is here, and needs to be converted to seconds
-    vp_usable = pd.read_parquet(
+    vp_usable = delayed(pd.read_parquet)(
         f"{SEGMENT_GCS}vp_usable_{analysis_date}/",
         columns = ["vp_idx",  "location_timestamp_local"],
-        **kwargs,
     )
 
-    vp_info = pd.merge(
-        vp_projected,
+    vp_info = delayed(pd.merge)(
         vp_usable,
+        vp_projected,
         on = "vp_idx",
         how = "inner"
     )
     
+    vp_info = compute(vp_info)[0]
+    
     return vp_info
 
 
-def get_stop_arrivals(df: pd.DataFrame) -> pd.DataFrame:
+def get_stop_arrivals(
+    df: pd.DataFrame,
+    segment_type: Literal["stop_segments", "road_segments"]
+) -> pd.DataFrame:
     """
     Apply np.interp to df.
     df must be set up so that a given stop is populated with its
     own stop_meters, as well as columns for nearest and subseq 
-    shape_meters / location_timestamp_local_sec.
+    shape_meters / location_timestamp_local.
     """
     x_col = "shape_meters"
     y_col = "location_timestamp_local"
+    
+    if segment_type == "stop_segments":
+        stop_meters_col = "stop_meters"
+        sort_cols = ["trip_instance_key", 
+                     "shape_array_key", "stop_sequence"]
+    
+    elif segment_type == "road_segments":
+        stop_meters_col = "road_meters"
+        sort_cols = ["trip_instance_key", 
+                     "linearid", "mtfcc", "segment_sequence"]
     
     stop_arrival_series = []
     for row in df.itertuples():
@@ -65,7 +88,7 @@ def get_stop_arrivals(df: pd.DataFrame) -> pd.DataFrame:
             getattr(row, f"subseq_{y_col}")
         ]).astype("datetime64[s]").astype("float64")
 
-        stop_position = getattr(row, "stop_meters")
+        stop_position = getattr(row, stop_meters_col)
         interpolated_arrival = np.interp(stop_position, xp, yp)
         stop_arrival_series.append(interpolated_arrival)
         
@@ -74,16 +97,70 @@ def get_stop_arrivals(df: pd.DataFrame) -> pd.DataFrame:
     ).astype(
         {"arrival_time": "datetime64[s]"}
     ).sort_values(
-        ["trip_instance_key", 
-        "shape_array_key", "stop_sequence"]
+        sort_cols
     ).reset_index(drop=True)
     
     return df
 
 
+def rename_vp_columns(
+    vp: pd.DataFrame, 
+    prefix: str, 
+    col_list = ["vp_idx", "location_timestamp_local", "shape_meters"]
+) -> pd.DataFrame:
+    """
+    Rename vp columns on-the-fly with prefixes like nearest_ or
+    subseq_.
+    On-the-fly, since we don't want to overwrite the columns,
+    we just want merge to work.
+    """
+    new_col_list = [f"{prefix}{c}" for c in col_list]
+    
+    return vp.rename(columns = {k: v for k, v in zip(col_list, new_col_list)})
+
+
+def add_nearest_subseq_info(
+    nearest_vp_result: pd.DataFrame, 
+    vp_info: pd.DataFrame,
+    segment_type: Literal["stop_segments", "road_segments"]
+) -> pd.DataFrame:
+    """
+    vp might be projected against shape or road, so how
+    we merge in the nearest_ and subseq_ will be different.
+    
+    For road segments, we need to make sure we merge with the
+    road-trip columns too.
+    """
+    if segment_type == "stop_segments":
+        nearest_merge_cols = "nearest_vp_idx"
+        subseq_merge_cols = "subseq_vp_idx"
+        
+    elif segment_type == "road_segments":
+        road_cols = ["linearid", "mtfcc", "trip_instance_key"]
+        nearest_merge_cols = road_cols + ["nearest_vp_idx"]
+        subseq_merge_cols = road_cols + ["subseq_vp_idx"]
+    
+    vp_with_nearest_info = pd.merge(
+        nearest_vp_result,
+        rename_vp_columns(vp_info, "nearest_"),
+        on = nearest_merge_cols,
+        how = "inner"
+    )
+
+    df = pd.merge(
+        vp_with_nearest_info,
+        rename_vp_columns(vp_info, "subseq_"),
+        on = subseq_merge_cols,
+        how = "inner"
+    )
+        
+    return df
+
+
 def main(
     analysis_date: str, 
-    dict_inputs: dict
+    dict_inputs: dict,
+    segment_type: Literal["stop_segments", "road_segments"]
 ):
     NEAREST_VP = f"{dict_inputs['stage2']}_{analysis_date}"
     STOP_ARRIVALS_FILE = f"{dict_inputs['stage3']}_{analysis_date}"
@@ -96,34 +173,18 @@ def main(
 
     # If we filter down pd.read_parquet, we can use np arrays
     # If we filter down dd.read_parquet, we have to use lists
-    subset_vp = np.union1d(
-        vp_pared.nearest_vp_idx.unique(), 
-        vp_pared.subseq_vp_idx.unique()
-    )
-    
     vp_info = attach_vp_shape_meters_with_timestamp(
-        analysis_date, 
-        filters = [[("vp_idx", "in", subset_vp)]]
-    )
-    
-    vp_with_nearest_info = pd.merge(
-        vp_pared,
-        vp_info.add_prefix("nearest_"),
-        on = "nearest_vp_idx",
-        how = "inner"
-    )
-    
-    df = pd.merge(
-        vp_with_nearest_info,
-        vp_info.add_prefix("subseq_"),
-        on = "subseq_vp_idx",
-        how = "inner"
-    )
+        analysis_date,
+        segment_type,
+    )    
+  
+    df = add_nearest_subseq_info(vp_pared, vp_info, segment_type)
     
     time1 = datetime.datetime.now()
-    logger.info(f"set up df with nearest / subseq vp info: {time1 - start}")
+    logger.info(f"{segment_type}: set up df with nearest / subseq vp info: "
+                f"{time1 - start}")
     
-    stop_arrivals_df = get_stop_arrivals(df)
+    stop_arrivals_df = get_stop_arrivals(df, segment_type)
     
     time2 = datetime.datetime.now()
     logger.info(f"interpolate stop arrival: {time2 - time1}")    
@@ -132,7 +193,7 @@ def main(
         f"{SEGMENT_GCS}{STOP_ARRIVALS_FILE}.parquet")
     
     end = datetime.datetime.now()
-    logger.info(f"execution time: {end - start}")    
+    logger.info(f"execution time for {segment_type}: {end - start}")    
 
     return
 
@@ -148,7 +209,12 @@ if __name__ == "__main__":
                level="INFO")
     
     STOP_SEG_DICT = helpers.get_parameters(CONFIG_PATH, "stop_segments")
+    ROAD_SEG_DICT = helpers.get_parameters(CONFIG_PATH, "road_segments")
     
     for analysis_date in analysis_date_list:
         logger.info(f"Analysis date: {analysis_date}")
-        main(analysis_date, STOP_SEG_DICT)
+        
+        main(analysis_date, STOP_SEG_DICT, "stop_segments")
+        main(analysis_date, ROAD_SEG_DICT, "road_segments")
+
+        

--- a/rt_segment_speeds/scripts/nearest_vp_to_road.py
+++ b/rt_segment_speeds/scripts/nearest_vp_to_road.py
@@ -11,153 +11,185 @@ from segment_speed_utils.project_vars import (SEGMENT_GCS,
                                               CONFIG_PATH, PROJECT_CRS)
 
 
-road_id_cols = ["linearid", "mtfcc"]
-segment_identifier_cols = road_id_cols + ["segment_sequence"]
+def filter_long_sjoin_results(
+    sjoin_long: dd.DataFrame,
+    sjoin_wide: pd.DataFrame,
+) -> dd.DataFrame:
+    """
+    Long results contain all sjoins.
+    Wide is filtered down to road linearids that have at least
+    2 vp_idx for that trip_instance_key on the road.
+    """
+    keep_cols = sjoin_long.columns.tolist()
+    
+    df = dd.merge(
+        sjoin_long,
+        sjoin_wide,
+        on = ["trip_instance_key", "linearid", "mtfcc"],
+        how = "inner"
+    )[keep_cols].drop_duplicates().reset_index(drop=True)
+    
+    return df
 
 
 def merge_vp_to_crosswalk(
     analysis_date: str, 
-    filters: tuple = None
-):
-    # vp to road segment crosswalk
-    df = pd.read_parquet(
+) -> dd.DataFrame:
+    """
+    """
+    sjoin_long = dd.read_parquet(
+        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}",
+    )
+
+    sjoin_wide = pd.read_parquet(
         f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_wide_{analysis_date}.parquet",
-        filters = filters
     )
     
-    # only keep the road segments that have at least 2 vp
-    df = df.assign(
-        n_vp = df.apply(lambda x: len(x.vp_idx_arr), axis=1)
-    ).query('n_vp > 1').drop(columns = "n_vp").reset_index(drop=True)
-    
-    df_long = df.explode(
-        "vp_idx_arr", 
-        ignore_index=True
-    ).rename(
-        columns = {"vp_idx_arr": "vp_idx"}
-    ).astype({"vp_idx": "int64"})
-        
-    # Turn series of arrays into 1d array
-    #subset_vp = np.concatenate(np.asarray(df.vp_idx_arr))
-    subset_vp = df_long.vp_idx.tolist()
+    # these are the vps joined to roads that we will narrow down
+    # for interpolation
+    sjoin_vp_roads = filter_long_sjoin_results(sjoin_long, sjoin_wide)
     
     # Pull the vp info for ones that join to road segments
     vp_usable = dd.read_parquet(
         f"{SEGMENT_GCS}vp_usable_{analysis_date}",
-        filters = [[("vp_idx", "in", subset_vp)]],
-        columns = ["vp_idx", "x", "y"],
+        columns = ["trip_instance_key", "vp_idx", "x", "y"],
     )
     
     vp_with_roads = dd.merge(
         vp_usable,
-        df_long,
-        on = "vp_idx",
+        sjoin_vp_roads,
+        on = ["trip_instance_key", "vp_idx"],
         how = "inner"
     )
     
     return vp_with_roads
 
 
-def expand_relevant_road_segments(
-    analysis_date: str,
-    segment_identifier_cols: list,
-    filters = None
-):
-    road_id_cols = [i for i in segment_identifier_cols 
-                    if i != "segment_sequence"]
+def expand_road_segments(
+    roads: pd.DataFrame, 
+    cols_to_unpack: list
+) -> pd.DataFrame:
+    """
+    Convert roads from wide to long.
+    This set up makes roads segment endpoints look like bus stops.
+    Once we use roads full line geometry to project, we can 
+    drop it and get it in a long format.
+    """
+    roads_long = (roads.drop(columns = "geometry")
+                  .explode(cols_to_unpack)
+                  .reset_index(drop=True)
+                 )
     
-    sjoin_results = pd.read_parquet(
-        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}_seg",
-        columns = road_id_cols
-    ).drop_duplicates()
+    return roads_long
+
+
+def make_wide(vp_with_projected: pd.DataFrame):
     
-    full_road_info = gpd.read_parquet(
-        f"{SEGMENT_GCS}segments_staging/"
-        f"roads_with_cutpoints_long_{analysis_date}.parquet",
-        filters = filters
+    vp_projected_wide = (vp_with_projected
+                     .groupby(["trip_instance_key"] + road_id_cols)
+                     .agg({
+                         "vp_idx": lambda x: list(x),
+                         "shape_meters": lambda x: list(x)})
+                     .reset_index()
+                     .rename(columns = {
+                         "vp_idx": "vp_idx_arr",
+                         "shape_meters": "shape_meters_arr"
+                     })
+                    )
+    
+    #https://stackoverflow.com/questions/42099024/pandas-pivot-table-rename-columns
+    narrowed_down_roads = (vp_with_projected
+                       .pivot_table(index = ["trip_instance_key"] + road_id_cols,
+                                    aggfunc = {"shape_meters": ["min", "max"]})
+                       .pipe(lambda x: 
+                             x.set_axis(map('_'.join, x), axis=1) 
+                             # if all column names are strings
+                             # ('_'.join(map(str, c)) for c in x)
+                             # if some column names are not strings
+                            )     
+                       .reset_index()
+                    )
+    
+    vp_projected_wide2 = pd.merge(
+        vp_projected_wide,
+        narrowed_down_roads,
+        on = ["trip_instance_key"] + road_id_cols,
+        how = "inner"
     )
     
-    road_segments = gpd.read_parquet(
-        f"{SEGMENT_GCS}road_segments_{analysis_date}",
-        filters = [[("mtfcc", "in", ["S1100", "S1200"])]],
-        columns = segment_identifier_cols + ["destination"],
-    ).merge(
-        full_road_info,
-        on = segment_identifier_cols,
-        how = "inner"
-    ).set_geometry("geometry").merge(
-        sjoin_results,
-        on = road_id_cols,
-        how = "inner"
-    )
-    
-    return road_segments
+    return vp_projected_wide2
 
 
 if __name__ == "__main__":
+    
     from segment_speed_utils.project_vars import analysis_date
     
     start = datetime.datetime.now()
     
-    vp = merge_vp_to_crosswalk(
-        analysis_date,
-    )
+    road_id_cols = ["linearid", "mtfcc"]
+    segment_identifier_cols = road_id_cols + ["segment_sequence"]
     
+    vp = merge_vp_to_crosswalk(analysis_date)
     vp = vp.repartition(npartitions=150)
     
     subset_roads = vp.linearid.unique().compute().tolist()
     
-    road_segments = expand_relevant_road_segments(
-        analysis_date,
-        segment_identifier_cols = segment_identifier_cols,
-        filters = [[("linearid", "in", subset_roads)]],
+    roads = gpd.read_parquet(
+        f"{SEGMENT_GCS}segments_staging/"
+        f"roads_with_cutpoints_wide_{analysis_date}.parquet",
+        filters = [[("linearid", "in", subset_roads)]]
     )
     
     road_dtypes = vp[road_id_cols].dtypes.to_dict()
 
     vp_projected = vp.map_partitions(
         wrangle_shapes.project_vp_onto_segment_geometry,
-        road_segments,
+        roads,
         grouping_cols = road_id_cols,
         meta = {
-            "vp_idx": "int64",
+            "vp_idx": "int",
             **road_dtypes,
-            "shape_meters": "float"},
+            "shape_meters": "float",
+        },
         align_dataframes = False
     ).persist()
     
-    # Merge vp with road segment info 
-    # with projected shape meters against the full road 
-    df_with_projection = dd.merge(
-        vp,
-        vp_projected,
-        on = ["vp_idx"] + road_id_cols,
-        how = "inner"
-    ).drop(columns = ["x", "y"]).compute()
     
-    df_with_projection.to_parquet(
+    vp2 = vp[["vp_idx", "trip_instance_key"]]
+
+    vp_with_projected = dd.merge(
+        vp2,
+        vp_projected,
+        on = "vp_idx",
+        how = "inner"
+    ).compute()
+    
+    vp_with_projected.to_parquet(
         f"{SEGMENT_GCS}projection/vp_projected_roads_{analysis_date}.parquet"
     )
     
-    df_with_projection_wide = (df_with_projection
-                           .groupby(["trip_instance_key"] + road_id_cols)
-                           .agg({
-                               "vp_idx": lambda x: list(x),
-                               "shape_meters": lambda x: list(x)})
-                           .reset_index()
-                           .rename(columns = {
-                               "vp_idx": "vp_idx_arr",
-                               "shape_meters": "shape_meters_arr"
-                           })
-                  )
+    vp_projected_wide2 = make_wide(vp_with_projected)
     
+    road_cutpoints = expand_road_segments(
+        roads, 
+        ["road_meters_arr", "segment_sequence_arr", "road_direction_arr"]
+    ).rename(columns = {
+        "road_meters_arr": "road_meters",
+        "segment_sequence_arr": "segment_sequence",
+        "road_direction_arr": "primary_direction"
+    })
+
     # Now merge road segments with each destination acting as the road's stop
     # and merge on arrays of projected vp against that road
     gdf = pd.merge(
-        road_segments,
-        df_with_projection_wide,
+        road_cutpoints,
+        vp_projected_wide2,
         on = road_id_cols,
         how = "inner"
+    ).query(
+        'road_meters >= shape_meters_min & road_meters <= shape_meters_max'
+    ).drop(
+        columns = ["shape_meters_min", "shape_meters_max"]
     )
     
     nearest_vp_idx = []

--- a/rt_segment_speeds/scripts/nearest_vp_to_road.py
+++ b/rt_segment_speeds/scripts/nearest_vp_to_road.py
@@ -241,7 +241,7 @@ if __name__ == "__main__":
     )
     
     result.to_parquet(
-        f"{SEGMENT_GCS}nearest_vp_roads_{analysis_date}.parquet"
+        f"{SEGMENT_GCS}projection/nearest_vp_roads_{analysis_date}.parquet"
     )
     
     end = datetime.datetime.now()

--- a/rt_segment_speeds/scripts/road_cutpoints.py
+++ b/rt_segment_speeds/scripts/road_cutpoints.py
@@ -19,23 +19,27 @@ if __name__ == "__main__":
         f"{SEGMENT_GCS}road_segments_{analysis_date}",
         filters = [[("mtfcc", "in", ["S1100", "S1200"])]],
         columns = segment_identifier_cols + [
-            "primary_direction", "destination", "geometry"],
+            #"primary_direction",
+            "destination", "geometry"],
     ).set_geometry("destination")
-    
+    '''
     full_roads = road_segments[
-        road_id_cols + ["primary_direction", "geometry"]
+        road_id_cols + [
+            #"primary_direction", 
+            "geometry"]
     ].set_geometry("geometry").dissolve(
-        by = road_id_cols + ["primary_direction"]
+        by = road_id_cols# + ["primary_direction"]
     ).reset_index()
-    #full_roads = cut_road_segments.load_roads(
-    #    filtering = [("MTFCC", "in", ["S1100", "S1200"])]
-    #).drop(columns = "road_length")
+    '''
+    full_roads = cut_road_segments.load_roads(
+        filtering = [("MTFCC", "in", ["S1100", "S1200"])]
+    ).drop(columns = "road_length")
 
     # Merge cut road segments with full road geometry
     gdf = pd.merge(
         full_roads,
         road_segments.drop(columns = "geometry"),
-        on = road_id_cols + ["primary_direction"],
+        on = road_id_cols, #+ ["primary_direction"],
         how = "inner"
     )
     
@@ -53,7 +57,7 @@ if __name__ == "__main__":
     
     # For each linearid, create an array tracking the cutpoints where
     # segments are created, which can act as "stops"
-    road_info = (gdf.groupby(road_id_cols + ["primary_direction"],
+    road_info = (gdf.groupby(road_id_cols,#+ ["primary_direction"],
                  observed=True, group_keys=False)
         .agg({
             "segment_sequence": lambda x: list(x),
@@ -68,7 +72,7 @@ if __name__ == "__main__":
     road_info_with_geom = pd.merge(
         full_roads,
         road_info,
-        on = road_id_cols + ["primary_direction"],
+        on = road_id_cols,# + ["primary_direction"],
         how = "inner"
     )
 

--- a/rt_segment_speeds/scripts/road_cutpoints.py
+++ b/rt_segment_speeds/scripts/road_cutpoints.py
@@ -3,6 +3,7 @@ Some prep work related to where road segments
 begin and end...this is analogous to transit
 "stops" along a shape.
 """
+import datetime
 import geopandas as gpd
 import pandas as pd
 
@@ -12,16 +13,17 @@ from calitp_data_analysis import utils
 
 if __name__ == "__main__":
     
+    start = datetime.datetime.now()
+    
     road_id_cols = ["linearid", "mtfcc"]
     segment_identifier_cols = road_id_cols + ["segment_sequence"]
     road_types = ["S1100", "S1200", "S1400"]
     
-    road_segments = gpd.read_parquet(
+    road_segments = pd.read_parquet(
         f"{SEGMENT_GCS}road_segments_{analysis_date}",
         filters = [[("mtfcc", "in", road_types)]],
-        columns = segment_identifier_cols + [
-            "destination", "geometry"],
-    ).set_geometry("destination")
+        columns = segment_identifier_cols + ["road_meters", "primary_direction"]
+    )
 
     full_roads = cut_road_segments.load_roads(
         filtering = [("MTFCC", "in", road_types)]
@@ -30,39 +32,29 @@ if __name__ == "__main__":
     # Merge cut road segments with full road geometry
     gdf = pd.merge(
         full_roads,
-        road_segments.drop(columns = "geometry"),
+        road_segments,
         on = road_id_cols, 
         how = "inner"
     )
     
-    # Project each segment destination against full road geometry
-    # note: we didn't add road's start at 0
-    gdf = gdf.assign(
-        road_meters = gdf.geometry.project(gdf.destination)
-    ).drop(columns = ["destination"])
-    
-    utils.geoparquet_gcs_export(
-        gdf,
-        f"{SEGMENT_GCS}segments_staging/",
-        f"roads_with_cutpoints_long_{analysis_date}"
-    )
-    
     # For each linearid, create an array tracking the cutpoints where
     # segments are created, which can act as "stops"
-    road_info = (gdf.groupby(road_id_cols,#+ ["primary_direction"],
+    road_info = (gdf.groupby(road_id_cols,
                  observed=True, group_keys=False)
         .agg({
             "segment_sequence": lambda x: list(x),
             "road_meters": lambda x: list(x),
+            "primary_direction": lambda x: list(x),
         }).reset_index()
         .rename(columns = {
             "segment_sequence": "segment_sequence_arr",
             "road_meters": "road_meters_arr",
+            "primary_direction": "road_direction_arr",
         })
     )
     
     road_info_with_geom = pd.merge(
-        full_roads,
+        full_roads[road_id_cols + ["fullname", "geometry"]],
         road_info,
         on = road_id_cols,
         how = "inner"
@@ -73,3 +65,6 @@ if __name__ == "__main__":
         f"{SEGMENT_GCS}segments_staging/",
         f"roads_with_cutpoints_wide_{analysis_date}"
     )
+    
+    end = datetime.datetime.now()
+    print(f"execution time: {end - start}")

--- a/rt_segment_speeds/scripts/road_cutpoints.py
+++ b/rt_segment_speeds/scripts/road_cutpoints.py
@@ -14,32 +14,24 @@ if __name__ == "__main__":
     
     road_id_cols = ["linearid", "mtfcc"]
     segment_identifier_cols = road_id_cols + ["segment_sequence"]
+    road_types = ["S1100", "S1200", "S1400"]
     
     road_segments = gpd.read_parquet(
         f"{SEGMENT_GCS}road_segments_{analysis_date}",
-        filters = [[("mtfcc", "in", ["S1100", "S1200"])]],
+        filters = [[("mtfcc", "in", road_types)]],
         columns = segment_identifier_cols + [
-            #"primary_direction",
             "destination", "geometry"],
     ).set_geometry("destination")
-    '''
-    full_roads = road_segments[
-        road_id_cols + [
-            #"primary_direction", 
-            "geometry"]
-    ].set_geometry("geometry").dissolve(
-        by = road_id_cols# + ["primary_direction"]
-    ).reset_index()
-    '''
+
     full_roads = cut_road_segments.load_roads(
-        filtering = [("MTFCC", "in", ["S1100", "S1200"])]
+        filtering = [("MTFCC", "in", road_types)]
     ).drop(columns = "road_length")
 
     # Merge cut road segments with full road geometry
     gdf = pd.merge(
         full_roads,
         road_segments.drop(columns = "geometry"),
-        on = road_id_cols, #+ ["primary_direction"],
+        on = road_id_cols, 
         how = "inner"
     )
     
@@ -72,7 +64,7 @@ if __name__ == "__main__":
     road_info_with_geom = pd.merge(
         full_roads,
         road_info,
-        on = road_id_cols,# + ["primary_direction"],
+        on = road_id_cols,
         how = "inner"
     )
 

--- a/rt_segment_speeds/scripts/shapely_project_vp.py
+++ b/rt_segment_speeds/scripts/shapely_project_vp.py
@@ -56,7 +56,6 @@ def project_usable_vp_one_day(
     )
     
     group_cols = ["shape_array_key"]
-    shape_cols_dtypes = shapes[group_cols].dtypes.to_dict()
     
     results = vp.map_partitions(
         wrangle_shapes.project_vp_onto_segment_geometry,
@@ -66,7 +65,8 @@ def project_usable_vp_one_day(
                 **shape_cols_dtypes,
                "shape_meters": "float64"},
         align_dataframes = False
-    ).drop(columns = group_cols)
+    ).drop(columns = group_cols).persist()
+
     
     time1 = datetime.datetime.now()
     logger.info(f"map partitions: {time1 - start}")

--- a/rt_segment_speeds/scripts/sjoin_vp_to_roads.py
+++ b/rt_segment_speeds/scripts/sjoin_vp_to_roads.py
@@ -33,7 +33,7 @@ def sjoin_vp_to_roads(
         vp_gdf,
         roads2,
         how = "inner",
-        predicate = "within"
+        predicate = "intersects"
     )[["vp_idx", "trip_instance_key"] + keep_road_cols
      ].drop_duplicates().sort_values("vp_idx")  
         
@@ -85,8 +85,6 @@ if __name__ == "__main__":
             align_dataframes = False
         ) for direction in all_directions
     ]
-    
-    #https://github.com/cal-itp/data-analyses/blob/f7ecb9252895374aaa3927a93d9bcd2253888973/rt_segment_speeds/scripts/sjoin_vp_roads.py
     
     full_results = dd.multi.concat(results, axis=0).reset_index(drop=True)
     full_results = full_results.repartition(npartitions=10).persist()

--- a/rt_segment_speeds/scripts/sjoin_vp_to_roads.py
+++ b/rt_segment_speeds/scripts/sjoin_vp_to_roads.py
@@ -1,11 +1,12 @@
 import dask.dataframe as dd
+import dask_geopandas as dg
 import datetime
 import geopandas as gpd
 import pandas as pd
 
 from segment_speed_utils.project_vars import (SEGMENT_GCS, analysis_date,
                                               PROJECT_CRS)
-from segment_speed_utils import wrangle_shapes
+from segment_speed_utils import helpers, wrangle_shapes
 
 
 def sjoin_vp_to_roads(
@@ -16,13 +17,15 @@ def sjoin_vp_to_roads(
     
     vp_gdf = wrangle_shapes.vp_as_gdf(vp)
     
-    roads = roads.assign(
-        geometry = roads.geometry.buffer(25)
+    roads2 = roads.dissolve(road_grouping_cols).reset_index()
+    
+    roads2 = roads2.assign(
+        geometry = roads2.geometry.buffer(25)
     )
         
     results = gpd.sjoin(
         vp_gdf,
-        roads,
+        roads2,
         how = "inner",
         predicate = "within"
     )[["vp_idx", "trip_instance_key"] + 
@@ -50,31 +53,57 @@ def make_wide(
     return results_wide
 
 
-def import_data(
-    analysis_date: str, 
-    direction: str,
-    segment_identifier_cols: list
-) -> tuple[dd.DataFrame, gpd.GeoDataFrame]:
-    
-    opposite_direction = wrangle_shapes.OPPOSITE_DIRECTIONS[direction]
-    
+def import_vp(analysis_date: str):
     vp = dd.read_parquet(
         f"{SEGMENT_GCS}vp_usable_{analysis_date}",
-        columns = ["vp_idx", "trip_instance_key", "x", "y"],
-        filters = [[("vp_primary_direction", "==", direction)]]
+        columns = ["vp_idx", "trip_instance_key", "x", "y", 
+                   "vp_primary_direction"],
     )
     
-    vp = vp.repartition(npartitions=10)
+    rt_trips = vp.trip_instance_key.unique().compute().tolist()
     
-    road_segments = gpd.read_parquet(
+    trip_to_shape = helpers.import_scheduled_trips(
+        analysis_date,
+        columns = ["trip_instance_key", "shape_array_key"],
+        filters = [[("trip_instance_key", "in", rt_trips)]],
+        get_pandas = True
+    )
+    
+    vp2 = dd.merge(
+        vp,
+        trip_to_shape,
+        on = "trip_instance_key",
+        how = "inner"
+    )
+    
+    return vp2
+
+
+def import_roads(
+    analysis_date: str, 
+    vp: dd.DataFrame,
+    road_grouping_cols: list,
+) -> gpd.GeoDataFrame:
+    
+    keep_shapes = vp.shape_array_key.unique().compute().tolist()
+    
+    # Import shapes to roads crosswalk
+    keep_roads = pd.read_parquet(
+        f"{SEGMENT_GCS}shape_road_crosswalk_{analysis_date}.parquet",
+        filters = [[("shape_array_key", "in", keep_shapes)]]
+    ).linearid.unique().tolist()
+        
+    road_segments = dg.read_parquet(
         f"{SEGMENT_GCS}road_segments_{analysis_date}",
         filters = [[
-            ("mtfcc", "in", ["S1100", "S1200"]), 
-            ("primary_direction", "!=", opposite_direction)]],
-        columns =  segment_identifier_cols + ["geometry"]
+            ("linearid", "in", keep_roads),
+            #("mtfcc", "in", ["S1100", "S1200"]), 
+        ]],
+        columns =  road_grouping_cols + ["primary_direction", 
+                                         "geometry"]
     )
-    
-    return vp, road_segments
+              
+    return road_segments
 
 
 if __name__ == "__main__":
@@ -82,20 +111,26 @@ if __name__ == "__main__":
     start = datetime.datetime.now()
     
     road_cols = ["linearid", "mtfcc"]
-    segment_identifier_cols = road_cols + ["segment_sequence", 
-                                           "primary_direction"]
 
-    all_directions = wrangle_shapes.ALL_DIRECTIONS
-    
-    dfs = [
-        import_data(
-            analysis_date, d, segment_identifier_cols)
+    all_directions = wrangle_shapes.ALL_DIRECTIONS + ["Unknown"]
+
+    vp = import_vp(analysis_date).persist()
+    roads = import_roads(analysis_date, vp, road_cols).persist()
+                
+    vp_dfs = [
+        vp[vp.vp_primary_direction == d].repartition(npartitions=20)
         for d in all_directions
     ]
     
-
-    vp_cols_dtypes = dfs[0][0][["vp_idx", "trip_instance_key"]].dtypes.to_dict()
-    road_cols_dtypes = dfs[0][1][road_cols].dtypes.to_dict()
+    road_dfs = [
+        roads[roads.primary_direction != 
+              wrangle_shapes.OPPOSITE_DIRECTIONS[d]
+             ].repartition(npartitions=40) 
+        for d in all_directions
+    ]
+    
+    vp_cols_dtypes = vp[["vp_idx", "trip_instance_key"]].dtypes.to_dict()
+    road_cols_dtypes = roads[road_cols].dtypes.to_dict()
     
     results = [
         vp_subset.map_partitions(
@@ -107,23 +142,23 @@ if __name__ == "__main__":
                 **road_cols_dtypes
             },
             align_dataframes = False
-        ) for vp_subset, road_subset in dfs
+        ) for vp_subset, road_subset in zip(vp_dfs, road_dfs)
     ]
     print("map partitions")
     
     full_results = dd.multi.concat(results, axis=0).reset_index(drop=True)
-    full_results = full_results.repartition(npartitions=10).persist()
+    full_results = full_results.repartition(npartitions=3).persist()
     
     time1 = datetime.datetime.now()
     print(f"map partitions and persist full results: {time1 - start}")
     
     full_results.to_parquet(
-        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}_seg",
+        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}",
         overwrite=True
     )
     
     full_results = dd.read_parquet(
-        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}_seg"
+        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}"
     )
         
     results_wide = full_results.map_partitions(

--- a/rt_segment_speeds/scripts/sjoin_vp_to_roads.py
+++ b/rt_segment_speeds/scripts/sjoin_vp_to_roads.py
@@ -1,4 +1,5 @@
 import dask.dataframe as dd
+import datetime
 import geopandas as gpd
 import pandas as pd
 
@@ -10,37 +11,30 @@ from segment_speed_utils import wrangle_shapes
 def sjoin_vp_to_roads(
     vp: dd.DataFrame, 
     roads: gpd.GeoDataFrame, 
-    direction: str
+    road_grouping_cols: list,
 ) -> dd.DataFrame:
     
-    opposite_direction = wrangle_shapes.OPPOSITE_DIRECTIONS[direction]
+    vp_gdf = wrangle_shapes.vp_as_gdf(vp)
     
-    vp2 = vp[vp.vp_primary_direction == direction]
-    
-    vp_gdf = wrangle_shapes.vp_as_gdf(vp2)
-    
-    keep_road_cols = ["linearid", "mtfcc", "primary_direction"]
-
-    roads2 = roads[
-        roads.primary_direction != opposite_direction
-    ].drop_duplicates(subset=keep_road_cols).reset_index(drop=True)
-    
-    roads2 = roads2.assign(
-        geometry = roads2.geometry.buffer(20)
+    roads = roads.assign(
+        geometry = roads.geometry.buffer(25)
     )
-    
+        
     results = gpd.sjoin(
         vp_gdf,
-        roads2,
+        roads,
         how = "inner",
-        predicate = "intersects"
-    )[["vp_idx", "trip_instance_key"] + keep_road_cols
-     ].drop_duplicates().sort_values("vp_idx")  
+        predicate = "within"
+    )[["vp_idx", "trip_instance_key"] + 
+      road_grouping_cols].drop_duplicates().sort_values("vp_idx")  
         
     return results
     
     
-def make_wide(full_results, road_cols):
+def make_wide(
+    full_results: pd.DataFrame, 
+    road_cols: list
+) -> pd.DataFrame:
     results_wide = (full_results.groupby(["trip_instance_key"] + road_cols, 
                       observed=True, group_keys=False)
                     .agg({"vp_idx": lambda x: list(x)})
@@ -48,51 +42,90 @@ def make_wide(full_results, road_cols):
                     .rename(columns = {"vp_idx": "vp_idx_arr"}) 
                    )
     
+    # No point in keeping results where there are fewer than 2 vp for entire road
+    results_wide = results_wide.assign(
+        n_vp = results_wide.apply(lambda x: len(x.vp_idx_arr), axis=1)
+    ).query('n_vp > 1').drop(columns = "n_vp").reset_index(drop=True)
+    
     return results_wide
+
+
+def import_data(
+    analysis_date: str, 
+    direction: str,
+    segment_identifier_cols: list
+) -> tuple[dd.DataFrame, gpd.GeoDataFrame]:
+    
+    opposite_direction = wrangle_shapes.OPPOSITE_DIRECTIONS[direction]
+    
+    vp = dd.read_parquet(
+        f"{SEGMENT_GCS}vp_usable_{analysis_date}",
+        columns = ["vp_idx", "trip_instance_key", "x", "y"],
+        filters = [[("vp_primary_direction", "==", direction)]]
+    )
+    
+    vp = vp.repartition(npartitions=10)
+    
+    road_segments = gpd.read_parquet(
+        f"{SEGMENT_GCS}road_segments_{analysis_date}",
+        filters = [[
+            ("mtfcc", "in", ["S1100", "S1200"]), 
+            ("primary_direction", "!=", opposite_direction)]],
+        columns =  segment_identifier_cols + ["geometry"]
+    )
+    
+    return vp, road_segments
 
 
 if __name__ == "__main__":
     
-    road_cols = ["linearid", "mtfcc", "primary_direction"]
-    segment_identifier_cols = road_cols + ["segment_sequence"]
-
-    road_segments = gpd.read_parquet(
-        f"{SEGMENT_GCS}road_segments_{analysis_date}",
-        filters = [[("mtfcc", "in", ["S1100", "S1200"])]],
-        columns = segment_identifier_cols + ["geometry"]
-    )
-
-    vp = dd.read_parquet(
-        f"{SEGMENT_GCS}vp_usable_{analysis_date}",
-        columns = ["vp_idx", "trip_instance_key", "x", "y", 
-                   "vp_primary_direction"]
-    )
+    start = datetime.datetime.now()
     
-    vp_cols_dtypes = vp[["vp_idx", "trip_instance_key"]].dtypes.to_dict()
-    road_cols_dtypes = road_segments[road_cols].dtypes.to_dict()
+    road_cols = ["linearid", "mtfcc"]
+    segment_identifier_cols = road_cols + ["segment_sequence", 
+                                           "primary_direction"]
+
+    all_directions = wrangle_shapes.ALL_DIRECTIONS
     
-    all_directions = wrangle_shapes.ALL_DIRECTIONS + ["Unknown"]
+    dfs = [
+        import_data(
+            analysis_date, d, segment_identifier_cols)
+        for d in all_directions
+    ]
+    
+
+    vp_cols_dtypes = dfs[0][0][["vp_idx", "trip_instance_key"]].dtypes.to_dict()
+    road_cols_dtypes = dfs[0][1][road_cols].dtypes.to_dict()
     
     results = [
-        vp.map_partitions(
+        vp_subset.map_partitions(
             sjoin_vp_to_roads,
-            road_segments,
-            direction,
+            road_subset,
+            road_cols,
             meta = {
                 **vp_cols_dtypes,
                 **road_cols_dtypes
             },
             align_dataframes = False
-        ) for direction in all_directions
+        ) for vp_subset, road_subset in dfs
     ]
+    print("map partitions")
     
     full_results = dd.multi.concat(results, axis=0).reset_index(drop=True)
     full_results = full_results.repartition(npartitions=10).persist()
+    
+    time1 = datetime.datetime.now()
+    print(f"map partitions and persist full results: {time1 - start}")
+    
     full_results.to_parquet(
-        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}",
+        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}_seg",
         overwrite=True
     )
     
+    full_results = dd.read_parquet(
+        f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_{analysis_date}_seg"
+    )
+        
     results_wide = full_results.map_partitions(
         make_wide,
         road_cols,
@@ -108,3 +141,5 @@ if __name__ == "__main__":
         f"{SEGMENT_GCS}vp_sjoin/vp_road_segments_wide_{analysis_date}.parquet",
     )
     
+    end = datetime.datetime.now()
+    print(f"execution time: {end - start}")

--- a/rt_segment_speeds/segment_speed_utils/array_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/array_utils.py
@@ -2,6 +2,9 @@
 Functions for working with numpy arrays.
 """
 import numpy as np
+import pandas as pd
+
+from numba import jit
 
 def get_index(array: np.ndarray, item) -> int:
     """
@@ -83,3 +86,34 @@ def cut_shape_by_origin_destination(
     # flatten so it's 1d array
 
     return shape_dist_subset_indices
+
+
+def rolling_window_make_array(
+    df: pd.DataFrame, 
+    window: int, 
+    rolling_col: str
+) -> pd.DataFrame:
+    # https://stackoverflow.com/questions/47482009/pandas-rolling-window-to-return-an-array
+    df[f"rolling_{rolling_col}"] = [
+        np.asarray(window)for window in 
+        df.groupby("trip_instance_key")[rolling_col].rolling(
+            window = window, center=True)
+    ]
+    
+    is_monotonic_series = np.vectorize(monotonic_check)(df[f"rolling_{rolling_col}"])
+    df[f"{rolling_col}_monotonic"] = is_monotonic_series
+    
+    return df
+    
+@jit(nopython=True)
+def monotonic_check(arr: np.ndarray) -> bool:
+    """
+    For an array, check if it's monotonically increasing. 
+    https://stackoverflow.com/questions/4983258/check-list-monotonicity
+    """
+    diff_arr = np.diff(arr)
+    
+    if np.all(diff_arr >= 0):
+        return True
+    else:
+        return False

--- a/rt_segment_speeds/segment_speed_utils/helpers.py
+++ b/rt_segment_speeds/segment_speed_utils/helpers.py
@@ -270,20 +270,22 @@ def remove_shapes_outside_ca(
         "query?outFields=*&where=1%3D1&f=geojson"
     )
     
-    
     border_states = ["CA", "NV", "AZ", "OR"]
     
+    SHAPE_CRS = shapes.crs.to_epsg()
+
     # Filter to California
     ca = us_states.query(
         'STATE_ABBR in @border_states'
-    ).dissolve()[["geometry"]]
+    ).dissolve()[["geometry"]].to_crs(SHAPE_CRS)
+    
     
     # Be aggressive and keep if shape
     # is within (does not cross CA + border state boundaries)
     if isinstance(shapes, dg.GeoDataFrame):
         shapes_within_ca = dg.sjoin(
             shapes,
-            ca.to_crs(shapes.crs),
+            ca,
             how = "inner",
             predicate = "within"
         )
@@ -291,7 +293,7 @@ def remove_shapes_outside_ca(
     else:
         shapes_within_ca = gpd.sjoin(
             shapes,
-            ca.to_crs(shapes.crs),
+            ca,
             how = "inner",
             predicate = "within",
         )

--- a/rt_segment_speeds/segment_speed_utils/project_vars.py
+++ b/rt_segment_speeds/segment_speed_utils/project_vars.py
@@ -8,7 +8,7 @@ SCHED_GCS = f"{GCS_FILE_PATH}gtfs_schedule/"
 PREDICTIONS_GCS = f"{GCS_FILE_PATH}rt_predictions/"
 SHARED_GCS = f"{GCS_FILE_PATH}shared_data/"
 
-analysis_date = rt_dates.DATES["oct2023"]
+analysis_date = rt_dates.DATES["nov2023"]
 
 analysis_date_list = [
     rt_dates.DATES["oct2023"] 

--- a/rt_segment_speeds/segment_speed_utils/project_vars.py
+++ b/rt_segment_speeds/segment_speed_utils/project_vars.py
@@ -8,12 +8,12 @@ SCHED_GCS = f"{GCS_FILE_PATH}gtfs_schedule/"
 PREDICTIONS_GCS = f"{GCS_FILE_PATH}rt_predictions/"
 SHARED_GCS = f"{GCS_FILE_PATH}shared_data/"
 
-analysis_date = rt_dates.DATES["nov2023"]
+analysis_date = rt_dates.DATES["oct2023"]
 
 analysis_date_list = [
-    rt_dates.DATES["nov2023"] 
+    rt_dates.DATES["oct2023"] 
 ]
 
 PROJECT_CRS = "EPSG:3310"
 CONFIG_PATH = "./config.yml"
-ROAD_SEGMENT_METERS = 500
+ROAD_SEGMENT_METERS = 250

--- a/rt_segment_speeds/segment_speed_utils/wrangle_shapes.py
+++ b/rt_segment_speeds/segment_speed_utils/wrangle_shapes.py
@@ -20,7 +20,7 @@ import shapely
 
 from typing import Literal
 
-from calitp_data_analysis.geography_utils import WGS84
+from calitp_data_analysis import geography_utils
 from shared_utils import rt_utils
 from segment_speed_utils.project_vars import PROJECT_CRS
 
@@ -170,10 +170,10 @@ def vp_as_gdf(vp: pd.DataFrame) -> gpd.GeoDataFrame:
     """
     Turn vp as a gdf and project to EPSG:3310.
     """
-    vp_gdf = gpd.GeoDataFrame(
+    vp_gdf = geography_utils.create_point_geometry(
         vp,
-        geometry = gpd.points_from_xy(vp.x, vp.y),
-        crs = WGS84
+        longitude_col = "x", latitude_col = "y",
+        crs = geography_utils.WGS84
     ).to_crs(PROJECT_CRS).drop(columns = ["x", "y"])
         
     return vp_gdf

--- a/rt_segment_speeds/setup.py
+++ b/rt_segment_speeds/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="segment_speed_utils",
     packages=find_packages(),
-    version="1.0.0",
+    version="1.2.0",
     description="Utility functions for GTFS RT segment speeds",
     author="Cal-ITP",
     license="Apache",


### PR DESCRIPTION
# road segment speeds
* When road segments are 1,000 m long, there are many vp that don't span that long on a road (no enter and exit). 
* Try 500 m and 250 m...go with 250 m road segments 
* Use a crosswalk of shapes-to-roads so that we only allow vp that's traveling along the shape to be used
* Do sjoin of vp to road segments. If there's not at least 2 vp for that trip on that road touching 2 unique segments, get rid of. These are viable vp we can use to interpolate against the endpoints of road segments.
* Use similar methodology in `segment_speeds` to find the nearest vp to a road segment endpoint (this is a road equivalent of a "stop") and interpolate when it passes that point. 
* #916 
* #921 

## open data
* fix the normal stop segments for oct and nov...weirdness came from the refactor, forgot to index into the coordinates in between endpoints, so segments are not following roads.
* move ArcPro step earlier to see if we can hold the `tags` that get lost when the FGDC template is applied first, and doesn't seem to come back when the ISO19139 template is applied -- doesn't seem to help, oh well