### PR TITLE
Route typology

### DIFF
--- a/gtfs_funnel/Makefile
+++ b/gtfs_funnel/Makefile
@@ -12,6 +12,8 @@ preprocess:
 	python vp_keep_usable.py
 	python vp_direction.py
 	python cleanup.py
+	python route_typologies.py
+    
     
 funnel_gtfs_data: 
 	make download_gtfs_data && make preprocess

--- a/gtfs_funnel/config.yml
+++ b/gtfs_funnel/config.yml
@@ -2,3 +2,6 @@ raw_vp_file: "vp"
 usable_vp_file: "vp_usable"
 timestamp_col: "location_timestamp_local"
 time_min_cutoff: 10
+stop_times_direction_file: "stop_times_direction"
+trip_metrics_file: "schedule_trip_metrics"
+route_direction_metrics_file: "schedule_route_direction_metrics"

--- a/gtfs_funnel/route_typologies.py
+++ b/gtfs_funnel/route_typologies.py
@@ -1,0 +1,148 @@
+"""
+Add some GTFS schedule derived metrics
+by trip (service frequency and stop spacing).
+"""
+import geopandas as gpd
+import pandas as pd
+
+from calitp_data_analysis.geography_utils import WGS84
+from calitp_data_analysis import utils
+from segment_speed_utils import helpers, gtfs_schedule_wrangling, sched_rt_utils
+from segment_speed_utils.project_vars import RT_SCHED_GCS
+
+def assemble_scheduled_trip_metrics(analysis_date: str):
+    
+    df = gpd.read_parquet(
+        f"{RT_SCHED_GCS}stop_times_direction_{analysis_date}.parquet"
+    )
+
+    trips_to_route = helpers.import_scheduled_trips(
+        analysis_date,
+        columns = ["trip_instance_key", "route_id", "direction_id"],
+        get_pandas = True
+    )
+    
+    time_of_day = (sched_rt_utils.get_trip_time_buckets(analysis_date)   
+                   [["trip_instance_key", "time_of_day", 
+                     "service_minutes"]]
+                   .rename(columns = {"service_minutes": "sched_service_min"})
+              )
+    
+    trip_cols = ["schedule_gtfs_dataset_key", "trip_instance_key"]
+    
+    grouped_df = df.groupby(trip_cols, observed=True, group_keys=False)
+
+    # Get median / mean stop meters for the trip
+    # Attach time-of-day and route_id and direction_id
+    df2 = pd.merge(
+        grouped_df.agg({"stop_meters": "median"}).reset_index().rename(
+            columns = {"stop_meters": "median_stop_meters"}),
+        time_of_day,
+        on = "trip_instance_key",
+        how = "left"
+    ).merge(
+        trips_to_route,
+        on = "trip_instance_key",
+        how = "inner"
+    )
+    
+    df2 = df2.assign(
+        median_stop_meters = df2.median_stop_meters.round(2)
+    )
+    
+    return df2
+    
+    
+def schedule_metrics_by_route_direction(
+    df: pd.DataFrame,
+    analysis_date: str,
+    group_cols: list
+) -> pd.DataFrame:
+    """
+    Aggregate trip-level metrics to route-direction, and 
+    attach shape geometry for common_shape_id.
+    """
+    
+    service_freq_df = gtfs_schedule_wrangling.aggregate_time_of_day_to_peak_offpeak(
+        df, group_cols)
+    
+    metrics_df = (df.groupby(group_cols, observed=True, group_keys=False)
+                  .agg({
+                      "median_stop_meters": "mean", 
+                      # take mean of the median stop spacing for trip
+                      # does this make sense?
+                      # median is the single boiled down metric at the trip-level
+                      "sched_service_min": "mean",
+                  }).reset_index()
+                  .rename(columns = {
+                      "median_stop_meters": "avg_stop_meters",
+                      "sched_service_min": "avg_sched_service_min"
+                  })
+                 )
+    
+    common_shape_for_route_dir = add_common_shape(analysis_date)
+    
+    df = pd.merge(
+        common_shape_for_route_dir,
+        metrics_df,
+        on = group_cols,
+        how = "inner"
+    ).merge(
+        service_freq_df,
+        on = group_cols,
+        how = "inner"
+    )
+    
+    return df
+
+
+def add_common_shape(analysis_date: str):
+    """
+    For route-direction df, add common_shape_id (most frequent shape)
+    and attach that shape geometry
+    """
+    common_shape = sched_rt_utils.most_common_shape_by_route_direction(analysis_date)
+    
+    shapes = helpers.import_scheduled_shapes(
+        analysis_date, 
+        columns = ["shape_array_key", "geometry"],
+        crs = WGS84,
+        get_pandas = True
+    )
+    
+    shapes_with_geom = pd.merge(
+        shapes,
+        common_shape,
+        on = "shape_array_key",
+        how = "inner"
+    )
+    
+    return shapes_with_geom
+    
+
+if __name__ == "__main__":
+    
+    from update_vars import analysis_date_list, CONFIG_DICT
+    
+    TRIP_EXPORT = CONFIG_DICT["trip_metrics_file"]
+    ROUTE_DIR_EXPORT = CONFIG_DICT["route_direction_metrics_file"]
+    
+    for date in analysis_date_list[:1]:
+        trip_metrics = assemble_scheduled_trip_metrics(date)
+        
+        trip_metrics.to_parquet(
+            f"{RT_SCHED_GCS}{TRIP_EXPORT}_{date}.parquet")
+        
+        route_cols = [
+            "schedule_gtfs_dataset_key", 
+            "route_id", 
+            "direction_id"
+        ]
+        route_dir_metrics = schedule_metrics_by_route_direction(
+            trip_metrics, date, route_cols)
+                
+        utils.geoparquet_gcs_export(
+            route_dir_metrics,
+            RT_SCHED_GCS,
+            f"{ROUTE_DIR_EXPORT}_{date}"
+        )

--- a/gtfs_funnel/stop_times_with_direction.py
+++ b/gtfs_funnel/stop_times_with_direction.py
@@ -132,7 +132,7 @@ def find_prior_stop(
     return stop_times_with_prior_geom
 
 
-def assemble_stop_times_with_direction(analysis_date: str):
+def assemble_stop_times_with_direction(analysis_date: str, dict_inputs: dict):
     """
     Assemble a stop_times table ready to be joined with 
     RT data (has trip_instance_key).
@@ -142,6 +142,8 @@ def assemble_stop_times_with_direction(analysis_date: str):
     """
     start = datetime.datetime.now()
 
+    EXPORT_FILE = dict_inputs["stop_times_direction_file"]
+    
     scheduled_stop_times = prep_scheduled_stop_times(analysis_date).repartition(
         npartitions=1).persist()
 
@@ -204,7 +206,7 @@ def assemble_stop_times_with_direction(analysis_date: str):
     utils.geoparquet_gcs_export(
         df,
         RT_SCHED_GCS,
-        f"stop_times_direction_{analysis_date}"
+        f"{EXPORT_FILE}_{analysis_date}"
     )
     
     end = datetime.datetime.now()
@@ -215,7 +217,7 @@ def assemble_stop_times_with_direction(analysis_date: str):
 
 if __name__ == "__main__":  
     
-    from update_vars import analysis_date_list
-    
+    from update_vars import analysis_date_list, CONFIG_DICT
+
     for date in analysis_date_list:
-        assemble_stop_times_with_direction(date)
+        assemble_stop_times_with_direction(date, CONFIG_DICT)

--- a/gtfs_funnel/update_vars.py
+++ b/gtfs_funnel/update_vars.py
@@ -2,7 +2,8 @@ import yaml
 from pathlib import Path
 from shared_utils import rt_dates
 
-months = ["nov"]         
+months = ["nov", "oct", "sep", "aug",
+         "jul", "jun", "may", "apr", "mar"]         
 
 analysis_date_list = [
     rt_dates.DATES[f"{m}2023"] for m in months


### PR DESCRIPTION
## gtfs_funnel
* derive additional scheduled metrics that we can get from `shapes`, `stops`, and `stop_times`, and what we know of from CalEnviroScreen / LEHD data by census tract
* add stop spacing, peak / off peak service frequency, and crude measure of pop density (pct of shape that runs in high density tracts...10,000 or more pop_sq_mi). high density here is basically top 1/3 of pop density values that show up
   * how else should we combine some line geometry length (unit = miles) with a population per sq mi (unit = square miles)? do we want very disaggregated numbers anyway?
* save out trip-level df that gets aggregated to route-direction 
* #955 