### PR TITLE
`rt_stop_times` table with nearest neighbor approach

### DIFF
--- a/rt_scheduled_v_ran/08_trip_distribution.ipynb
+++ b/rt_scheduled_v_ran/08_trip_distribution.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e3cc1e6c-f7c8-4ed7-b02c-fb83af68c106",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from segment_speed_utils import helpers\n",
+    "from shared_utils import rt_dates\n",
+    "from segment_speed_utils.project_vars import RT_SCHED_GCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8f6d09bb-e5fe-4f8c-9179-85d9bb9097e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_daily_stats(analysis_date: str):\n",
+    "    scheduled_trips = helpers.import_scheduled_trips(\n",
+    "        analysis_date,\n",
+    "        columns = [\"gtfs_dataset_key\", \"trip_instance_key\"],\n",
+    "        get_pandas = True\n",
+    "    )\n",
+    "\n",
+    "    vp_trips = pd.read_parquet(\n",
+    "        f\"{RT_SCHED_GCS}vp_trip/trip_metrics/trip_{analysis_date}.parquet\"\n",
+    "    )\n",
+    "\n",
+    "    df = pd.merge(\n",
+    "        scheduled_trips,\n",
+    "        vp_trips,\n",
+    "        on = [\"schedule_gtfs_dataset_key\", \"trip_instance_key\"],\n",
+    "        how = \"outer\",\n",
+    "        indicator = True\n",
+    "    )\n",
+    "\n",
+    "    print(df._merge.value_counts(normalize=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7c4f7005-158e-453f-a63a-88ecf61a7f71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-01-17\n",
+      "both          0.686273\n",
+      "left_only     0.219728\n",
+      "right_only    0.093999\n",
+      "Name: _merge, dtype: float64\n",
+      "2024-02-14\n",
+      "both          0.692545\n",
+      "left_only     0.239297\n",
+      "right_only    0.068158\n",
+      "Name: _merge, dtype: float64\n",
+      "2023-12-13\n",
+      "both          0.705866\n",
+      "left_only     0.220349\n",
+      "right_only    0.073785\n",
+      "Name: _merge, dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "analysis_date_list = rt_dates.y2024_dates + [\n",
+    "    rt_dates.DATES[\"dec2023\"]\n",
+    "    \n",
+    "]\n",
+    "\n",
+    "for analysis_date in analysis_date_list:\n",
+    "    print(analysis_date)\n",
+    "    get_daily_stats(analysis_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad6c8bd6-ff2c-44ff-a64a-096ae00e2d21",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5871829e-292d-4964-8542-0131ff336760",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rt_scheduled_v_ran/scripts/config.yml
+++ b/rt_scheduled_v_ran/scripts/config.yml
@@ -1,2 +1,3 @@
 trip_metrics: "vp_trip/trip_metrics"
 route_direction_metrics: "vp_route_dir/route_direction_metrics"
+schedule_rt_stop_times: "schedule_rt_stop_times"

--- a/rt_scheduled_v_ran/scripts/rt_stop_times.py
+++ b/rt_scheduled_v_ran/scripts/rt_stop_times.py
@@ -92,10 +92,8 @@ def assemble_scheduled_rt_stop_times(
 
 if __name__ == "__main__":
     
-    from shared_utils import rt_dates
     from update_vars import CONFIG_DICT
-    
-    analysis_date_list = rt_dates.get_week("apr2023", exclude_wed=True)
+    from update_vars import analysis_date_list
     
     EXPORT_FILE = CONFIG_DICT["schedule_rt_stop_times"]
     

--- a/rt_scheduled_v_ran/scripts/rt_stop_times.py
+++ b/rt_scheduled_v_ran/scripts/rt_stop_times.py
@@ -5,94 +5,107 @@ what was derived from RT vehicle positions.
 import datetime
 import pandas as pd
 
-from segment_speed_utils import array_utils, helpers, segment_calcs
+from segment_speed_utils import helpers, segment_calcs
 from segment_speed_utils.project_vars import SEGMENT_GCS, RT_SCHED_GCS
 
-
-def assemble_stop_times(analysis_date: str):
+def prep_scheduled_stop_times(
+    analysis_date: str
+) -> pd.DataFrame: 
     """
-    Import schedule stop times and merge with trips to 
-    get trip_instance_key.
-    
-    Only keep rows where arrival_sec is not NaN.
+    Import scheduled stop times and merge in 
+    gtfs_dataset_key and trip_instance_key.
     """
-    sched_trip_cols = ["feed_key", "trip_id"]
-    
-    # Get trip_instance_key and gtfs_dataset_key
-    # and merge to stop_times
     trips = helpers.import_scheduled_trips(
         analysis_date,
-        columns = ["gtfs_dataset_key", 
-                   "trip_instance_key"] + sched_trip_cols,
+        columns = ["feed_key", "gtfs_dataset_key",
+                   "trip_id", "trip_instance_key"],
         get_pandas = True
     )
-    
+
     stop_times = helpers.import_scheduled_stop_times(
         analysis_date,
-        columns = sched_trip_cols + ["stop_sequence", "arrival_sec"]
+        columns = ["feed_key", "trip_id", 
+                   "stop_id", "stop_sequence",
+                   "arrival_sec",
+                  ],
+        get_pandas = True,
+        with_direction = False
     ).merge(
         trips,
-        on = sched_trip_cols, 
+        on = ["feed_key", "trip_id"],
         how = "inner"
-    ).drop(columns = ["feed_key"]).compute()
-    
-    stop_times2 = stop_times[
-        stop_times.arrival_sec.notna()
-    ].reset_index(drop=True).astype({"arrival_sec": "int"})
-    
-    return stop_times2
-
-
-def main(analysis_date: str):
-    # Import scheduled stop times
-    stop_times = assemble_stop_times(analysis_date).rename(
-        columns = {"arrival_sec": "scheduled_arrival_sec"})
-    
-    # Import stop arrivals (which has interpolated arrival time)
-    stop_arrivals = pd.read_parquet(
-        f"{SEGMENT_GCS}stop_arrivals_{analysis_date}.parquet",
-        columns = ["trip_instance_key", "stop_sequence", "arrival_time"]
-    ).rename(columns = {"arrival_time": "actual_arrival"})
-
-    trips_with_rt = stop_arrivals.trip_instance_key.unique()
-    
-    stop_arrivals = segment_calcs.convert_timestamp_to_seconds(
-        stop_arrivals, ["actual_arrival"]).drop(columns = "actual_arrival")
-    
-    # Check a rolling window, flag those fail monotonic test
-    stop_arrivals2 = array_utils.rolling_window_make_array(
-        stop_arrivals, 
-        window = 3, rolling_col = "actual_arrival_sec"
+    ).drop(
+        columns = ["feed_key"]
+    ).rename(
+        columns = {"arrival_sec": "scheduled_arrival_sec"}
     )
     
-    stop_arrivals3 = stop_arrivals2[
-        stop_arrivals2.actual_arrival_sec_monotonic==True
-    ].drop(columns = ["rolling_actual_arrival_sec", 
-                      "actual_arrival_sec_monotonic"])
+    return stop_times
+
+
+def prep_rt_stop_times(
+    analysis_date: str
+) -> pd.DataFrame: 
+    """
+    For RT stop arrivals, drop duplicates based on interpolated
+    arrival times. Keep the first arrival time,
+    the rest would violate a monotonically increasing condition.
+    """
+    df = pd.read_parquet(
+        f"{SEGMENT_GCS}rt_stop_times/stop_arrivals_{analysis_date}.parquet",
+        columns = ["trip_instance_key", "stop_sequence", "stop_id",
+                  "arrival_time"]
+    ).rename(columns = {"arrival_time": "rt_arrival"})
+
+    df2 = df.sort_values(
+        ["trip_instance_key", "stop_sequence"]
+    ).drop_duplicates(
+        subset=["trip_instance_key", "rt_arrival"]
+    ).reset_index(drop=True)
     
+    df2 = segment_calcs.convert_timestamp_to_seconds(
+        df2, ["rt_arrival"]
+    ).drop(columns = "rt_arrival")
     
-    # Merge scheduled with RT stop_times, only keep rows with vp
+    return df2
+
+
+def assemble_scheduled_rt_stop_times(
+    analysis_date: str
+) -> pd.DataFrame: 
+    """
+    Merge scheduled and rt stop times so we can compare
+    scheduled arrival (seconds) and RT arrival (seconds).
+    """
+    sched_stop_times = prep_scheduled_stop_times(analysis_date)
+    rt_stop_times = prep_rt_stop_times(analysis_date)
+    
     df = pd.merge(
-        stop_times[stop_times.trip_instance_key.isin(trips_with_rt)],
-        stop_arrivals3,
-        on = ["trip_instance_key", "stop_sequence"],
-        how = "left"
+        sched_stop_times,
+        rt_stop_times,
+        on = ["trip_instance_key", "stop_sequence", "stop_id"],
+        how = "inner"
     )
     
-    df.to_parquet(f"{RT_SCHED_GCS}rt_stop_times_{analysis_date}.parquet")
-    
-    return 
+    return df
 
 
 if __name__ == "__main__":
     
-    from segment_speed_utils.project_vars import analysis_date_list
+    from shared_utils import rt_dates
+    from update_vars import CONFIG_DICT
+    
+    analysis_date_list = rt_dates.get_week("apr2023", exclude_wed=True)
+    
+    EXPORT_FILE = CONFIG_DICT["schedule_rt_stop_times"]
     
     for analysis_date in analysis_date_list:
         
         start = datetime.datetime.now()
         
-        main(analysis_date)
+        df = assemble_scheduled_rt_stop_times(analysis_date)
+        
+        df.to_parquet(f"{RT_SCHED_GCS}{EXPORT_FILE}_{analysis_date}.parquet")
         
         end = datetime.datetime.now()
         print(f"execution time: {analysis_date} {end - start}")

--- a/rt_segment_speeds/scripts/Makefile
+++ b/rt_segment_speeds/scripts/Makefile
@@ -14,14 +14,15 @@ prep_roads:
     
 speeds_pipeline:
 	make segmentize
-	python nearest_vp_to_stop.py
-	python interpolate_stop_arrival.py
-	python stop_arrivals_to_speed.py
+	python pipeline_segment_speeds.py
 	make export
 
 export: 
 	python average_speeds.py  
-    
+
+rt_stop_times_pipeline:
+	python pipeline_rt_stop_times.py
+
 download_roads:
 	#pip install esridump
 	#esri2geojson https://geo.dot.gov/server/rest/services/Hosted/California_2018_PR/FeatureServer/0 ca_roads.geojson

--- a/rt_segment_speeds/scripts/config.yml
+++ b/rt_segment_speeds/scripts/config.yml
@@ -18,8 +18,8 @@ stop_segments:
 rt_stop_times:
     stage1: "vp_usable"
     stage2: "nearest/nearest_vp_rt_stop_times"    
-    stage3: "stop_arrivals_rt_stop_times"  
-    stage4: "speeds_rt_stop_times"
+    stage3: "rt_stop_times/stop_arrivals" 
+    stage4: "rt_stop_times/speeds"
     segments_file: "segment_options/stop_segments"
 road_segments:
     stage1: "vp_usable"

--- a/rt_segment_speeds/scripts/nearest_vp_to_stop.py
+++ b/rt_segment_speeds/scripts/nearest_vp_to_stop.py
@@ -2,155 +2,34 @@
 Find nearest_vp_idx to the stop position 
 using scipy KDTree.
 """
-import dask.dataframe as dd
-import dask_geopandas as dg
 import datetime
 import geopandas as gpd
-import numpy as np
 import pandas as pd
-import shapely
 import sys
 
 from loguru import logger
+from pathlib import Path
+from typing import Literal, Optional
 
 from calitp_data_analysis.geography_utils import WGS84
 from calitp_data_analysis import utils
 from segment_speed_utils import helpers, neighbor
-from segment_speed_utils.project_vars import SEGMENT_GCS
-
-stop_time_col_order = [
-    'trip_instance_key', 'shape_array_key',
-    'stop_sequence', 'stop_id', 'stop_pair',
-    'stop_primary_direction', 'geometry'
-]   
-
-def add_nearest_neighbor_result(
-    gdf: gpd.GeoDataFrame, 
-    analysis_date: str
-) -> pd.DataFrame:
-    """
-    Add the nearest vp_idx. Also add and trio of be the boundary
-    of nearest_vp_idx. Trio provides the vp_idx, timestamp,
-    and vp coords we need to do stop arrival interpolation.
-    """
-    # Grab vp_condensed, which contains all the coords for entire trip
-    vp_full = gpd.read_parquet(
-        f"{SEGMENT_GCS}condensed/vp_condensed_{analysis_date}.parquet",
-        columns = ["trip_instance_key", "vp_idx", 
-                   "location_timestamp_local", 
-                   "geometry"],
-    ).rename(columns = {
-        "vp_idx": "trip_vp_idx",
-        "geometry": "trip_geometry"
-    }).set_geometry("trip_geometry").to_crs(WGS84)
+from segment_speed_utils.project_vars import (SEGMENT_GCS,
+                                              SEGMENT_TYPES,
+                                              CONFIG_PATH)
+  
     
-    gdf2 = pd.merge(
-        gdf,
-        vp_full,
-        on = "trip_instance_key",
-        how = "inner"
-    )
-    
-    del vp_full, gdf
-    
-    nearest_vp_idx_series = []    
-    vp_trio_series = []
-    time_trio_series = []
-    coords_trio_series = []
-    
-    # Iterate through and find the nearest_vp_idx, then surrounding trio
-    nearest_vp_idx = np.vectorize(neighbor.add_nearest_vp_idx)( 
-        gdf2.vp_geometry, gdf2.stop_geometry, gdf2.vp_idx
-    )
-        
-    gdf2 = gdf2.assign(
-        nearest_vp_idx = nearest_vp_idx,
-    ).drop(
-        columns = ["vp_idx", "vp_geometry"]
-    )
-    
-    for row in gdf2.itertuples():
-        vp_trio, time_trio, coords_trio = neighbor.add_trio(
-            getattr(row, "nearest_vp_idx"), 
-            np.asarray(getattr(row, "trip_vp_idx")),
-            np.asarray(getattr(row, "location_timestamp_local")),
-            np.asarray(getattr(row, "trip_geometry").coords),
-        )
-        
-        vp_trio_series.append(vp_trio)
-        time_trio_series.append(time_trio)
-        coords_trio_series.append(shapely.LineString(coords_trio))
-                
-    drop_cols = [
-        "location_timestamp_local",
-        "trip_vp_idx", "trip_geometry"
-    ]
-    
-    gdf2 = gdf2.assign(
-        vp_idx_trio = vp_trio_series,
-        location_timestamp_local_trio = time_trio_series,
-        vp_coords_trio = gpd.GeoSeries(coords_trio_series, crs = WGS84)
-    ).drop(columns = drop_cols)
-    
-    del vp_trio_series, time_trio_series, coords_trio_series
-    
-    return gdf2
-    
-
-def nearest_neighbor_rt_stop_times(
+def stop_times_for_shape_segments(
     analysis_date: str,
     dict_inputs: dict
-):
+) -> gpd.GeoDataFrame:
     """
-    Set up nearest neighbors for RT stop times, which
-    includes all trips. Use stop sequences for each trip.
+    This is the stop times table using only 1 shape for each 
+    route-direction. Every trip belong to that shape
+    will be cut along the same stops.
+    This allows us to aggregate segments across trips because each 
+    segment has the same stop_id1 and stop_id2.
     """
-    start = datetime.datetime.now()
-    EXPORT_FILE = f'{dict_inputs["stage2"]}'
-        
-    stop_times = helpers.import_scheduled_stop_times(
-        analysis_date,
-        columns = ["trip_instance_key", "shape_array_key",
-                   "stop_sequence", "stop_id", "stop_pair", 
-                   "stop_primary_direction",
-                   "geometry"],
-        with_direction = True,
-        get_pandas = True,
-        crs = WGS84
-    ).reindex(columns = stop_time_col_order)
-        
-    gdf = neighbor.merge_stop_vp_for_nearest_neighbor(
-        stop_times, analysis_date)
-        
-    results = add_nearest_neighbor_result(gdf, analysis_date)
-    
-    utils.geoparquet_gcs_export(
-        results,
-        SEGMENT_GCS,
-        f"{EXPORT_FILE}_{analysis_date}",
-    )
-    
-    end = datetime.datetime.now()
-    logger.info(f"RT stop times {analysis_date}: {end - start}")
-    
-    del results
-    
-    return
-
-
-def nearest_neighbor_shape_segments(
-    analysis_date: str,
-    dict_inputs: dict
-):
-    """
-    Set up nearest neighbors for segment speeds, which
-    includes chooses 1 trip's stop sequences for that shape. 
-    That trip, with stop sequences, stop ids from stop_times,
-    is shared across all trips that use that shape_array_key. 
-    """
-    start = datetime.datetime.now()
-
-    EXPORT_FILE = dict_inputs["stage2"]
     SEGMENT_FILE = dict_inputs["segments_file"]
     
     rt_trips = helpers.import_unique_vp_trips(analysis_date)
@@ -182,48 +61,86 @@ def nearest_neighbor_shape_segments(
         how = "inner"
     ).drop(
         columns = "st_trip_instance_key"
-    ).drop_duplicates().reset_index(drop=True).reindex(
-        columns = stop_time_col_order
+    ).drop_duplicates().reset_index(drop=True)
+    
+    return stop_times
+
+
+def stop_times_for_all_trips(
+    analysis_date: str,
+) -> gpd.GeoDataFrame:
+    """
+    This is the stop times table for all trips.
+    We will do nearest neighbors for every stop along a trip.
+    """
+    stop_times = helpers.import_scheduled_stop_times(
+        analysis_date,
+        columns = ["trip_instance_key", "shape_array_key",
+                   "stop_sequence", "stop_id", "stop_pair", 
+                   "stop_primary_direction",
+                   "geometry"],
+        with_direction = True,
+        get_pandas = True,
+        crs = WGS84
     )
     
-    del stops_to_use, shape_stop_combinations
+    return stop_times
+
+
+def nearest_neighbor_for_stop(
+    analysis_date: str,
+    segment_type: Literal[SEGMENT_TYPES],
+    config_path: Optional[Path] = CONFIG_PATH
+):
+    """
+    Set up nearest neighbors for RT stop times, which
+    includes all trips. Use stop sequences for each trip.
+    """
+    
+    dict_inputs = helpers.get_parameters(config_path, segment_type)
+    
+    start = datetime.datetime.now()
+    EXPORT_FILE = f'{dict_inputs["stage2"]}'
+    
+    stop_time_col_order = [
+        'trip_instance_key', 'shape_array_key',
+        'stop_sequence', 'stop_id', 'stop_pair',
+        'stop_primary_direction', 'geometry'
+    ] 
+    
+    if segment_type == "stop_segments":
+        stop_times = stop_times_for_shape_segments(analysis_date, dict_inputs)
+    
+    elif segment_type == "rt_stop_times":
+        stop_times = stop_times_for_all_trips(analysis_date)
+    
+    else:
+        print(f"{segment_type} is not valid")
+    
+    stop_times = stop_times.reindex(columns = stop_time_col_order)
     
     gdf = neighbor.merge_stop_vp_for_nearest_neighbor(
         stop_times, analysis_date)
+        
+    results = neighbor.add_nearest_neighbor_result(gdf, analysis_date)
     
-    results = add_nearest_neighbor_result(gdf, analysis_date)
-    
-    del stop_times, gdf
-
     utils.geoparquet_gcs_export(
         results,
         SEGMENT_GCS,
         f"{EXPORT_FILE}_{analysis_date}",
     )
     
+    
     end = datetime.datetime.now()
-    logger.info(
-        f"shape segments {analysis_date}: {end - start}")
+    logger.info(f"nearest neighbor for {segment_type} "
+                f"{analysis_date}: {end - start}")
     
-    del results
-    
-    return 
-
+    return
     
 if __name__ == "__main__":
-    
-    from segment_speed_utils.project_vars import analysis_date_list, CONFIG_PATH
-    
+        
     LOG_FILE = "../logs/nearest_vp.log"
     logger.add(LOG_FILE, retention="3 months")
     logger.add(sys.stderr, 
                format="{time:YYYY-MM-DD at HH:mm:ss} | {level} | {message}", 
-               level="INFO")
-    
-    STOP_SEG_DICT = helpers.get_parameters(CONFIG_PATH, "stop_segments")
-    RT_STOP_TIMES_DICT = helpers.get_parameters(CONFIG_PATH, "rt_stop_times")
-    
-    for analysis_date in analysis_date_list:
-        nearest_neighbor_shape_segments(analysis_date, STOP_SEG_DICT)
-        #nearest_neighbor_rt_stop_times(analysis_date, RT_STOP_TIMES_DICT)
-                               
+               level="INFO")                           

--- a/rt_segment_speeds/scripts/pipe.py
+++ b/rt_segment_speeds/scripts/pipe.py
@@ -1,0 +1,45 @@
+"""
+Wrapper function over
+nearest_vp_to_stop.py, 
+interpolate_stop_arrivals.py,
+and calculate_speed_from_stop_arrivals.py
+"""
+from pathlib import Path
+from typing import Literal, Optional
+
+from nearest_vp_to_stop import nearest_neighbor_for_stop
+from interpolate_stop_arrival import interpolate_stop_arrivals
+from stop_arrivals_to_speed import calculate_speed_from_stop_arrivals
+
+from segment_speed_utils.project_vars import CONFIG_PATH, SEGMENT_TYPES
+
+def nearest_neigbor_to_speed(
+    analysis_date,
+    segment_type: Literal[SEGMENT_TYPES],
+    config_path: Optional[Path] = CONFIG_PATH
+):
+    """
+    Wrapper function calling nearest neighbor, 
+    stop arrival interpolation and monotonicity,
+    interpolation of stop arrival, deriving segment speeds 
+    between stops.
+    """
+    nearest_neighbor_for_stop(
+        analysis_date = analysis_date,
+        segment_type = segment_type,
+        config_path = config_path
+    )    
+
+    interpolate_stop_arrivals(
+        analysis_date = analysis_date, 
+        segment_type = segment_type, 
+        config_path = config_path
+    )
+
+    calculate_speed_from_stop_arrivals(
+        analysis_date = analysis_date, 
+        segment_type = segment_type,
+        config_path = config_path
+    )
+
+    return

--- a/rt_segment_speeds/scripts/pipeline_rt_stop_times.py
+++ b/rt_segment_speeds/scripts/pipeline_rt_stop_times.py
@@ -1,0 +1,22 @@
+"""
+Run nearest_vp_to_stop.py, 
+interpolate_stop_arrivals.py,
+and calculate_speed_from_stop_arrivals.py for rt_stop_times.
+"""
+from pipe import nearest_neigbor_to_speed
+segment_type = "rt_stop_times"
+
+if __name__ == "__main__":
+    
+    from segment_speed_utils.project_vars import analysis_date_list
+    
+    print(f"segment_type: {segment_type}")
+    
+    for analysis_date in analysis_date_list:
+
+        nearest_neigbor_to_speed(
+            analysis_date = analysis_date,
+            segment_type = segment_type
+        )    
+        
+       

--- a/rt_segment_speeds/scripts/pipeline_segment_speeds.py
+++ b/rt_segment_speeds/scripts/pipeline_segment_speeds.py
@@ -1,0 +1,22 @@
+"""
+Run nearest_vp_to_stop.py, 
+interpolate_stop_arrivals.py,
+and calculate_speed_from_stop_arrivals.py for stop_segments.
+"""
+from pipe import nearest_neigbor_to_speed
+segment_type = "stop_segments"
+
+if __name__ == "__main__":
+    
+    from segment_speed_utils.project_vars import analysis_date_list
+    
+    print(f"segment_type: {segment_type}")
+    
+    for analysis_date in analysis_date_list:
+
+        nearest_neigbor_to_speed(
+            analysis_date = analysis_date,
+            segment_type = segment_type
+        )    
+
+       

--- a/rt_segment_speeds/scripts/stop_arrivals_to_speed.py
+++ b/rt_segment_speeds/scripts/stop_arrivals_to_speed.py
@@ -6,13 +6,20 @@ import pandas as pd
 import sys
 
 from loguru import logger
+from pathlib import Path
+from typing import Literal, Optional
 
-from segment_speed_utils import helpers, gtfs_schedule_wrangling, segment_calcs
-from segment_speed_utils.project_vars import SEGMENT_GCS, CONFIG_PATH
+from segment_speed_utils import (helpers, 
+                                 gtfs_schedule_wrangling, 
+                                 segment_calcs)
+from segment_speed_utils.project_vars import (SEGMENT_GCS,
+                                              CONFIG_PATH,
+                                              SEGMENT_TYPES)
 
 def attach_operator_natural_identifiers(
     df: pd.DataFrame, 
-    analysis_date: str
+    analysis_date: str,
+    segment_type: Literal["stop_segments", "rt_stop_times"]
 ) -> pd.DataFrame:
     """
     For each gtfs_dataset_key-shape_array_key combination,
@@ -41,30 +48,49 @@ def attach_operator_natural_identifiers(
     ).rename(
         columns = {"time_of_day": "vp_time_of_day"})
     
-    
-    trip_used_for_shape = pd.read_parquet(
-        f"{SEGMENT_GCS}segment_options/"
-        f"shape_stop_segments_{analysis_date}.parquet",
-        columns = ["st_trip_instance_key"]
-    ).st_trip_instance_key.unique()
-    
-    stop_pair = helpers.import_scheduled_stop_times(
-        analysis_date,
-        filters = [[("trip_instance_key", "in", trip_used_for_shape)]],
-        columns = ["shape_array_key", "stop_sequence", "stop_pair"],
-        with_direction = True,
-        get_pandas = True
-    )
-    
     df_with_natural_ids = pd.merge(
         df,
         shape_identifiers,
         on = "shape_array_key",
         how = "inner"
-    ).merge(
-        stop_pair,
-        on = ["shape_array_key", "stop_sequence"]
-    ).merge(
+    )
+    
+    
+    if segment_type == "stop_segments":
+        trip_used_for_shape = pd.read_parquet(
+            f"{SEGMENT_GCS}segment_options/"
+            f"shape_stop_segments_{analysis_date}.parquet",
+            columns = ["st_trip_instance_key"]
+        ).st_trip_instance_key.unique()
+
+        stop_pair = helpers.import_scheduled_stop_times(
+            analysis_date,
+            filters = [[("trip_instance_key", "in", trip_used_for_shape)]],
+            columns = ["shape_array_key", "stop_sequence", "stop_pair"],
+            with_direction = True,
+            get_pandas = True
+        )
+        
+        df_with_natural_ids = df_with_natural_ids.merge(
+            stop_pair,
+            on = ["shape_array_key", "stop_sequence"]
+        )
+    
+    elif segment_type == "rt_stop_times":
+        stop_pair = helpers.import_scheduled_stop_times(
+            analysis_date,
+            columns = ["trip_instance_key", "stop_sequence", "stop_pair"],
+            with_direction = True,
+            get_pandas = True
+        )
+        
+        df_with_natural_ids = df_with_natural_ids.merge(
+            stop_pair,
+            on = ["trip_instance_key", "stop_sequence"]
+        )
+        
+
+    df_with_natural_ids = df_with_natural_ids.merge(
         sched_time_of_day,
         on = "trip_instance_key",
         how = "left"
@@ -86,17 +112,19 @@ def attach_operator_natural_identifiers(
 
 def calculate_speed_from_stop_arrivals(
     analysis_date: str, 
-    dict_inputs: dict
+    segment_type: Literal[SEGMENT_TYPES],
+    config_path: Optional[Path] = CONFIG_PATH,
 ):
     """
     Calculate speed between the interpolated stop arrivals of 
     2 stops. Use current stop to subsequent stop, to match
     with the segments cut by gtfs_segments.create_segments
     """
-    
+    dict_inputs = helpers.get_parameters(config_path, segment_type)
+
     STOP_ARRIVALS_FILE = f"{dict_inputs['stage3']}_{analysis_date}"
     SPEED_FILE = f"{dict_inputs['stage4']}_{analysis_date}"
-        
+    
     start = datetime.datetime.now()
     
     df = pd.read_parquet(
@@ -132,29 +160,25 @@ def calculate_speed_from_stop_arrivals(
         ("arrival_time_sec", "subseq_arrival_time_sec")
     ).pipe(
         attach_operator_natural_identifiers, 
-        analysis_date
+        analysis_date, 
+        segment_type
     )
         
     speed.to_parquet(
         f"{SEGMENT_GCS}{SPEED_FILE}.parquet")
     
     end = datetime.datetime.now()
-    logger.info(f"speeds by segment: {analysis_date}: {end - start}")
-
+    logger.info(f"speeds by segment for {segment_type} "
+                f"{analysis_date}: {end - start}")
+    
+    
     return
 
 
 if __name__ == "__main__":
-    
-    from segment_speed_utils.project_vars import analysis_date_list
     
     LOG_FILE = "../logs/speeds_by_segment_trip.log"
     logger.add(LOG_FILE, retention="3 months")
     logger.add(sys.stderr, 
                format="{time:YYYY-MM-DD at HH:mm:ss} | {level} | {message}", 
                level="INFO")
-        
-    STOP_SEG_DICT = helpers.get_parameters(CONFIG_PATH, "stop_segments")
-    
-    for analysis_date in analysis_date_list:
-        calculate_speed_from_stop_arrivals(analysis_date, STOP_SEG_DICT)


### PR DESCRIPTION
## rt vs schedule
* Follow-up to #954 
* Now that we use nearest neighbors approach, adapt scripts to run in a way that we can input `segment_type="rt_stop_times"` or `segment_type = "stop_segments"` 
   * `rt_stop_times` shares the `nearest_vp_to_stop`, `interpolate_stop_arrivals` and `stop_arrivals_to_speeds` scripts
   * from getting stop arrivals, then merge it onto scheduled stop times data , so we have columns for scheduled arrival vs RT arrival time (seconds)
* Fill in all dates from 2023 and 2024, including oct2023 week and apr2023 week
* Spend some time trying out `typer` and `click`, which are packages that improve upon `argparse`, but haven't figured out an approach that can inject an analysis date within a loop and via CLI.
   *  Use `pipe.py` to wrap the function and we'll just set the segment type in `pipeline_segment_speeds` and `pipeline_rt_stop_times`.
* Add notebook looking at how many trips on a day are schedule only / schedule_and_vp / vp_only for Thomas Craig's request (Washington State WSDOT)
* #824