### PR TITLE
Fix shared utils imports

### DIFF
--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -1,1 +1,3 @@
 -e .
+gtfs-segments==0.1.0
+pyairtable==2.2.2

--- a/_shared_utils/shared_utils/dask_utils.py
+++ b/_shared_utils/shared_utils/dask_utils.py
@@ -8,9 +8,9 @@ import dask_geopandas as dg
 import gcsfs
 import geopandas as gpd
 import pandas as pd
+from calitp_data_analysis import utils
 from dask import compute, delayed
 from dask.delayed import Delayed  # type hint
-from shared_utils import utils
 
 fs = gcsfs.GCSFileSystem()
 

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -12,8 +12,9 @@ import geopandas as gpd
 import pandas as pd
 import shapely
 import siuba  # need this to do type hint in functions
+from calitp_data_analysis import geography_utils
 from calitp_data_analysis.tables import tbls
-from shared_utils import geography_utils, schedule_rt_utils
+from shared_utils import schedule_rt_utils
 from siuba import *
 
 GCS_PROJECT = "cal-itp-data-infra"

--- a/_shared_utils/shared_utils/rt_dates.py
+++ b/_shared_utils/shared_utils/rt_dates.py
@@ -50,6 +50,12 @@ DATES = {
     "jan2024": "2024-01-17",
 }
 
+y2023_dates = [DATES[f"{m}2023"] for m in ["dec", "nov", "oct", "sep", "aug", "jul", "jun", "may", "apr", "mar"]]
+y2024_dates = [v for k, v in DATES.items() if "2024" in k]
+
+apr_week = [v for k, v in DATES.items() if "apr2023" in k]
+oct_week = [v for k, v in DATES.items() if "oct2023" in k]
+
 
 # Planning and Modal Advisory Committee (PMAC) - quarterly
 PMAC = {

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -15,10 +15,10 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import shapely
-from calitp_data_analysis import get_fs
+from calitp_data_analysis import geography_utils, get_fs, utils
 from calitp_data_analysis.tables import tbls
 from numba import jit
-from shared_utils import geography_utils, gtfs_utils_v2, rt_dates, utils
+from shared_utils import gtfs_utils_v2, rt_dates
 from siuba import *
 
 fs = get_fs()


### PR DESCRIPTION
* Point references to `shared_utils` -> `calitp_data_analysis` within `shared_utils` modules
* Re-add `pyairtable` and `gtfs-segments` here, doesn't look like it's installed properly in Hub image. 
* Add variables for all the 2023 dates and 2024 dates available in `rt_dates`