### PR TITLE
March hqta rerun 

### DIFF
--- a/high_quality_transit_areas/B1_create_hqta_segments.py
+++ b/high_quality_transit_areas/B1_create_hqta_segments.py
@@ -112,7 +112,7 @@ def select_shapes_and_segment(
     gdf = gtfs_schedule_wrangling.longest_shape_by_route_direction(
         analysis_date
     ).query(
-        'shape_array_key not in @outside_ca_amtrak_shapes'
+        'shape_array_key not in @outside_amtrak_shapes'
     ).drop(
         columns = ["schedule_gtfs_dataset_key", 
                    "shape_array_key", "route_length"]

--- a/high_quality_transit_areas/Makefile
+++ b/high_quality_transit_areas/Makefile
@@ -7,4 +7,9 @@ hqta_data:
 	python C3_create_bus_hqta_types.py
 	python D1_assemble_hqta_points.py
 	python D2_assemble_hqta_polygons.py 
-    
+
+# Only need this is operator input changes
+# For now, Muni sent over a date-versioned list of stops
+# they want included as BRT
+add_operator_input:
+	python operator_input.py

--- a/high_quality_transit_areas/logs/hqta_processing.log
+++ b/high_quality_transit_areas/logs/hqta_processing.log
@@ -79,3 +79,11 @@
 2024-03-14 11:56:55.334 | INFO     | __main__:<module>:163 - C3_create_bus_hqta_types 2024-03-13 execution time: 0:00:27.390021
 2024-03-14 12:12:21.763 | INFO     | __main__:<module>:295 - D1_assemble_hqta_points 2024-03-13 execution time: 0:00:26.480160
 2024-03-14 12:13:12.687 | INFO     | __main__:<module>:167 - D2_assemble_hqta_polygons 2024-03-13 execution time: 0:00:29.033860
+2024-03-21 11:54:40.930 | INFO     | __main__:<module>:354 - A1_rail_ferry_brt_stops 2024-03-13 execution time: 0:00:51.987419
+2024-03-21 12:01:28.365 | INFO     | __main__:<module>:249 - B1_create_hqta_segments execution time: 0:03:02.428114
+2024-03-21 12:02:23.099 | INFO     | __main__:<module>:256 - B2_sjoin_stops_to_segments 2024-03-13 execution time: 0:00:35.845848
+2024-03-21 12:02:46.911 | INFO     | __main__:<module>:142 - C1_prep_pairwise_intersections 2024-03-13 execution time: 0:00:05.864652
+2024-03-21 12:03:24.770 | INFO     | __main__:<module>:125 - C2_find_intersections 2024-03-13 execution time: 0:00:21.158652
+2024-03-21 12:04:01.449 | INFO     | __main__:<module>:163 - C3_create_bus_hqta_types 2024-03-13 execution time: 0:00:19.553787
+2024-03-21 12:04:42.807 | INFO     | __main__:<module>:295 - D1_assemble_hqta_points 2024-03-13 execution time: 0:00:22.988739
+2024-03-21 12:05:20.102 | INFO     | __main__:<module>:167 - D2_assemble_hqta_polygons 2024-03-13 execution time: 0:00:19.166756

--- a/high_quality_transit_areas/muni_brt.ipynb
+++ b/high_quality_transit_areas/muni_brt.ipynb
@@ -53,8 +53,7 @@
     "import pandas as pd\n",
     "\n",
     "from segment_speed_utils import helpers\n",
-    "from update_vars import analysis_date\n",
-    "from utilities import GCS_FILE_PATH\n",
+    "from update_vars import analysis_date, GCS_FILE_PATH\n",
     "\n",
     "analysis_date"
    ]

--- a/high_quality_transit_areas/operator_input.py
+++ b/high_quality_transit_areas/operator_input.py
@@ -1,0 +1,30 @@
+"""
+Script to save any custom operator request
+to include in our workflow.
+For now, this is Muni's list of bus stops to include
+as BRT.
+Initially, we tagged all of the routes on which
+these stops took place, but that flagged over 1_000 stops
+as major_stop_brt.
+Here, it's just 136 stops.
+"""
+import pandas as pd
+
+from update_vars import GCS_FILE_PATH
+
+if __name__ == "__main__":
+    FILE = "SFMTA_muni_high_quality_transit_stops_2024-02-01.csv"
+
+    muni_stops = (
+        pd.read_csv(f"{GCS_FILE_PATH}operator_input/{FILE}", 
+                    dtype={"bs_id": "str"})
+        .drop(columns=["latitude", "longitude"])
+        .rename(columns={"bs_id": "stop_id"})
+    )
+    
+    muni_stops.to_parquet(
+        f"{GCS_FILE_PATH}operator_input/"
+        f"muni_brt_stops.parquet"
+    )
+    
+    print(f"saved muni stops")


### PR DESCRIPTION
## open data
* Rerun hqta because too many Muni stops are being tagged as BRT
* Filtering by routes leaves over 1,000 stops as `major_stop_brt`, so instead, add a script that takes the input of the stops Muni wants and filter against that
* Overwrite the public GCS url for that file too. Depending on when our existing ticket gets fulfilled...it may show up or with this change or not
* #991 