### PR TITLE
github repo workflow changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,7 +6,7 @@ labels: ["bug", "admin"]
 assignees: ''
 ---
 **Where did the bug occur?**
-Select from the below, and be sure to affix the appropriate label to this issue (e.g. `dataset`, `jupyterhub`, `metabase`, `analytics.calitp.org`)
+Select from the below, and be sure to affix the appropriate label to this issue (e.g. `dataset`, `jupyterhub`, `metabase`, `analysis.calitp.org`)
 - [ ] Data (the warehouse)
 - [ ] JupyterHub
 - [ ] Metabase

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report - Data or Tooling
 about: Create a report to help us improve our warehouse or our analytics tooling.
-title: 'Bug: : [description]'
+title: 'Bug: [description]'
 labels: ["bug", "admin"]
 assignees: ''
 ---
@@ -10,7 +10,7 @@ Select from the below, and be sure to affix the appropriate label to this issue 
 - [ ] Data (the warehouse)
 - [ ] JupyterHub
 - [ ] Metabase
-- [ ] analytics.calitp.org  
+- [ ] analysis.calitp.org  
 - [ ] Other (add detail)
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,7 +1,7 @@
 ---
 name: Docs - Edits or Additions
 about: For making changes or additions to the data services analytics documentation.
-title: 'Docs: : [description]'
+title: 'Docs: [description]'
 labels: 'documentation'
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -11,7 +11,7 @@ Select from the below, and be sure to affix the appropriate label to this issue 
 - [ ] Data (the warehouse)
 - [ ] JupyterHub
 - [ ] Metabase
-- [ ] analytics.calitp.org  
+- [ ] analysis.calitp.org  
 - [ ] Other (add detail)
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 **Where does your feature apply?**
-Select from the below, and be sure to affix the appropriate label to this issue (e.g. `dataset`, `jupyterhub`, `metabase`, `analytics.calitp.org`)
+Select from the below, and be sure to affix the appropriate label to this issue (e.g. `dataset`, `jupyterhub`, `metabase`, `analysis.calitp.org`)
 - [ ] Data (the warehouse)
 - [ ] JupyterHub
 - [ ] Metabase

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -49,7 +49,7 @@ jobs:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
     - name: Add netlify link PR comment
-      uses: actions/github-script@v3
+      uses: actions/github-script@v7
       if: ${{ github.event_name == 'pull_request' }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -33,8 +33,9 @@ jobs:
     - name: Netlify docs preview
       if: ${{ github.ref != 'refs/heads/main' }}
       run: |
-        npm install -g netlify-cli
+        npm install -g netlify-cli@17.x.x
         python portfolio/portfolio.py index --deploy --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER}
+
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         PR_NUMBER: ${{ github.event.number }}
@@ -42,7 +43,7 @@ jobs:
     - name: Netlify docs production
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
-        npm install -g netlify-cli
+        npm install -g netlify-cli@17.x.x
         python portfolio/portfolio.py index --deploy --prod
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install python packages
       run: |

--- a/portfolio/requirements.txt
+++ b/portfolio/requirements.txt
@@ -1,8 +1,8 @@
-papermill==2.3.4
-#nbformat==5.1.3
-#typer==0.4.1
+papermill~=2.4
+nbformat~=5.8
+typer~=0.9
 jupyter-book==1.0.0
 python-slugify==6.1.1
 pyaml==21.10.1
-humanize==4.2.3
-#pydantic==1.10.5
+humanize~=4.6
+pydantic~=1.9


### PR DESCRIPTION
* Attempt to resolve #1053 
   * Manually turning on GH action does not actually get this working
   * Needs a `netlify build` statement, but when running `python portfolio/portfolio.py`, it looks like it's looking for a template within a folder. Given that we no longer check in files to GH, and use LFS, there's no actual `_build` files to find
   * Investigate more [these lines](https://github.com/cal-itp/data-analyses/blob/main/portfolio/portfolio.py#L318-L319)...what will happen if we change it to `./portfolio/{template}`?:
```
for template in ["index.html", "_redirects"]:
        fname = f"./portfolio/index/{template}"
```
* Pin `netlify cli`
* Fix some typos in our templated issues, `analytics.calitp.org` -> `analysis.calitp.org` and remove extra colons