### PR TITLE
Cardinal Direction 

### DIFF
--- a/gtfs_digest/19_cardinal_dir_round2.ipynb
+++ b/gtfs_digest/19_cardinal_dir_round2.ipynb
@@ -8,10 +8,10 @@
     "## Improving Cardinal Direction work\n",
     "* Responding to comments on [PR 1145](https://github.com/cal-itp/data-analyses/pull/1145)\n",
     "\n",
-    "* 6/19\n",
+    "* 6/25\n",
     "    * I experimented with not filling in the nans in `direction_id`.\n",
-    "    * When I did fill in the nans, I got \"10,489\" rows found in both datafarmes and \"745\" found in \"right_only\"\n",
-    "    * When I didn't, I got a curious result. These two don't match?\n",
+    "    * When I did fill in the nans, I got \"10,489\" rows found in both datafarmes and \"745\" found in \"right_only\". The result from `schedule_metrics_by_route_direction` is 10,489 rows. \n",
+    "    * When I didn't fill in the nans, I got a curious result. The dataframe produced by `schedule_metrics_by_route_direction` is 10,486 rows. These two don't match?\n",
     "    _merge    \n",
     "    both          10486\n",
     "    right_only      615\n",
@@ -104,10 +104,9 @@
     "    ]\n",
     "        \n",
     "    trips_df = helpers.import_scheduled_trips(analysis_date, \n",
-    "                                              columns = trip_scheduled_col,\n",
+    "                                             columns = trip_scheduled_col,\n",
     "                                             get_pandas = True)\n",
     "\n",
-    "    \n",
     "    \n",
     "    # Merge dfs\n",
     "    merge_cols = [\"trip_instance_key\", \n",
@@ -118,16 +117,17 @@
     "    \n",
     "    # Fill in missing direction id with 0, per our usual practice.\n",
     "    print(f\"# of nulls for direction_id: {stop_times_with_trip['direction_id'].isna().sum()}\")\n",
-    "    #stop_times_with_trip.direction_id = stop_times_with_trip.direction_id.fillna(0)\n",
+    "    stop_times_with_trip.direction_id = stop_times_with_trip.direction_id.fillna(0)\n",
+    "    \n",
+    "    main_cols = [\n",
+    "        \"route_id\",\n",
+    "        \"schedule_gtfs_dataset_key\",\n",
+    "        \"direction_id\"\n",
+    "    ]\n",
     "    \n",
     "    agg1 = (\n",
     "        stop_times_with_trip.groupby(\n",
-    "            [\n",
-    "                \"route_id\",\n",
-    "                \"schedule_gtfs_dataset_key\",\n",
-    "                \"direction_id\",\n",
-    "                \"stop_primary_direction\",\n",
-    "            ]\n",
+    "            main_cols + [\"stop_primary_direction\"]\n",
     "        )\n",
     "        .agg({\"stop_sequence\": \"count\"})\n",
     "        .reset_index()\n",
@@ -137,20 +137,12 @@
     "    # Sort and drop duplicates so that the\n",
     "    # largest # of stops by stop_primary_direction is at the top\n",
     "    agg2 = agg1.sort_values(\n",
-    "        by=[\"route_id\", \n",
-    "            \"schedule_gtfs_dataset_key\",\n",
-    "            \"direction_id\",\n",
-    "            \"total_stops\"],\n",
+    "        by= main_cols + [\"total_stops\"],\n",
     "        ascending=[True, True, True, False],\n",
     "    )\n",
     "    \n",
     "    # Drop duplicates so only the top stop_primary_direction is kept.\n",
-    "    agg3 = agg2.drop_duplicates(\n",
-    "    subset=[\n",
-    "        \"route_id\",\n",
-    "        \"schedule_gtfs_dataset_key\",\n",
-    "        \"direction_id\",\n",
-    "    ]).reset_index(drop=True)\n",
+    "    agg3 = agg2.drop_duplicates(subset= main_cols).reset_index(drop=True)\n",
     "    \n",
     "    agg3 = agg3.drop(columns=[\"total_stops\"])\n",
     "    return agg3"
@@ -283,16 +275,16 @@
      "output_type": "stream",
      "text": [
       "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 4345 entries, 0 to 4344\n",
+      "RangeIndex: 4475 entries, 0 to 4474\n",
       "Data columns (total 4 columns):\n",
       " #   Column                     Non-Null Count  Dtype  \n",
       "---  ------                     --------------  -----  \n",
-      " 0   route_id                   4345 non-null   object \n",
-      " 1   schedule_gtfs_dataset_key  4345 non-null   object \n",
-      " 2   direction_id               4345 non-null   float64\n",
-      " 3   stop_primary_direction     4345 non-null   object \n",
+      " 0   route_id                   4475 non-null   object \n",
+      " 1   schedule_gtfs_dataset_key  4475 non-null   object \n",
+      " 2   direction_id               4475 non-null   float64\n",
+      " 3   stop_primary_direction     4475 non-null   object \n",
       "dtypes: float64(1), object(3)\n",
-      "memory usage: 135.9+ KB\n"
+      "memory usage: 140.0+ KB\n"
      ]
     }
    ],
@@ -318,37 +310,7 @@
    "execution_count": 9,
    "id": "3d96173d-216b-4e36-a3ff-ac5b17d5e26e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "Int64Index: 104941 entries, 0 to 104940\n",
-      "Data columns (total 7 columns):\n",
-      " #   Column                     Non-Null Count   Dtype  \n",
-      "---  ------                     --------------   -----  \n",
-      " 0   schedule_gtfs_dataset_key  104941 non-null  object \n",
-      " 1   trip_instance_key          104941 non-null  object \n",
-      " 2   median_stop_meters         104937 non-null  float64\n",
-      " 3   time_of_day                104941 non-null  object \n",
-      " 4   scheduled_service_minutes  104941 non-null  float64\n",
-      " 5   route_id                   104941 non-null  object \n",
-      " 6   direction_id               95044 non-null   float64\n",
-      "dtypes: float64(3), object(4)\n",
-      "memory usage: 6.4+ MB\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "None"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "trip_metrics = schedule_stats_by_route_direction.assemble_scheduled_trip_metrics(analysis_date, GTFS_DATA_DICT)\n",
     "trip_metrics = trip_metrics.rename(columns = {\"stop_primary_direction\":\"route_primary_direction\"})"
@@ -392,28 +354,28 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>37780</th>\n",
-       "      <td>7cc0cb1871dfd558f11a2885c145d144</td>\n",
-       "      <td>2fd67215db5942ad0944e3457757e9b7</td>\n",
-       "      <td>429.92</td>\n",
-       "      <td>AM Peak</td>\n",
-       "      <td>41.00</td>\n",
-       "      <td>M</td>\n",
-       "      <td>0.00</td>\n",
+       "      <th>4687</th>\n",
+       "      <td>1ebafaca8716652559b2017b6eedc4ef</td>\n",
+       "      <td>3b05e38bba586be01828035921b806e1</td>\n",
+       "      <td>367.87</td>\n",
+       "      <td>PM Peak</td>\n",
+       "      <td>29.00</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "              schedule_gtfs_dataset_key                 trip_instance_key  \\\n",
-       "37780  7cc0cb1871dfd558f11a2885c145d144  2fd67215db5942ad0944e3457757e9b7   \n",
+       "             schedule_gtfs_dataset_key                 trip_instance_key  \\\n",
+       "4687  1ebafaca8716652559b2017b6eedc4ef  3b05e38bba586be01828035921b806e1   \n",
        "\n",
-       "       median_stop_meters time_of_day  scheduled_service_minutes route_id  \\\n",
-       "37780              429.92     AM Peak                      41.00        M   \n",
+       "      median_stop_meters time_of_day  scheduled_service_minutes route_id  \\\n",
+       "4687              367.87     PM Peak                      29.00        2   \n",
        "\n",
-       "       direction_id  \n",
-       "37780          0.00  "
+       "      direction_id  \n",
+       "4687          1.00  "
       ]
      },
      "execution_count": 10,
@@ -432,13 +394,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "route_group_cols = [\n",
-    "            \"schedule_gtfs_dataset_key\", \n",
-    "            \"route_id\", \n",
-    "            \"direction_id\"\n",
-    "        ]\n",
-    "        \n",
-    "route_merge_cols = [\n",
+    "\n",
+    "route_merge_group_cols = [\n",
     "            \"schedule_gtfs_dataset_key\", \n",
     "            \"route_id\", \n",
     "            \"direction_id\",\n",
@@ -452,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "route = schedule_stats_by_route_direction.schedule_metrics_by_route_direction(trip_metrics, analysis_date,route_group_cols, route_merge_cols)\n",
+    "route = schedule_stats_by_route_direction.schedule_metrics_by_route_direction(trip_metrics, analysis_date,route_merge_group_cols)\n",
     "        "
    ]
   },
@@ -497,17 +454,17 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4150</th>\n",
-       "      <td>ecd018ad66f497fb8f188ed5a71b284b</td>\n",
-       "      <td>453</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0821</td>\n",
-       "      <td>Orange Transportation Center - St Joseph Hospital via Chapman/Main/La Veta</td>\n",
-       "      <td>20.00</td>\n",
-       "      <td>0.25</td>\n",
-       "      <td>7</td>\n",
+       "      <th>8857</th>\n",
+       "      <td>4c6b107352b318297bb39173c796f357</td>\n",
+       "      <td>3822</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>20470</td>\n",
+       "      <td>HUGHES/MCKINLEY</td>\n",
+       "      <td>51.73</td>\n",
+       "      <td>0.23</td>\n",
+       "      <td>33</td>\n",
        "      <td>all_day</td>\n",
-       "      <td>0.29</td>\n",
+       "      <td>1.38</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -515,16 +472,13 @@
       ],
       "text/plain": [
        "             schedule_gtfs_dataset_key route_id  direction_id common_shape_id  \\\n",
-       "4150  ecd018ad66f497fb8f188ed5a71b284b      453          0.00            0821   \n",
+       "8857  4c6b107352b318297bb39173c796f357     3822          1.00           20470   \n",
        "\n",
-       "                                                                      route_name  \\\n",
-       "4150  Orange Transportation Center - St Joseph Hospital via Chapman/Main/La Veta   \n",
+       "           route_name  avg_scheduled_service_minutes  avg_stop_miles  n_trips  \\\n",
+       "8857  HUGHES/MCKINLEY                          51.73            0.23       33   \n",
        "\n",
-       "      avg_scheduled_service_minutes  avg_stop_miles  n_trips time_period  \\\n",
-       "4150                          20.00            0.25        7     all_day   \n",
-       "\n",
-       "      frequency  \n",
-       "4150       0.29  "
+       "     time_period  frequency  \n",
+       "8857     all_day       1.38  "
       ]
      },
      "execution_count": 13,
@@ -538,63 +492,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "f72635ac-3157-4ef2-9988-196539b7c854",
+   "execution_count": 14,
+   "id": "0628ec12-085b-424c-96f4-00b0340f6e5a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "_merge    \n",
-       "both          10486\n",
-       "right_only      615\n",
-       "left_only         0\n",
-       "dtype: int64"
+       "10489"
       ]
      },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd.merge(\n",
-    "            route,\n",
-    "            test,\n",
-    "            on = route_merge_cols,\n",
-    "            how = \"outer\",\n",
-    "            indicator = True\n",
-    "        )[[\"_merge\"]].value_counts(dropna=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "ee7d97ff-0408-49b0-a59d-612aa4011861",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "route2= pd.merge(\n",
-    "            route,\n",
-    "            test,\n",
-    "            on = route_merge_cols,\n",
-    "            how = \"left\"\n",
-    "        )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "18c7d2f4-6926-43f4-95b0-9919d3a7cc70",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "10486"
-      ]
-     },
-     "execution_count": 19,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -605,7 +513,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
+   "id": "f72635ac-3157-4ef2-9988-196539b7c854",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "both          10489\n",
+       "right_only      745\n",
+       "left_only         0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "            route,\n",
+    "            test,\n",
+    "            on = route_merge_group_cols,\n",
+    "            how = \"outer\",\n",
+    "            indicator = True\n",
+    "        )[[\"_merge\"]].value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ee7d97ff-0408-49b0-a59d-612aa4011861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route2= pd.merge(\n",
+    "            route,\n",
+    "            test,\n",
+    "            on = route_merge_group_cols,\n",
+    "            how = \"left\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "18c7d2f4-6926-43f4-95b0-9919d3a7cc70",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10489"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(route2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "id": "12843bf6-771c-44d4-bec6-1558c1b04f89",
    "metadata": {},
    "outputs": [
@@ -645,46 +620,46 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>3969</th>\n",
-       "      <td>8eecb796518dafd3c1b971a99f8b8252</td>\n",
-       "      <td>3205</td>\n",
+       "      <th>899</th>\n",
+       "      <td>7891c0d5e91c8dccf88536129dbac084</td>\n",
+       "      <td>B</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>7612</td>\n",
-       "      <td>Apple Valley - Lucerne Valley</td>\n",
-       "      <td>47.88</td>\n",
-       "      <td>0.79</td>\n",
-       "      <td>5</td>\n",
+       "      <td>96</td>\n",
+       "      <td></td>\n",
+       "      <td>46.92</td>\n",
+       "      <td>0.22</td>\n",
+       "      <td>7</td>\n",
        "      <td>peak</td>\n",
-       "      <td>0.62</td>\n",
-       "      <td>Eastbound</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4034</th>\n",
-       "      <td>ecd018ad66f497fb8f188ed5a71b284b</td>\n",
-       "      <td>400</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>4001</td>\n",
-       "      <td>John Wayne Airport - Tustin Metrolink via Jamboree</td>\n",
-       "      <td>26.00</td>\n",
-       "      <td>0.25</td>\n",
-       "      <td>10</td>\n",
-       "      <td>peak</td>\n",
-       "      <td>1.25</td>\n",
+       "      <td>0.88</td>\n",
        "      <td>Southbound</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6229</th>\n",
-       "      <td>55a01ef72af21906934ae8ffb4786e86</td>\n",
-       "      <td>200X</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>83</td>\n",
-       "      <td>Martinez / Pittsburg</td>\n",
-       "      <td>44.50</td>\n",
-       "      <td>0.88</td>\n",
-       "      <td>6</td>\n",
+       "      <th>4694</th>\n",
+       "      <td>ecb6e412d4745e9ebbfb9df814e336f2</td>\n",
+       "      <td>353</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>3530028</td>\n",
+       "      <td>Escondido to Nordahl Market Pl via Citracado</td>\n",
+       "      <td>21.40</td>\n",
+       "      <td>0.20</td>\n",
+       "      <td>15</td>\n",
        "      <td>all_day</td>\n",
-       "      <td>0.25</td>\n",
-       "      <td>Eastbound</td>\n",
+       "      <td>0.62</td>\n",
+       "      <td>Westbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9521</th>\n",
+       "      <td>7dbe3e19a4966e0c0531fa826e0446d8</td>\n",
+       "      <td>525</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>33383</td>\n",
+       "      <td>DTC-Main-Myrtle-Oro</td>\n",
+       "      <td>16.76</td>\n",
+       "      <td>0.22</td>\n",
+       "      <td>11</td>\n",
+       "      <td>offpeak</td>\n",
+       "      <td>0.69</td>\n",
+       "      <td>Westbound</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -692,33 +667,260 @@
       ],
       "text/plain": [
        "             schedule_gtfs_dataset_key route_id  direction_id common_shape_id  \\\n",
-       "3969  8eecb796518dafd3c1b971a99f8b8252     3205          0.00            7612   \n",
-       "4034  ecd018ad66f497fb8f188ed5a71b284b      400          1.00            4001   \n",
-       "6229  55a01ef72af21906934ae8ffb4786e86     200X          0.00              83   \n",
+       "899   7891c0d5e91c8dccf88536129dbac084        B          0.00              96   \n",
+       "4694  ecb6e412d4745e9ebbfb9df814e336f2      353          1.00         3530028   \n",
+       "9521  7dbe3e19a4966e0c0531fa826e0446d8      525          0.00           33383   \n",
        "\n",
-       "                                              route_name  \\\n",
-       "3969                       Apple Valley - Lucerne Valley   \n",
-       "4034  John Wayne Airport - Tustin Metrolink via Jamboree   \n",
-       "6229                                Martinez / Pittsburg   \n",
+       "                                        route_name  \\\n",
+       "899                                                  \n",
+       "4694  Escondido to Nordahl Market Pl via Citracado   \n",
+       "9521                           DTC-Main-Myrtle-Oro   \n",
        "\n",
        "      avg_scheduled_service_minutes  avg_stop_miles  n_trips time_period  \\\n",
-       "3969                          47.88            0.79        5        peak   \n",
-       "4034                          26.00            0.25       10        peak   \n",
-       "6229                          44.50            0.88        6     all_day   \n",
+       "899                           46.92            0.22        7        peak   \n",
+       "4694                          21.40            0.20       15     all_day   \n",
+       "9521                          16.76            0.22       11     offpeak   \n",
        "\n",
        "      frequency stop_primary_direction  \n",
-       "3969       0.62              Eastbound  \n",
-       "4034       1.25             Southbound  \n",
-       "6229       0.25              Eastbound  "
+       "899        0.88             Southbound  \n",
+       "4694       0.62              Westbound  \n",
+       "9521       0.69              Westbound  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "route2.drop(columns = ['geometry']).sample(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "4effe5af-3b74-4b92-8e21-11223a104238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ROUTE_TYPOLOGIES = GTFS_DATA_DICT.schedule_tables.route_typologies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "01fb0f64-157b-436f-b17d-fc9fee0dca58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route_typologies = pd.read_parquet(\n",
+    "            f\"{SCHED_GCS}{ROUTE_TYPOLOGIES}_{analysis_date}.parquet\",\n",
+    "            columns = route_merge_group_cols + [\n",
+    "                \"is_coverage\", \"is_downtown_local\", \n",
+    "                \"is_local\", \"is_rapid\", \"is_express\", \"is_rail\"]\n",
+    "        )\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b59b9f5f-15af-43e6-9ea5-929c734c2ec7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route_dir_metrics2 = pd.merge(\n",
+    "            route,\n",
+    "            route_typologies,\n",
+    "            on = route_merge_group_cols,\n",
+    "            how = \"left\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "334ddfda-1817-4695-811d-d660f46f7157",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    \n",
+    "route_dir_metrics3 = pd.merge(\n",
+    "            route,\n",
+    "            route_typologies,\n",
+    "            on = route_merge_group_cols,\n",
+    "            how = \"left\"\n",
+    "        ).merge(test,\n",
+    "            on = route_merge_group_cols,\n",
+    "            how = \"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "66a27975-143a-4ea3-a1b5-e9d8dafa7a52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10489, 10489, 10489)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(route_dir_metrics3), len(route_dir_metrics2), len(route)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "801e5709-bc2e-4d6d-b76e-e03ba7b9b1bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>schedule_gtfs_dataset_key</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>common_shape_id</th>\n",
+       "      <th>route_name</th>\n",
+       "      <th>avg_scheduled_service_minutes</th>\n",
+       "      <th>avg_stop_miles</th>\n",
+       "      <th>n_trips</th>\n",
+       "      <th>time_period</th>\n",
+       "      <th>frequency</th>\n",
+       "      <th>is_coverage</th>\n",
+       "      <th>is_downtown_local</th>\n",
+       "      <th>is_local</th>\n",
+       "      <th>is_rapid</th>\n",
+       "      <th>is_express</th>\n",
+       "      <th>is_rail</th>\n",
+       "      <th>stop_primary_direction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1513</th>\n",
+       "      <td>8de1f1a3b9ae172c6b8255b1c82c340f</td>\n",
+       "      <td>32390</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>p_1303422</td>\n",
+       "      <td>The Lincoln Circulator Overflow only operates Monday – Friday when school is in session only, to supplement the regular bus route during peak service to serving stops nearby schools.</td>\n",
+       "      <td>60.00</td>\n",
+       "      <td>0.30</td>\n",
+       "      <td>1</td>\n",
+       "      <td>all_day</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Southbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7526</th>\n",
+       "      <td>95cb514215c61ca578b01d885f35ec0a</td>\n",
+       "      <td>11050</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>36699</td>\n",
+       "      <td>YUCAIPA</td>\n",
+       "      <td>24.07</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>8</td>\n",
+       "      <td>peak</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Southbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>363</th>\n",
+       "      <td>e524db270831632bdcf71df1d7e74d25</td>\n",
+       "      <td>554</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>p_1131</td>\n",
+       "      <td>South County/ Commuter</td>\n",
+       "      <td>83.00</td>\n",
+       "      <td>2.78</td>\n",
+       "      <td>1</td>\n",
+       "      <td>offpeak</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Westbound</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             schedule_gtfs_dataset_key route_id  direction_id common_shape_id  \\\n",
+       "1513  8de1f1a3b9ae172c6b8255b1c82c340f    32390          0.00       p_1303422   \n",
+       "7526  95cb514215c61ca578b01d885f35ec0a    11050          1.00           36699   \n",
+       "363   e524db270831632bdcf71df1d7e74d25      554          0.00          p_1131   \n",
+       "\n",
+       "                                                                                                                                                                                  route_name  \\\n",
+       "1513  The Lincoln Circulator Overflow only operates Monday – Friday when school is in session only, to supplement the regular bus route during peak service to serving stops nearby schools.   \n",
+       "7526                                                                                                                                                                                 YUCAIPA   \n",
+       "363                                                                                                                                                                   South County/ Commuter   \n",
+       "\n",
+       "      avg_scheduled_service_minutes  avg_stop_miles  n_trips time_period  \\\n",
+       "1513                          60.00            0.30        1     all_day   \n",
+       "7526                          24.07            0.25        8        peak   \n",
+       "363                           83.00            2.78        1     offpeak   \n",
+       "\n",
+       "      frequency  is_coverage  is_downtown_local  is_local  is_rapid  \\\n",
+       "1513       0.04         1.00               0.00      0.00      1.00   \n",
+       "7526       1.00         1.00               0.00      0.00      1.00   \n",
+       "363        0.06         1.00               0.00      0.00      0.00   \n",
+       "\n",
+       "      is_express  is_rail stop_primary_direction  \n",
+       "1513        0.00     0.00             Southbound  \n",
+       "7526        0.00     0.00             Southbound  \n",
+       "363         0.00     0.00              Westbound  "
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "route_dir_metrics3.drop(columns = ['geometry']).sample(3)"
    ]
   }
  ],

--- a/gtfs_digest/19_cardinal_dir_round2.ipynb
+++ b/gtfs_digest/19_cardinal_dir_round2.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc141923-f139-4654-ae9d-0e7387d4f163",
+   "metadata": {},
+   "source": [
+    "## Improving Cardinal Direction work"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9ce35c98-8821-44ee-8450-65ef3e786dbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import _section2_utils as section2\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from segment_speed_utils import gtfs_schedule_wrangling, helpers, time_series_utils\n",
+    "from segment_speed_utils.project_vars import (\n",
+    "    COMPILED_CACHED_VIEWS,\n",
+    "    GTFS_DATA_DICT,\n",
+    "    PROJECT_CRS,\n",
+    "    RT_SCHED_GCS,\n",
+    "    SCHED_GCS,\n",
+    "    SEGMENT_GCS,\n",
+    ")\n",
+    "from shared_utils import catalog_utils, rt_dates, rt_utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5b630233-a221-44fc-8c54-03ea6ad7e6f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.options.display.max_columns = 100\n",
+    "pd.options.display.float_format = \"{:.2f}\".format\n",
+    "pd.set_option(\"display.max_rows\", None)\n",
+    "pd.set_option(\"display.max_colwidth\", None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21c880c9-5226-4630-a462-ecfee837cf54",
+   "metadata": {},
+   "source": [
+    "### `gtfs_funnel/schedule_stats_by_route_direction`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e236ad41-2f33-4433-ae22-51fe61bc8099",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtfs_digest/19_cardinal_dir_round2.ipynb
+++ b/gtfs_digest/19_cardinal_dir_round2.ipynb
@@ -5,7 +5,17 @@
    "id": "bc141923-f139-4654-ae9d-0e7387d4f163",
    "metadata": {},
    "source": [
-    "## Improving Cardinal Direction work"
+    "## Improving Cardinal Direction work\n",
+    "* Responding to comments on [PR 1145](https://github.com/cal-itp/data-analyses/pull/1145)\n",
+    "\n",
+    "* 6/19\n",
+    "    * I experimented with not filling in the nans in `direction_id`.\n",
+    "    * When I did fill in the nans, I got \"10,489\" rows found in both datafarmes and \"745\" found in \"right_only\"\n",
+    "    * When I didn't, I got a curious result. These two don't match?\n",
+    "    _merge    \n",
+    "    both          10486\n",
+    "    right_only      615\n",
+    "    left_only         0"
    ]
   },
   {
@@ -45,6 +55,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "db12e63a-099b-434e-94ca-5d4798d6d1e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis_date = \"2024-04-16\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "21c880c9-5226-4630-a462-ecfee837cf54",
    "metadata": {},
@@ -54,11 +74,652 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "e236ad41-2f33-4433-ae22-51fe61bc8099",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "def cardinal_direction_for_route_direction(analysis_date:str, dict_inputs:dict):\n",
+    "    \"\"\"\n",
+    "    Get a cardinal direction (North, South, East, West) for each\n",
+    "    route.\n",
+    "    \"\"\"\n",
+    "    STOP_TIMES_FILE = dict_inputs.rt_vs_schedule_tables.stop_times_direction\n",
+    "    \n",
+    "    stop_times_gdf = pd.read_parquet(\n",
+    "    f\"{RT_SCHED_GCS}{STOP_TIMES_FILE}_{analysis_date}.parquet\",\n",
+    "    filters=[[(\"stop_primary_direction\", \"!=\", \"Unknown\")]\n",
+    "    ])\n",
+    "    \n",
+    "    trip_scheduled_col = [\n",
+    "    \"route_id\",\n",
+    "    \"trip_instance_key\",\n",
+    "    \"gtfs_dataset_key\",\n",
+    "    \"shape_array_key\",\n",
+    "    \"direction_id\",\n",
+    "    \"route_long_name\",\n",
+    "    \"route_short_name\",\n",
+    "    \"route_desc\",\n",
+    "    \"name\"\n",
+    "    ]\n",
+    "        \n",
+    "    trips_df = helpers.import_scheduled_trips(analysis_date, \n",
+    "                                              columns = trip_scheduled_col,\n",
+    "                                             get_pandas = True)\n",
+    "\n",
+    "    \n",
+    "    \n",
+    "    # Merge dfs\n",
+    "    merge_cols = [\"trip_instance_key\", \n",
+    "                  \"schedule_gtfs_dataset_key\", \n",
+    "                  \"shape_array_key\"]\n",
+    "    \n",
+    "    stop_times_with_trip = pd.merge(stop_times_gdf, trips_df, on = merge_cols)\n",
+    "    \n",
+    "    # Fill in missing direction id with 0, per our usual practice.\n",
+    "    print(f\"# of nulls for direction_id: {stop_times_with_trip['direction_id'].isna().sum()}\")\n",
+    "    #stop_times_with_trip.direction_id = stop_times_with_trip.direction_id.fillna(0)\n",
+    "    \n",
+    "    agg1 = (\n",
+    "        stop_times_with_trip.groupby(\n",
+    "            [\n",
+    "                \"route_id\",\n",
+    "                \"schedule_gtfs_dataset_key\",\n",
+    "                \"direction_id\",\n",
+    "                \"stop_primary_direction\",\n",
+    "            ]\n",
+    "        )\n",
+    "        .agg({\"stop_sequence\": \"count\"})\n",
+    "        .reset_index()\n",
+    "        .rename(columns={\"stop_sequence\": \"total_stops\"})\n",
+    "    )\n",
+    "    \n",
+    "    # Sort and drop duplicates so that the\n",
+    "    # largest # of stops by stop_primary_direction is at the top\n",
+    "    agg2 = agg1.sort_values(\n",
+    "        by=[\"route_id\", \n",
+    "            \"schedule_gtfs_dataset_key\",\n",
+    "            \"direction_id\",\n",
+    "            \"total_stops\"],\n",
+    "        ascending=[True, True, True, False],\n",
+    "    )\n",
+    "    \n",
+    "    # Drop duplicates so only the top stop_primary_direction is kept.\n",
+    "    agg3 = agg2.drop_duplicates(\n",
+    "    subset=[\n",
+    "        \"route_id\",\n",
+    "        \"schedule_gtfs_dataset_key\",\n",
+    "        \"direction_id\",\n",
+    "    ]).reset_index(drop=True)\n",
+    "    \n",
+    "    agg3 = agg3.drop(columns=[\"total_stops\"])\n",
+    "    return agg3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f8de58df-0b0e-47dc-9ce3-331a32612677",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# of nulls for direction_id: 90598\n"
+     ]
+    }
+   ],
+   "source": [
+    "test = cardinal_direction_for_route_direction(analysis_date,GTFS_DATA_DICT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5dd1e244-0187-49b7-815b-93cd3a012454",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>schedule_gtfs_dataset_key</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>stop_primary_direction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>001</td>\n",
+       "      <td>cb3074eb8b423dfc5acfeeb0de95eb82</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Westbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>001</td>\n",
+       "      <td>cb3074eb8b423dfc5acfeeb0de95eb82</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>Eastbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>001-132</td>\n",
+       "      <td>9809d3f8121513057bc5cb8de7b54ce2</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Eastbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>001-132</td>\n",
+       "      <td>9809d3f8121513057bc5cb8de7b54ce2</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>Northbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>002-132</td>\n",
+       "      <td>9809d3f8121513057bc5cb8de7b54ce2</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Eastbound</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  route_id         schedule_gtfs_dataset_key  direction_id  \\\n",
+       "0      001  cb3074eb8b423dfc5acfeeb0de95eb82          0.00   \n",
+       "1      001  cb3074eb8b423dfc5acfeeb0de95eb82          1.00   \n",
+       "2  001-132  9809d3f8121513057bc5cb8de7b54ce2          0.00   \n",
+       "3  001-132  9809d3f8121513057bc5cb8de7b54ce2          1.00   \n",
+       "4  002-132  9809d3f8121513057bc5cb8de7b54ce2          0.00   \n",
+       "\n",
+       "  stop_primary_direction  \n",
+       "0              Westbound  \n",
+       "1              Eastbound  \n",
+       "2              Eastbound  \n",
+       "3             Northbound  \n",
+       "4              Eastbound  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c210e9c5-bcea-4b84-80e8-5fcab230a9bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 4345 entries, 0 to 4344\n",
+      "Data columns (total 4 columns):\n",
+      " #   Column                     Non-Null Count  Dtype  \n",
+      "---  ------                     --------------  -----  \n",
+      " 0   route_id                   4345 non-null   object \n",
+      " 1   schedule_gtfs_dataset_key  4345 non-null   object \n",
+      " 2   direction_id               4345 non-null   float64\n",
+      " 3   stop_primary_direction     4345 non-null   object \n",
+      "dtypes: float64(1), object(3)\n",
+      "memory usage: 135.9+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "test.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "22760896-39b1-40a6-bc54-12b137a83c94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../gtfs_funnel\")\n",
+    "import schedule_stats_by_route_direction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3d96173d-216b-4e36-a3ff-ac5b17d5e26e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 104941 entries, 0 to 104940\n",
+      "Data columns (total 7 columns):\n",
+      " #   Column                     Non-Null Count   Dtype  \n",
+      "---  ------                     --------------   -----  \n",
+      " 0   schedule_gtfs_dataset_key  104941 non-null  object \n",
+      " 1   trip_instance_key          104941 non-null  object \n",
+      " 2   median_stop_meters         104937 non-null  float64\n",
+      " 3   time_of_day                104941 non-null  object \n",
+      " 4   scheduled_service_minutes  104941 non-null  float64\n",
+      " 5   route_id                   104941 non-null  object \n",
+      " 6   direction_id               95044 non-null   float64\n",
+      "dtypes: float64(3), object(4)\n",
+      "memory usage: 6.4+ MB\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "None"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "trip_metrics = schedule_stats_by_route_direction.assemble_scheduled_trip_metrics(analysis_date, GTFS_DATA_DICT)\n",
+    "trip_metrics = trip_metrics.rename(columns = {\"stop_primary_direction\":\"route_primary_direction\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5ab31f97-b712-4325-bca0-e0ff2a447e9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>schedule_gtfs_dataset_key</th>\n",
+       "      <th>trip_instance_key</th>\n",
+       "      <th>median_stop_meters</th>\n",
+       "      <th>time_of_day</th>\n",
+       "      <th>scheduled_service_minutes</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>37780</th>\n",
+       "      <td>7cc0cb1871dfd558f11a2885c145d144</td>\n",
+       "      <td>2fd67215db5942ad0944e3457757e9b7</td>\n",
+       "      <td>429.92</td>\n",
+       "      <td>AM Peak</td>\n",
+       "      <td>41.00</td>\n",
+       "      <td>M</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              schedule_gtfs_dataset_key                 trip_instance_key  \\\n",
+       "37780  7cc0cb1871dfd558f11a2885c145d144  2fd67215db5942ad0944e3457757e9b7   \n",
+       "\n",
+       "       median_stop_meters time_of_day  scheduled_service_minutes route_id  \\\n",
+       "37780              429.92     AM Peak                      41.00        M   \n",
+       "\n",
+       "       direction_id  \n",
+       "37780          0.00  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trip_metrics.sample()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f6e81b56-d903-4148-b916-fb58f07c0b1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route_group_cols = [\n",
+    "            \"schedule_gtfs_dataset_key\", \n",
+    "            \"route_id\", \n",
+    "            \"direction_id\"\n",
+    "        ]\n",
+    "        \n",
+    "route_merge_cols = [\n",
+    "            \"schedule_gtfs_dataset_key\", \n",
+    "            \"route_id\", \n",
+    "            \"direction_id\",\n",
+    "        ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "70d084ec-5832-4f17-9d61-66867a1dddc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route = schedule_stats_by_route_direction.schedule_metrics_by_route_direction(trip_metrics, analysis_date,route_group_cols, route_merge_cols)\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "368a915d-8a09-45a1-9830-c92ec1f05fe3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>schedule_gtfs_dataset_key</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>common_shape_id</th>\n",
+       "      <th>route_name</th>\n",
+       "      <th>avg_scheduled_service_minutes</th>\n",
+       "      <th>avg_stop_miles</th>\n",
+       "      <th>n_trips</th>\n",
+       "      <th>time_period</th>\n",
+       "      <th>frequency</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>4150</th>\n",
+       "      <td>ecd018ad66f497fb8f188ed5a71b284b</td>\n",
+       "      <td>453</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0821</td>\n",
+       "      <td>Orange Transportation Center - St Joseph Hospital via Chapman/Main/La Veta</td>\n",
+       "      <td>20.00</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>7</td>\n",
+       "      <td>all_day</td>\n",
+       "      <td>0.29</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             schedule_gtfs_dataset_key route_id  direction_id common_shape_id  \\\n",
+       "4150  ecd018ad66f497fb8f188ed5a71b284b      453          0.00            0821   \n",
+       "\n",
+       "                                                                      route_name  \\\n",
+       "4150  Orange Transportation Center - St Joseph Hospital via Chapman/Main/La Veta   \n",
+       "\n",
+       "      avg_scheduled_service_minutes  avg_stop_miles  n_trips time_period  \\\n",
+       "4150                          20.00            0.25        7     all_day   \n",
+       "\n",
+       "      frequency  \n",
+       "4150       0.29  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "route.drop(columns = ['geometry']).sample()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f72635ac-3157-4ef2-9988-196539b7c854",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_merge    \n",
+       "both          10486\n",
+       "right_only      615\n",
+       "left_only         0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(\n",
+    "            route,\n",
+    "            test,\n",
+    "            on = route_merge_cols,\n",
+    "            how = \"outer\",\n",
+    "            indicator = True\n",
+    "        )[[\"_merge\"]].value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ee7d97ff-0408-49b0-a59d-612aa4011861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route2= pd.merge(\n",
+    "            route,\n",
+    "            test,\n",
+    "            on = route_merge_cols,\n",
+    "            how = \"left\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "18c7d2f4-6926-43f4-95b0-9919d3a7cc70",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10486"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(route)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "12843bf6-771c-44d4-bec6-1558c1b04f89",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>schedule_gtfs_dataset_key</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>common_shape_id</th>\n",
+       "      <th>route_name</th>\n",
+       "      <th>avg_scheduled_service_minutes</th>\n",
+       "      <th>avg_stop_miles</th>\n",
+       "      <th>n_trips</th>\n",
+       "      <th>time_period</th>\n",
+       "      <th>frequency</th>\n",
+       "      <th>stop_primary_direction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3969</th>\n",
+       "      <td>8eecb796518dafd3c1b971a99f8b8252</td>\n",
+       "      <td>3205</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>7612</td>\n",
+       "      <td>Apple Valley - Lucerne Valley</td>\n",
+       "      <td>47.88</td>\n",
+       "      <td>0.79</td>\n",
+       "      <td>5</td>\n",
+       "      <td>peak</td>\n",
+       "      <td>0.62</td>\n",
+       "      <td>Eastbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4034</th>\n",
+       "      <td>ecd018ad66f497fb8f188ed5a71b284b</td>\n",
+       "      <td>400</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>4001</td>\n",
+       "      <td>John Wayne Airport - Tustin Metrolink via Jamboree</td>\n",
+       "      <td>26.00</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>10</td>\n",
+       "      <td>peak</td>\n",
+       "      <td>1.25</td>\n",
+       "      <td>Southbound</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6229</th>\n",
+       "      <td>55a01ef72af21906934ae8ffb4786e86</td>\n",
+       "      <td>200X</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>83</td>\n",
+       "      <td>Martinez / Pittsburg</td>\n",
+       "      <td>44.50</td>\n",
+       "      <td>0.88</td>\n",
+       "      <td>6</td>\n",
+       "      <td>all_day</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>Eastbound</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             schedule_gtfs_dataset_key route_id  direction_id common_shape_id  \\\n",
+       "3969  8eecb796518dafd3c1b971a99f8b8252     3205          0.00            7612   \n",
+       "4034  ecd018ad66f497fb8f188ed5a71b284b      400          1.00            4001   \n",
+       "6229  55a01ef72af21906934ae8ffb4786e86     200X          0.00              83   \n",
+       "\n",
+       "                                              route_name  \\\n",
+       "3969                       Apple Valley - Lucerne Valley   \n",
+       "4034  John Wayne Airport - Tustin Metrolink via Jamboree   \n",
+       "6229                                Martinez / Pittsburg   \n",
+       "\n",
+       "      avg_scheduled_service_minutes  avg_stop_miles  n_trips time_period  \\\n",
+       "3969                          47.88            0.79        5        peak   \n",
+       "4034                          26.00            0.25       10        peak   \n",
+       "6229                          44.50            0.88        6     all_day   \n",
+       "\n",
+       "      frequency stop_primary_direction  \n",
+       "3969       0.62              Eastbound  \n",
+       "4034       1.25             Southbound  \n",
+       "6229       0.25              Eastbound  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "route2.drop(columns = ['geometry']).sample(3)"
+   ]
   }
  ],
  "metadata": {

--- a/gtfs_digest/_cardinal_direction_notes.md
+++ b/gtfs_digest/_cardinal_direction_notes.md
@@ -5,6 +5,16 @@
 * [Mermaid 1](https://mermaid.live/view#pako:eNqNVttu2zgQ_RWCi8BZwAosqWpsPRRI6sh96AKLNFgEKxsFLY5sohKpklS2bpB_X1KUY_rW1A-2zDlz5sxwONQzLgQFnOIgCOZcM11BimYP2Rd0w0m10axQ6G_WQMU4oJkkjKs577AXF89zjhDjTKeoe0RooNdQwyBFgyVRMBj6q_8QyciyAjV4hRtTI1lN5OajqIS0fn_cJVmS3Wxdd4gH-KF3qNFodAy5FZKCPAeyGZyzKSgEp_s6suz67tbDaJCa7UHKshw484v9MV8vFxdzPudlJf4r1kRq9PneAYqKKDWFEkkoNCpZVaV9pgf2gsmigi2i03CCIeoB2SQb3UU2pIWodrmSpFkjxfjKkFCycYZtDgjd5KpYA20rWKAg-IBuwlyKVkNAmeVlgi88sINEuWhAEi3kvu3KGuNcadEsthLs5zZ_gjWzWTRCMcupXLDbMFewqoFrpBoAqnY-ByKCHrfPG_Ys5DJXa9JAYEOjHuqR2eWv2-XFn2ma9lX1uUhH9jEkOXky2a3gbU2WtiFMLgxjtws77AmVy8ucVBXSkjXnhN4_dFqRZjX4Qn22Za9zmftopO1R-j0hhSmXTa0mOw0eLvxWnwld9KGLgxKhN_ftK6OethOa6KXpO0JP1CREZ_XQXg89u2X2jJsxQ4Nal0XxqkbB9xZ48Ua9nDTT0G1tp8mbyS5852hve9TB_vTUfimm1uFJof3zOP3VeZw6SOSOnPsTH9D4DeXL69FbBcDp0dSwTqZkkoHyhWYnFHnWjjgL81pwvQ4DM3NCJ-3etJ0mdqpS9hNc8RAn5zq9J4ocUeQT-fHuHSw-FLWvftdMlJioZnyhjvZkU85OzbeZm2-zMLcH2ApBZLWSsLJ8Wji6TsssPvaKjmr2-wTdSl9Or8NcWVxFPr0qRo0U5iqAo8RObXBH4Wf-eHAbPPbd59Xh0Rn27gAvAkJ4iGuQNWHUvER09_ocd_f9HKfmkUJJ2krPsbkcDZS0WnzZ8AKnWrYwxCbcao3TklTK_Gsbu11TRozeegsBykzYv9xbSveyMsQN4Th9xj9wGkTx5CpJkjhOkvej8WiSDPEGp-G75CpKovA6CZPrSTKJXob4pxCGdHQ1GU_exeNkEsfj6_ejeNzR_dsZOx0v_wPlerTj)
 * [Mermaid 2](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/mermaid.md)
 
+### 6/19/2024
+[PR 1145](https://github.com/cal-itp/data-analyses/pull/1145)
+* Rerun the files for May and June once Cardinal Direction stuff is updated. 
+* Address comments left by Tiffany.
+    * <s>Change grouping columns.</s> AH: done. 
+    * Streamline counting stop directions:
+        * Make it into its own function. Don't stick it on. 
+        * Use it directly in `schedule_metrics_by_route_direction()`.
+    * Checkout what happens if there are nulls in `cardinal_direction_df` and how `nans` that are filled in can prevent some merges.
+    * 
 ### 6/12/2024
 * [Issue 1135](https://github.com/cal-itp/data-analyses/issues/1135)
 * Notebook: `gtfs_digest/17_cardinal_dir_pipeline`.

--- a/gtfs_digest/_cardinal_direction_notes.md
+++ b/gtfs_digest/_cardinal_direction_notes.md
@@ -7,14 +7,16 @@
 
 ### 6/19/2024
 [PR 1145](https://github.com/cal-itp/data-analyses/pull/1145)
-* Rerun the files for May and June once Cardinal Direction stuff is updated. 
+* <s>Rerun the files for May and June.</s>
+    * AH: Done on 6/20 but with the old code, not incorporating the comments from the PR above.
 * Address comments left by Tiffany.
     * <s>Change grouping columns.</s> AH: done. 
-    * Streamline counting stop directions:
-        * Make it into its own function. Don't stick it on. 
-        * Use it directly in `schedule_metrics_by_route_direction()`.
-    * Checkout what happens if there are nulls in `cardinal_direction_df` and how `nans` that are filled in can prevent some merges.
-    * 
+    * <s>Streamline counting stop directions:
+        * Make it into its own function. Don't stick it on. </s> AH: Done on 6/20
+        * <s>Use it directly in `schedule_metrics_by_route_direction()`.</s> AH: Done on 6/25`
+    * <s>Switch out the columns in `gtfs_digest/merge_data`</s> AH: Done on 6/20.
+    *  <b>What if there are nulls in cardinal_direction_df? would this NaN filled in prevent some merges? </b>
+        * I still need assistance with this. It seems like filling in the direction_id leads to a few more rows being added to the dataframe produced by `schedule_metrics_by_route_direction()`.
 ### 6/12/2024
 * [Issue 1135](https://github.com/cal-itp/data-analyses/issues/1135)
 * Notebook: `gtfs_digest/17_cardinal_dir_pipeline`.

--- a/gtfs_digest/_portfolio_notes_todo.md
+++ b/gtfs_digest/_portfolio_notes_todo.md
@@ -1,398 +1,145 @@
-## Notes for my reference for testing the [portfolio](https://test-gtfs-exploratory--cal-itp-data-analyses.netlify.app/readme)
-* cd ../ && pip install -r portfolio/requirements.txt
-* python portfolio/portfolio.py clean gtfs_digest_testing && python portfolio/portfolio.py build test_gtfs_exploratory  --deploy 
-* python portfolio/portfolio.py build gtfs_digest  --deploy 
-* cd data-analyses/rt_segment_speeds && pip install altair_transform && pip install -r requirements.txt && cd ../_shared_utils && make setup_env &&  pip install -U altair && cd ../gtfs_digest
-* RT Dates https://github.com/cal-itp/data-analyses/blob/main/_shared_utils/shared_utils/rt_dates.py
+### Cardinal Direction Links to address [this GH issue](https://github.com/cal-itp/data-analyses/pull/1124).
+* [Slack thread](https://cal-itp.slack.com/archives/D02QC97TRA6/p1717516644055619)
+* [This is where I need to input my cardinal direction work](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L23)
+* [This creates the dataframe that forms the basis of GTFS Digest](https://github.com/cal-itp/data-analyses/blob/main/gtfs_digest/merge_data.py)
+* [Mermaid 1](https://mermaid.live/view#pako:eNqNVttu2zgQ_RWCi8BZwAosqWpsPRRI6sh96AKLNFgEKxsFLY5sohKpklS2bpB_X1KUY_rW1A-2zDlz5sxwONQzLgQFnOIgCOZcM11BimYP2Rd0w0m10axQ6G_WQMU4oJkkjKs577AXF89zjhDjTKeoe0RooNdQwyBFgyVRMBj6q_8QyciyAjV4hRtTI1lN5OajqIS0fn_cJVmS3Wxdd4gH-KF3qNFodAy5FZKCPAeyGZyzKSgEp_s6suz67tbDaJCa7UHKshw484v9MV8vFxdzPudlJf4r1kRq9PneAYqKKDWFEkkoNCpZVaV9pgf2gsmigi2i03CCIeoB2SQb3UU2pIWodrmSpFkjxfjKkFCycYZtDgjd5KpYA20rWKAg-IBuwlyKVkNAmeVlgi88sINEuWhAEi3kvu3KGuNcadEsthLs5zZ_gjWzWTRCMcupXLDbMFewqoFrpBoAqnY-ByKCHrfPG_Ys5DJXa9JAYEOjHuqR2eWv2-XFn2ma9lX1uUhH9jEkOXky2a3gbU2WtiFMLgxjtws77AmVy8ucVBXSkjXnhN4_dFqRZjX4Qn22Za9zmftopO1R-j0hhSmXTa0mOw0eLvxWnwld9KGLgxKhN_ftK6OethOa6KXpO0JP1CREZ_XQXg89u2X2jJsxQ4Nal0XxqkbB9xZ48Ua9nDTT0G1tp8mbyS5852hve9TB_vTUfimm1uFJof3zOP3VeZw6SOSOnPsTH9D4DeXL69FbBcDp0dSwTqZkkoHyhWYnFHnWjjgL81pwvQ4DM3NCJ-3etJ0mdqpS9hNc8RAn5zq9J4ocUeQT-fHuHSw-FLWvftdMlJioZnyhjvZkU85OzbeZm2-zMLcH2ApBZLWSsLJ8Wji6TsssPvaKjmr2-wTdSl9Or8NcWVxFPr0qRo0U5iqAo8RObXBH4Wf-eHAbPPbd59Xh0Rn27gAvAkJ4iGuQNWHUvER09_ocd_f9HKfmkUJJ2krPsbkcDZS0WnzZ8AKnWrYwxCbcao3TklTK_Gsbu11TRozeegsBykzYv9xbSveyMsQN4Th9xj9wGkTx5CpJkjhOkvej8WiSDPEGp-G75CpKovA6CZPrSTKJXob4pxCGdHQ1GU_exeNkEsfj6_ejeNzR_dsZOx0v_wPlerTj)
+* [Mermaid 2](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/mermaid.md)
 
-### Running to-do list
-* Portfolio:
-    * Figure out Makefile situation.
-
+### 6/19/2024
+[PR 1145](https://github.com/cal-itp/data-analyses/pull/1145)
+* Rerun the files for May and June once Cardinal Direction stuff is updated. 
+* Address comments left by Tiffany.
+    * <s>Change grouping columns.</s> AH: done. 
+    * Streamline counting stop directions:
+        * Make it into its own function. DOn't stick it on. 
+        * Use it directly in `schedule_metrics_by_route_direction()`.
+    * Checkout what happens if there are nulls in `cardinal_direction_df` and how `nans` that are filled in can prevent some merges.
+    * 
+### 6/12/2024
+* [Issue 1135](https://github.com/cal-itp/data-analyses/issues/1135)
+* Notebook: `gtfs_digest/17_cardinal_dir_pipeline`.
+* I have edited `gtfs_funnel/schedule_stats_by_route_direction` and tested the dates April 15 and 16, 2024.
+    * This is a different branch than the one I used to run the open_data/HQTA/etc stuff.
+    * I saved out all my results with AH Testing
+* I broke apart `gtfs_digest/merge_data`.
+    * I used `concatenate_schedule_by_route_direction` to stack 4/15 and 4/16 together.
+    * The dataframe from `concatenate_speeds_by_route_direction` and `concatenate_rt_vs_schedule_by_route_direction` and `concatenate_speeds_by_route_direction` don't have `stop_primary_direction`. Is that ok?
+        * Yes that's ok. Cardinal_direction is derived from `schedule_only`.
+        * Any row that is only found in `vehicle_positions` won't have cardinal directions.
+    * Having issues with `merge_in_standardized_route_names` because the test dates I chose  don't have corresponding service_dates in the standardized routes dataframe. I think this should be ok.
+        * Go to `gtfs_funnel/clean_route_naming` and update the `analysis_date` list.
+        * The dataframe with standardized route names should have all dates to correspond. 
+* I deleted out unknowns, so every row has an actual direction.
+<s>* Now what? 
+    * I think I'm done with the second checkbox in Issue #1135.
+    * I am not sure if I should run it on a few dates without my `testing` string attached? Then proceed to backfilling all the dates?
+    * " if digest needs to create new datasets in a different grain, do so"? I don't think I need a new dataset in a different grain? How would I know for certain?</s>
+    * Amanda: discovered that there are many nans after doing `.value_counts(dropna=False`). Need to go back and fix this.
+        * Don't replace missing data until the very last step. 
+        <s>* Figure out what's going on and why there are so many unpopulated rows, especially the rows that don't have `sched_only`, `sched_vp`, and `vp_only` values in `sched_rt_category`.</s> Note: this was due to the `merge_standardized_name`, now that all the test dates are also in that file, the `sched_rt_category` column looks accurate.
+        * <s>Rename `stop_primary_direction` to `route_primary_direction`</s> Done. 
+        * Once I'm done: go into `gtfs_funnel/MakeFile` and write. Run this part of the Makefile to make changes to all of the files for all of the dates. Then go to `gtfs_digest/merge_data`. Delete the lines below after I'm done.
+        `cardinal_dir_changes: 
+         --- python schedule_stats_by_route
+         --- python clean_route_naming`
+<s>* Makefile and installing requirements for gtfs digest?
+    * Find those versions and pin it down. 
+    * Maybe it should be moved to _shared_utils/requirements
+    * Amanda: done with this, found the latest version of `altair` and `altair_transform` that I download and update.</s>
+* Tiffany ran May later because LA Metro was missing.
+    * June's data will be run tomorrow.
+    * Data for the most current month is run on the 2nd Thursday of each month. 
+    * There are certain areas  of the `gtfs_funnel/MAKE_FILE` when you can actually open up a notebook and work. VP stuff gets close to the limit, but schedule takes a lot less memory.
     
-### 6/6/2024
-* Troubleshooting the # of unique routes an operator runs. BART seems really high, which is the impetus for this investigation. 
-    * Work is in `18_operator_profiles.ipynb`.
-    * BART splits the route into essentially 2 because it uses one Route ID when the train goes North and another Route ID when the train goes South.
-    * Also took a look at San Francisco Muni: we identify 68 unique routes and their website lists about 70. 
-    * IDEA: add verbiage that says "approximately":
-    <i>Route Typologies The following data presents an overview of GTFS statistics using data from the most recent date of April 2024. City and County of San Francisco ran <b>approximately</b> 68 unique routes.</i>
-* Continue working on adding Cardinal Direction to the pipeline.
-* Second draft of common definitions added into `methodology.md`.
-### 6/5/2024
-* Was working on adding Cardinal Dir to the Pipeline.
+### 6/7/2024
+* I have added my work into the right file and it runs pretty fast. However, now that I'm done with this step I have no idea what to do. 
+* Questions for Tiffany about adding Cardinal Direction into the pipeline
+> so i would definitely stand up a test portfolio + scripts that generate the time-series data. you will need to cover the complete pipeline:
+most upstream step (somewhere in gtfs_funnel)
+data processing (situate your steps somewhere, either in gtfs_funnel, but it may be elsewhere, and you'd want to slightly programmatically rename the file, maybe just +_test so you can grab the newly processed data easily through each stage)
+  * What does "upstream step" mean?
+  * What's the difference between all your work in `data-analyses/gtfs_funnel` and `gtfs_funnel/merge_data.py`. 
+> every output needs a new suffix while you're testing. and then you point your input to that.
+otherwise, you'd have to run all the dates (with schedule data, that's not a big deal, but 2 min here and there over 30-40 dates does add up).
+stop_times -> aggregate to route_dir -> schedule_data_for_date1 (AH note: this is how the dataset is constructed for one date)
+time-series = schedule_data_for_date1 , schedule_data_for_date2, schedule_data_for_date3 (AH note: )
+if you added a column in date3, that column isn't present in date1, date2, so time_series_utils would error because it's looking for all the columns you listed
+digest is displaying whatever is concatenated in time_series_utils
+* What do you mean by output and input? When you say input are you talking about the dataframes I add to make this into a time series?
 
-### 6/4/2024
-* Finish up writing the common definitions that will be added in the `methodology.md`.
-* <s>Rerun all of the districts for schedule+GTFS and schedule only operators for TTTF #4.</s>
+> if you want to test a smaller set of dates to make sure it's working, i would start adding suffixes to everything.
+stop_times -> aggregate to route_dir -> schedule_data_for_date1_test
+time-series = schedule_data_for_date1_test , schedule_data_for_date2_test, schedule_data_for_date3_test
+digest can pull from a test file with just 3 dates to see if it has everything.
+once you're happy with it, you have to run all the scripts that are affected schedule_stats_by_route_direction, anything downstream that uses that intermediate output, all the way through to digest for all the dates in rt_dates.y2023_dates and rt_dates.y2024_dates
+* Where do I find `aggregate to route_dir`? 
+* `Test file`: is this like saving the outputs into GCS like 'may_2024_test.parquet'?
+* How do I know which scripts are affected by `schedule_stats_by_route_direction`?
 
-### 6/3/2024
-* <s>Add back operators even if they don't have VP positions such as BART.</s>
-    * Updates made in `gtfs_digest/_operators_prep`
-    * Deployed the portfolio with only  D4 operators as a test [here](https://gtfs-digest-testing--cal-itp-data-analyses.netlify.app/district_04-oakland/0__03_report__district_04-oakland__organization_name_stanford-university).
-    * After deploying the D4 subset, I rearranged the organization names in the Table of Content to be alphabetical. 
-    * Bugs in the portfolio
-        <s> * The `try except` clause i put behind <i>Detailed Route Overview</i> doesn't show anything even for operators that have GTFS data. 
-            * For operators without RT data,  the area under <i>Detailed Route Overview</i> displays nothing when it's supposed to display the message I set.</s>
-            * Fixed: have to wrap `display` around the function that makes all the charts. 
-        * BART runs 12 lines according to the `operator_profile` but the map only displays one route.
-            * Same thing with Emeryville Transportation Management, runs 2 routes but only 1 route is on the map.
-        * City of Rio Vista's Route Typology Pie Chart isn't showing up
-            * Was missing the new category '# Coverage Route Types'
-        * <s>The 'longest vs shortest' route charts aren't appearing even in the actual portfolio.</s>
-            * Fixed: I was using a color_palette reference that was renamed awhile back.
-### 5/30/2024
-* <s>Rerun all the operators.</s>
-* Ideas on next steps (in order of priority)
-    * Update the methodology.
-    * <s>Add back operators even if they don't have VP positions such as BART.</s>
-    * Figure out how to add in the cardinal directions back to frequency/text tables as some of the routes switch directions. 
-    * Double check NTD stuff. 
-    * <s>Take out the subtitle for the following graphs since it looks repetitive and cluttered. 
-        * `Frequency of Trips in Minutes` 
-        * `Daily Scheduled Service Hours` charts following Weekday</s>
-### 5/29/2024
-* [Netlify test link I created 5/17.](https://gtfs-digest-testing--cal-itp-data-analyses.netlify.app/district_07-los-angeles/0__03_report__district_07-los-angeles__organization_name_los-angeles-county-metropolitan-transportation-authority)
+> yes, but before the meeting, can you go through and identify in a notebook or text file what you think is the "batch" from upstream to downstream?
+script 1, input file is data1, output file is data2
+script 2, input file is data2, output is data3
+and so forth, until you reach the digest, wherever you think the end script is
+* What is the "batch"?
+* What do you mean by "reach the digest?"
+* [Run everything using this Makefile](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/Makefile)
+* [schedule_stats_by_route_direction.py](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L15)
+    * `assemble_scheduled_trip_metrics` 
+        * Input:
+            * `import_scheduled_trips`
+            * `import stop times direction`
+        * Output:
+            *GTFS_DATA_DICT.rt_vs_schedule_tables.sched_trip_metrics
+    * `schedule_metrics_by_route_direction`
+        * Input:
+            * End result from `assemble_scheduled_trip_metrics` (for one date)
+        * Output
+            * GTFS_DATA_DICT.rt_vs_schedule_tables.sched_route_direction_metrics
+    * After this goes [here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_digest/merge_data.py#L25)
 
-### 5/17/2024
-* State of the GTFS Digest Portfolio 
-    * All the tweaks in [Issue](https://github.com/cal-itp/data-analyses/issues/1101) except cardinal directions & mapping the routes based on the `route_colors` provided by operators have been addressed. 
-    * There is a rough estimate of the cardinal directions a route is headed.
-        * Cons:
-            * The function to grab the cardinal direction takes a long time. It will take about 2 hours for all the operators to run.
-            * The function looks across the route for all time periods, rather than looking at the direction per date. This is less accurate.
-            * Not all routes record data for both directions. There will be empty graphs for these routes. 
-        * Current tackling:
-            * `Route_id` and the associated names for routes change over time. I am still working on refining the function that attaches the most current `route_id` to the same routes across the entire time span of the dataset. 
-            * Ex: Main Street Route had the ID of 123 in April 2023 but ABC in April 2024. I have to go back and update the ID for April 2023 to be ABC. 
-            * The function is very slow. Grabbing all of the stops and finding the direction they points means the dataset is huge, especially because we need all the dates possible. I am working on using `dask deployed` to speed things up. 
-    * Service Hour Charts
-        * Finished. There are now 3 charts for daily weekday, Saturday, and Sunday total service hours across all the routes.
-        * Right now, we only have data for the entire weeks of April and October 2023. April 2024 to come.
-        * Added a new column `weekday_service_hours` to `_section1_utils.total_service_hours` that divides the sum of `service_hours` by 5 for an accurate count. Previously, this was done incorrectly. 
-
-### 5/16/2024
-To-Do
-* <s>Noticed a bug after running all of the operators...Figure out why the cardinal direction shows southbound and northbound even for the east/west directions.</s>
-* In the future, speed up the cardinal direction work? Or it'll be added to the pipeline? Right now it takes a very long time. 
-* Table of Contents on the portfolio site: the operators are not alphabetical. 
-    * D7: LA Metro is before City of Santa Monica/City of X/City of Y
-* <s>Fix service_hours chart-> divide weekday by 5</s>
-* <s>Add in dropdown menu to show only the first route</s>
-    * Found a solution through Stackoverflow. 
-### 5/15/2024
-* <s>Add explanations for why we chose these cutoffs in the `color_palette.yml`</s>
-* Continue cardinal directions work.
-* Rerun portfolio. 
-
-### 5/14/2024
-* Add back cardinal directions to `direction_id`. 
-    * I am done grabbing all the dates available, stacking them together, and aggregating for only one particular operator, let's call the dataframe `cardinal_dir_df`. 
-    * This is a big dataset, so I want to read in only the rows that are absolutely necessary. 
-    * When I merge this `cardinal_dir_df` with `sched_vp_df`, none of the routes match. I need to use [this script](https://github.com/cal-itp/data-analyses/blob/b1e5d4f870400251240eeba4a6515a0848e5d6f8/gtfs_funnel/clean_route_naming.py#L4) to clean up the names on the `cardinal_dir_df`
-* Displaying only the first route -> 
-    * Even after upgrading `altair` to the latest version of `5.3` I am still unable to accomplish this goal using the sample `cars` dataset. 
-### 5/13/2024
-* <s>For Service Hour Charts by weekday, Saturday, and Sunday.
-    * Added this to the target notebook for the GitHub site</s>
-* Didn't receive any answers to my question on  Stackoverflow yet about displaying only the first route. 
-* Add back cardinal directions to `direction_id`. 
-    * Met with Tiffany yesterday to understand how to aggregate everything properly. 
-* Section 2
-         * Vehicle Positions per Minute, % of RealTime Trips, % of Scheduled Trips, and Spatial Accuracy charts, figure out if there's a way to color the background so the bottom  red, middle is yellow, and the top is green to signify the different "zones/grades".
-        * <b> Note 4/16 </b> Having a hard time getting this to work. Facet doesn't allow for layering and it seems like the background impacts the colors of the main chart, making everything hard to view.
-        * <b> Note 5/13 </b>: I was able to get the background to be shaded perfectly for the `Service Hour Charts` but `faceting` charts causes this shading to become wonky. Therefore, this goal is now retired. 
-        <s>* Create an Altair chart with just a title/subtitle to divide out metrics about the quality of the rider's experience on a route vs the quality of the data collected about the route.</s>
-### 5/10/2024
-* How to display only the first value before filtering for charts. Right now, the charts show stuff for all months/routes and this is confusing.
-    * Still couldn't get this to work even with a very simple `cars` dataset from the Altair example. 
-    * Submitted a question onto StackOverflow for help. 
-* <s>Service Hour chart.</s>
-    * Show chart to Eric and Katrina & double check the aggregation with Tiffany before making it into functions.
-
-
-### 5/9/2024 To-Do
-* <s>Frequency Chart: make the colors a set range, so all routes will always be dark green if a bus going that route and direction comes by every 10 minutes, dark red if every 60 minutes.</s>
-* <s>Spatial Accuracy: Confirm with Tiffany about buffer and add the buffer into the subtitle.</s>
-    * The buffer is 35m.
-
-### 5/8/2024 To-Do 
-* <s>% RT Journey Chart with VP: delete</s>
-* <s>Total Monthly Scheduled Service Chart: delete</s>
-* <s>Speed Chart: use different colors. Red, green, and yellow suggest bad, good, and ok.</s>
-
-* <s>Route Typology Chart: remove the subtitle. Add in a blurb from the methodology.md about how routes are categorized. Add a hyperlink to NACTO Route guide.</s>
-### 5/6/2024
-<s>* Eric: the maps from .explore() look pretty overwhelming when an operator has many routes. 
-    * Can we modify the reports site maps to be used here too? 
-    * Check Total Service Hours charts.</s>
-    * 5/8: Not worth the effort and people probably won't even interact with the map to look at a singular/a few routes.
-* Streamline code, some of the code for my charts is redundant.
-* NTD
-    * Ask people for feedback on the NTD copy.
-    * Try to connect the agencies by ntd_id instead of name? 
-    * Tiffany:
-        * Explain NTD_ID situation again? 
-    * Change NTD copy so it doesn't run off the page
-    * Alternatively, set the max width for each cell so nothing runs off?
-* Update Makefile stuff.
-    * https://github.com/cal-itp/data-analyses/blob/main/ntd/Makefile#L4
-    * The goal is to write one line of code in the terminal and have the entire portfolio deploy each month.
-* When should this be updated every month? The beginning?
-* If I want to start on the bunching metric, which folder do I work out of? 
-
-### 5/2/2024
-* <s>Update README with some of the methodology FAQ.
-* Officially deploy portfolio
-    * https://github.com/cal-itp/data-analyses/blob/main/Makefile#L69</s>
-### 5/1/2024
-* <s>Add in NTD data.</s>
-* Update Readme.MD
-    * Cherry pick commit.
-    * Link to Methodology
-* <b>Consolidate the total service hours charts with Eric's findings.</b>
-* <s>Address Tiffany's comments
-    * can you change the thickness of the line chart, looking a bit thick, no?
-    * also in the text in the beginning, it's now reading like Apr, 2024, but should read Apr 2024
-    * semi-annoying that the legend label runs off the page, perhaps the chart width needs to shrink by a little. the alternative seems more cumbersome, which is to inject a list into the legend</s>
-        * Amanda: Changed the name of legend values that were running off. 
-    * <s>maybe work more headers in? there's just 2 main headers, but kind of a lot of sections, like "map of routes" (this one esp gets buried) probably can be its own, "route typology"</s>
-    * spacing after the map is really big - why?
-        * Amanda: Think this always happens with `.explore()` but I need to talk to Eric about using something else to display the maps because operators with a lot of routes gets very overwhelming. 
-    * <s>in the caption, pick a consistent spacing: Early AM:time vs Early AM: time</s>
-    * <s>monthly aggregation label Full Date actually refers to  Month</s>
-    *<s> spatial accuracy - static route shape -> scheduled shape (path)
-        * Amanda: Confirm with Tiffany what this means? </s>
-    * <s>GTFS always spelled like that, not Gtfs (in your text box for route dropdown)</s>
-    * <s><b>name of the portfolio should be GTFS Digest, not GTFS Exploratory</b></s>
-    * <s>colors for the average scheduled minutes for route...yellow/red may not be the best choice here, it's not a good or bad thing to be direction 0/1. the way yellow/red are used elsewhere does seem to indicate good vs bad.</s>
-    * <s>can you write the counties served as a sentence? LA Metro: Los Angeles, Ventura, Orange (alphabetized).</s>
-        
-### 4/30/2024
-* <s>Update readme.
-    * 5/1 Check with Tiffany that this is what she's looking for.</s>
-* <s>Rebase off of main and update the URL for service_hours</s>
-* <s>Add in divider charts to Section 2 that sort the charts thematically.</s>
-### 4/29/2024
-#### To-Do
-*  <s>Routes Pie Chart
-    * Confirm again that a route can fall into various categories.
-    * D3 UCD only runs 19 unique routes but the piechart has like 30+ routes.
-    * Same with D4 Central Contra Costa Transit Authority
-    * Update with new cols: 'it's like downtown_local, local, coverage, rapid, express, rail'</s>
-* <s>Section 1 Total Service Hours
-    * Dates should be sorted in descending order, so the most recent date is at the top
-    * Make a new daily chart, continue automating finding the number of each type of day in a year. 
-    * Refine total hours across the month chart.</s> 
-* Section 2
-    * <s>Need to update `spatial_accuracy` subtitle.</s>
-    * Continue troubleshooting the javascript message that has now appeared.
-        * Figured out the error was due to `def create_data_unavailable_chart():
-
-        chart = alt.LayerChart()
-    
-        return chart`
-    
-### 4/26/2024
-#### To-do Today
-* <s>Remove the mapping for the `Total Service Hours` with the weekday column that is in the dataset. </s>
-     * Create a new chart  chart names to Eric's suggestions.
-* <s>Reorder charts thematically. Add a little chart in between that explains the divide.</s>
-* <s>Double check that all the column names when injecting into charts/display are correct. I caught a mistake: I plugged in RT trips when I wanted to display Scheduled trips in section 3.</s>
-
-#### Notes 
-* Tried making a map that is controlled with an `ipywidget` dropdown menu so users can view one map at a time. This only works in the notebook and not when uploaded onto GH pages.
-    * Go back to using .explore()
-    * I tried using altair yesterday but altair can only plot geomtype of points, not lines. 
-* `Total Service Hours` doesn't match reports...still trying to debug.
-* Section2
-    * After updating the graphs for section 2, I now get this message `Javascript Error: Unrecognized signal name: "concat_1_width"
-This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`. 
-    * I noticed I have to run the same cell twice in order to get the charts to generate `for _ in range(2):` but this is not ideal because the error is not resolved and is still displayed. 
-    * Some operators aren't even running like Emeryville:
-        `Javascript Error: Unrecognized signal name: "concat_1_width"
-This usually means there's a typo in your chart specification. See the javascript console for the full traceback.
-Javascript Error: Unrecognized signal name: "concat_3_width"
-This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`
-    * All the charts generate fine on their own, error is coming from concating them? 
-    
-* Goals
-    * <s>Finish copy on readable.yml</s>
-    *<s> Convert all of the charts to read from the readable.yml. </s>
-        <s>* For charts in section 1, add subtitles and title.</s>
-    * <s>Change section3utils references back to section2.</s>
-   
-  
-   * <s>Double check section3.add_categories() is accurate. 
-       * Decided to take it out since I'm not using this in any of the charts.</s>
-### 4/24/2024 
-#### Questions for Tiffany
-* Operator Overview (section 1)
-    * The Pie Chart with Total Routes by Typology doesn't match the number of unique routes. 
-            * UC Davis runs 19 unique routes but there are 20 routes in the pie chart.
-            * Double check this w/ Tiffany.
-    * For the `Total Service Hours` month, I mapped 1 to be Monday, 2 to be Tuesday, etc. Double check and make sure it's correct.
-    * Confirm about total daily trips
-        * This is now only displaying "all_day" columns but some still seem very high?
-* Status on route classification?
-* Status on road classification?
-* Bunching metric game plan? 
-* Incorporate agency classification into this portfolio? 
-
-#### Comments from Tiffany
-##### Done
-* formatting for numbers, include the comma (like 1,000 instead of 1000)...like {,} (https://pbpython.com/styling-pandas.html)
-    * Done, rounded up the individual numbers since I'm not sure if you can grab values off of a styled dataframe.
-* First sentence: This section presents an overview of statistics for Los Angeles County Metropolitan Transportation Authority, using data from the most * recent date of 3/2024 ...replace the 3/2024 to display March 2024 as a more readable format
-    * Done, now displays month in string
-* add a map displaying all the routes, i think a gdf.explore() would work -- although let me know if this is what's breaking the map
-* vp per minute chart probably shouldn't run up to 5. it really only hits 3 as a max...so either 3.5 or 4 for y-axis
-    * 4/24: added it back in.
-* Total Scheduled Service Hours ....not blue for time-of-day. go with categorical scale? also set the colorscale manually because no color should be repeated
-    * I think I addressed this? Confirm with Tiffany.
-* Fill out your readable.yml for better displaying column names and captions -- you're already working on this    
-
-##### Having Issues
-* yes, leave out the chart unavailable. i've tried this: when you're concatenating altair charts but you're missing one, you'd basically do like chart2= alt.LayerChart() so that when you do
- chart_list = [chart1, chart2, chart3]
- chart = alt.vconcat(*chart_list)
-you're not missing any chart, but it's just an empty nothing, but there's no title, no df being read in</s>
-    * Still doesn't work once I concat the charts, I think the route dropdown is impacting this? 
-* have you tried this: https://stackoverflow.com/questions/70937066/make-dropdown-selection-responsive-for-y-axis-altair-python
-    * Having trouble getting it to work with our charts but it works in the Stack Overflow example.
-    `dropdown = alt.binding_select(
-    options=['Miles_per_Gallon', 'Displacement', 'Weight_in_lbs', 'Acceleration'],
-    name='X-axis column '
-)
-xcol_param = alt.param(
-    value='Miles_per_Gallon',
-    bind=dropdown
-)`
-#### Goals for today 
-* <s>Update frequency</s>
-* Incorporate comments from Tiffany.
-
-### 4/23/2024
-* <s>Check the # of daily trips again in section 3. Even after dropping duplicates, it still seems crazy high.</s>
-    * Solution: filter on `time_period == all_day`.
-* <s>"Operator Overview":
-    * Add a sentence about the Total Scheduled Service Hours and what it means.</s>
-* Reran all pages for all operators: this time it worked.
-    * I think it's because I dropped duplicates  when reading in `sched_vp`.
-    * Observations of wonky things.
-    * Organization - City of Eureka, Route - AMTRS Red Route
-        * Frequency of Trips Per Hour Chart: some of the charts look funky.
-        * Section 3
-        * <s>Still says "Scroll down to filter for a specific route" update it to something else since the dropdown menu is now on the right.</s>
-        * `Frequency of Trips per Hour` is kidn of confusing, when it's a low number like 0.04. What does that mean? Should it be X every X hours instead? 
-        * `Average Speed` charts' interactive legend doesn't work. I want people to be able to view one time period at a time because sometimes the lines overlap too closely to see anything.
-        * `Vehicle Postions per Minute`: set anything above 2 as green. Right now, the color scale maps to lowest and highest value. Some routes that record 3 vps per minute now have bars that red when only 2 vps were recorded, even though 2 is good.
-            * Ex: Mendocino Transity Authority 20 Willits/Ukiah 
-            * Same thing with `Spatial Accuracy` Chart: anything above 95 should be green...
-    * <s>Bring make the `explore` map maybe once all the other sections are done so we can visualize the reach of the transit agency?</s>
-* Notes from 1:1
-    * Who is the target audience?
-        * Local agencies 
-        * TTTF
-        * Advocates
-    * What is the transit background/knowledge of the audience?
-        * General public?
-        * Data enthusiasts? 
-        * Transit enthusiasts?
-    * The metrics presented cover both data quality metrics (spatial accuracy, density of GPS pings per minute) and the quality of the rider's experience (early/late/ontime trips and speed). How to incorporate these two themes seamlessly? 
-        * Themes are interrelated.
-        * Some audience members are interested more in one theme than the other. 
-        * Delineate Section 3 into these two themes? Section 2 is a snapshot...focus on quality of the experience?
-    * How to present this information?
-        * Too much information and too many charts is overwhelming, what's the perfect amount? 
-        * Perhaps to the general person, vehicle positions is not easily grasped. Explain what it is, why it's important to transit improvement, why it's relevant to the transit rider's experience.
-        * Work on captions/chart names/metric names/metric categories to make them more easily understandable.
-            * Use the readme.md as a "How to Understand" Guide? Glossary?
-    * Bunching: mostly relevant to agencies with lots of riders/frequent routes. 
-        * Do we run this metric for all agencies or only some? This metric wouldn't be meaningful to some agencies/routes...
-    
-### 4/22/2024
-* I updated the yaml because last week, I discovered there are multiple organization name-name combos and duplicates. This work is in `07_crosswalk.ipynb`. 
-    * The new yaml includes only one row for one organization.
-* Last week, I tried to run all the operators. However, the notebook would error out at AC Transit & SF Muni. 
-    * To test, I commented out a lot of the charts in the `section2.filtered_route(sched_vp_df)` part. 
-    * All the operators' github pages were successfully generated however this seems to hint that too many Altair charts causes things to go a bit wild. 
-    * Cut down on charts? Not sure. 
-* Comments on the new GitHub Pages
-    * Operator Overview (section 1)
-        * The Pie Chart with Total Routes by Typology doesn't match the number of unique routes. 
-            * UC Davis runs 19 unique routes but there are 20 routes in the pie chart.
-            * Double check this w/ Tiffany.
-        * <s>Double check the longest and shortest route. Some routes are VERY long.
-            * City of Eureka in D1 has a route that is almost 160 miles.
-            * Yes this is correct</s>
-        * For the "public transit provided in the following counties" style the dataframe instead of printing it. Maybe concat a bullet point to the county so it looks like a list?
-         * Need to add back stop information. </s>
-   * Detailed Route-Direction Overview (section 3)
-       * <s>What's that box that prints "None"?? Why is it generated for every page??
-           * Prints "None" because I wrapped the `great_table` with `display()`</s>
-       * <s>`create_data_unavailable_chart()` doesn't work  when adding a dropdown menu to allow for route selection...only works with one route example  in `01_section3.ipynb` 
-           * Test: Gold Route in City of Eureka 
-           * Test: 6 wellness express  "Palo Verde Valley Transit Agency"/'Desert Roadrunner GMV Schedule' in d8
-           * Tried returning a `print` statement but it didn't work. </s>
-        
-### 4/17/2024 Notes
-    * Example: just have one chart for speeds for both directions? 
-* For `operator_profiles` some organizations don't have any information for March. 
-    * in `04_gtfs_exploratory.ipynb` Blue Lake Rancheria's most recent information is from last September. 
-    * Some organizations don't have information at all such as Peninsula Corridor Joint Powers. 
-        * However this organization appears to have speed/trip data. 
-    * We want only one organization to map with one name
-        * Keep only the most recent name-row for the organization_name.
-* AC Transit & SF Muni always throws an error:
-    * "nbclient.exceptions.CellTimeoutError: A cell timed out while it was being executed, after 4 seconds.
-    The message was: Timeout waiting for IOPub output.
-    Here is a preview of the cell contents:
-    -------------------
-    section2.filtered_route(sched_vp_df)"
-    
-    * This didn't happen last time. 
-    * Test what is going wrong one element at a time. 
-* Readable.yml
-    * Operators -> what does it mean when you have `organization_name:Organization`. 
-        * Organization is a string. 
-        * Other column names have "" to avoid any special symbols like () or + being read in weird. 
-
-### 4/11/2024 Run 
-To-Do
-* YML
-    * How do I get the values from the `organization_name` column to show up on the left hand panel but I want to filter on  `name`?
-* Modify the `makefile`
-* Add in the different sections.
-* <s>Move all `read_parquet` to reference stuff grabbed from `catalog_utils.get_catalog("gtfs_analytics_data")`.</s>
-* <s>`Average Total Service Hours` chart </s>
-    * Rename as `Total` because it is not the average.
-    * Move the chart out of route-direction monthly overview
-    * Concat the dataframes together so users can filter for months in both 2023 and 2024.
-* Route-Direction Monthly Overview Section
-    * <s>Great tables: dates are a little different (minor). Move the great table to the bottom OR add another markdown line right before all the charts to instruct users to filter by route or else the charts won't make any sense.</s>
-    * Charts: 
-        * Test if making a simple chart then adding more encoding and domain ranges will work? This is for later.
-        * Make it a bit smaller.
-        * Add a function that resizes the charts instead of having the properties configured for each one? 
-        * <s>Move dropdown to the top</s>
-        * I got the `this exceeds the max rows allowed for Altair` error for AC Transit...I turned off the warning but I am worried this will backfire in the future. Figure out a way to summarize all the info without making files unbearably large.
-        * <s>Maybe update the color palette to something more meaningful? Like red to green to for `vehicle positions per minute` so the fewer the vps, the redder?</s>
-        <s>* If there are no values for a certain chart,display a message instead of a blank chart.</s>
-            * <b> Note 4/17</b>: Created a chart that returns "no chart available, not enough data."
-        * Maybe all_day can be a pink/red color while the peak and offpeak can remain blue? 
-        * <s>Add interactive() behind each chart.</s>
-        * <s>Minor but make sure all the dates are slanted at 45 degrees for readability.</s>
-        * What will happen once we add more dates?? 
-        * How to display only one route before you filter down to the route you choose. For now all the routes show and this is seriously confusing.
-            * <b> Note 4/17 </b> [The former method is no longer working.](https://github.com/cal-itp/data-analyses/blob/main/rt_segment_speeds/_threshold_utils.py)
-    * <s>Frequency of Route chart: change from heatmap because this is confusing to people.</s>
-        * <b> Note 4/16 </b>: switched to a faceted chart that repeats. 
-    * <s>Speed chart: how to make `all_day` speed more obvious.</s>
-            * <b> Note 4/16 </b>: switching over to a new color palette now makes `all_day` a red color so this is more obvious. 
-    * For Vehicle Positions per Minute, % of RealTime Trips, % of Scheduled Trips, and Spatial Accuracy charts, figure out if there's a way to color the background so the bottom  red, middle is yellow, and the top is green to signify the different "zones/grades".
-        * <b> Note 4/16 </b> Having a hard time getting this to work. Facet doesn't allow for layering and it seems like the background impacts the colors of the main chart, making everything hard to view.
-    * <s>Route Statistics for Route for Dir 0/1: Quite often nothing shows up...Figure out why?? Stuff shows up on the charts. 
-        * Example route: 652 Skyline High - Elmhurst Bay Area 511 AC Transit Schedule</s>
-            * <b> Note 4/17 </b>: Fixed this. The `_section2_utils.route_stats()` function needs outer merges. I also edited the `create_text_table()` function to drop duplicate rows. Without dropping duplicate rows, the text table overlays all the rows and you can't read the text. 
-
+* What I need to change
+    * [Here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L118C19-L120) add `test` behind the name and [here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L122) change the `analysis_date_list` to only a few dates.
+    * [Here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_digest/merge_data.py#L25) add _test 
+    * [Edit here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_digest/merge_data.py#L212) so I only run a few dates.
+* [Only run above here](https://github.com/cal-itp/data-analyses/blob/main/gtfs_digest/merge_data.py#L208-L268)
+* Once I'm happy with this, there's a GCS Public Bucket. That's the very, very late step.
+    * After I deploy everything. 
+* 
+#### Terms
+* Batch
+* Upstream: the least processed
+    * Warehouse: could be unzipped files.
+    * For me, it's something downloaded from the mart.
+    * WE process these unprocessed files with scripts. 
+    * Called by helper functions.
+* Downstream: the most final product.
+    * The most downstream is the digest. 
+    * Whatever is done in the GTFS Digest. 
+* Digest
+    * 
+* Funnel 
+    * When Tiffany is downloading stuff.
+    * Funneling the least processed tables through various scripts to trasnform.
+    * There are 5 tables that are transformed repeatedly into different products. 
+    * Everything that is in `gtfs_funnel`.
+    * 3 big workstreams: 
+        * RT Segment Speeds
+        * Schedule
+        * RT vs Schedule. 
+        * Schedule is also processed in GTFS Funnel. 
+    * Schedule data informs a lot of the interpreation of the vehicle positions
+        * We don't know anything about vehicle positions, what route, shape, direction it is. This data is all found in Schedule data that we connect with GTFS Key.
+        * Trips is the main table of the Schedule universe. 
+* Helper functions just pull dataframes that are downloaded.
+* Downloading happens in another step.
+* Tiffany runs the MAKEFILE in gtfs_funnel.
+* Then Tiffany goes to various other folders and runs everything (HQTA, RT Segment Speeds, etc)
+* Everything at the end goes into the GTFS Digest.
+* GTFS Digest is trying to represent everything through the grain of route-direction.
+* Every month Tiffany runs one day.
+* Batch: a combination of various scripts that are run together.
+* Look at the MAKEFILE and compare it to Mermaid. 
+* Digest: simply a compilation by dates, collects the columns TIffany wants
+    * Select the columns they want.
+* Not all the scripts in the Makefile need to be matched.
+* I can duplicate the files. 

--- a/gtfs_digest/_portfolio_notes_todo.md
+++ b/gtfs_digest/_portfolio_notes_todo.md
@@ -1,145 +1,399 @@
-### Cardinal Direction Links to address [this GH issue](https://github.com/cal-itp/data-analyses/pull/1124).
-* [Slack thread](https://cal-itp.slack.com/archives/D02QC97TRA6/p1717516644055619)
-* [This is where I need to input my cardinal direction work](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L23)
-* [This creates the dataframe that forms the basis of GTFS Digest](https://github.com/cal-itp/data-analyses/blob/main/gtfs_digest/merge_data.py)
-* [Mermaid 1](https://mermaid.live/view#pako:eNqNVttu2zgQ_RWCi8BZwAosqWpsPRRI6sh96AKLNFgEKxsFLY5sohKpklS2bpB_X1KUY_rW1A-2zDlz5sxwONQzLgQFnOIgCOZcM11BimYP2Rd0w0m10axQ6G_WQMU4oJkkjKs577AXF89zjhDjTKeoe0RooNdQwyBFgyVRMBj6q_8QyciyAjV4hRtTI1lN5OajqIS0fn_cJVmS3Wxdd4gH-KF3qNFodAy5FZKCPAeyGZyzKSgEp_s6suz67tbDaJCa7UHKshw484v9MV8vFxdzPudlJf4r1kRq9PneAYqKKDWFEkkoNCpZVaV9pgf2gsmigi2i03CCIeoB2SQb3UU2pIWodrmSpFkjxfjKkFCycYZtDgjd5KpYA20rWKAg-IBuwlyKVkNAmeVlgi88sINEuWhAEi3kvu3KGuNcadEsthLs5zZ_gjWzWTRCMcupXLDbMFewqoFrpBoAqnY-ByKCHrfPG_Ys5DJXa9JAYEOjHuqR2eWv2-XFn2ma9lX1uUhH9jEkOXky2a3gbU2WtiFMLgxjtws77AmVy8ucVBXSkjXnhN4_dFqRZjX4Qn22Za9zmftopO1R-j0hhSmXTa0mOw0eLvxWnwld9KGLgxKhN_ftK6OethOa6KXpO0JP1CREZ_XQXg89u2X2jJsxQ4Nal0XxqkbB9xZ48Ua9nDTT0G1tp8mbyS5852hve9TB_vTUfimm1uFJof3zOP3VeZw6SOSOnPsTH9D4DeXL69FbBcDp0dSwTqZkkoHyhWYnFHnWjjgL81pwvQ4DM3NCJ-3etJ0mdqpS9hNc8RAn5zq9J4ocUeQT-fHuHSw-FLWvftdMlJioZnyhjvZkU85OzbeZm2-zMLcH2ApBZLWSsLJ8Wji6TsssPvaKjmr2-wTdSl9Or8NcWVxFPr0qRo0U5iqAo8RObXBH4Wf-eHAbPPbd59Xh0Rn27gAvAkJ4iGuQNWHUvER09_ocd_f9HKfmkUJJ2krPsbkcDZS0WnzZ8AKnWrYwxCbcao3TklTK_Gsbu11TRozeegsBykzYv9xbSveyMsQN4Th9xj9wGkTx5CpJkjhOkvej8WiSDPEGp-G75CpKovA6CZPrSTKJXob4pxCGdHQ1GU_exeNkEsfj6_ejeNzR_dsZOx0v_wPlerTj)
-* [Mermaid 2](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/mermaid.md)
+## Notes for my reference for testing the [portfolio](https://test-gtfs-exploratory--cal-itp-data-analyses.netlify.app/readme)
+* python portfolio/portfolio.py clean gtfs_digest_testing && python portfolio/portfolio.py build test_gtfs_exploratory  --deploy 
+* python portfolio/portfolio.py build gtfs_digest  --deploy 
+* cd data-analyses/rt_segment_speeds && pip install -r requirements.txt && cd ../_shared_utils && make setup_env && cd ../gtfs_digest
+* RT Dates https://github.com/cal-itp/data-analyses/blob/main/_shared_utils/shared_utils/rt_dates.py
 
-### 6/19/2024
-[PR 1145](https://github.com/cal-itp/data-analyses/pull/1145)
-* Rerun the files for May and June once Cardinal Direction stuff is updated. 
-* Address comments left by Tiffany.
-    * <s>Change grouping columns.</s> AH: done. 
-    * Streamline counting stop directions:
-        * Make it into its own function. DOn't stick it on. 
-        * Use it directly in `schedule_metrics_by_route_direction()`.
-    * Checkout what happens if there are nulls in `cardinal_direction_df` and how `nans` that are filled in can prevent some merges.
-    * 
-### 6/12/2024
-* [Issue 1135](https://github.com/cal-itp/data-analyses/issues/1135)
-* Notebook: `gtfs_digest/17_cardinal_dir_pipeline`.
-* I have edited `gtfs_funnel/schedule_stats_by_route_direction` and tested the dates April 15 and 16, 2024.
-    * This is a different branch than the one I used to run the open_data/HQTA/etc stuff.
-    * I saved out all my results with AH Testing
-* I broke apart `gtfs_digest/merge_data`.
-    * I used `concatenate_schedule_by_route_direction` to stack 4/15 and 4/16 together.
-    * The dataframe from `concatenate_speeds_by_route_direction` and `concatenate_rt_vs_schedule_by_route_direction` and `concatenate_speeds_by_route_direction` don't have `stop_primary_direction`. Is that ok?
-        * Yes that's ok. Cardinal_direction is derived from `schedule_only`.
-        * Any row that is only found in `vehicle_positions` won't have cardinal directions.
-    * Having issues with `merge_in_standardized_route_names` because the test dates I chose  don't have corresponding service_dates in the standardized routes dataframe. I think this should be ok.
-        * Go to `gtfs_funnel/clean_route_naming` and update the `analysis_date` list.
-        * The dataframe with standardized route names should have all dates to correspond. 
-* I deleted out unknowns, so every row has an actual direction.
-<s>* Now what? 
-    * I think I'm done with the second checkbox in Issue #1135.
-    * I am not sure if I should run it on a few dates without my `testing` string attached? Then proceed to backfilling all the dates?
-    * " if digest needs to create new datasets in a different grain, do so"? I don't think I need a new dataset in a different grain? How would I know for certain?</s>
-    * Amanda: discovered that there are many nans after doing `.value_counts(dropna=False`). Need to go back and fix this.
-        * Don't replace missing data until the very last step. 
-        <s>* Figure out what's going on and why there are so many unpopulated rows, especially the rows that don't have `sched_only`, `sched_vp`, and `vp_only` values in `sched_rt_category`.</s> Note: this was due to the `merge_standardized_name`, now that all the test dates are also in that file, the `sched_rt_category` column looks accurate.
-        * <s>Rename `stop_primary_direction` to `route_primary_direction`</s> Done. 
-        * Once I'm done: go into `gtfs_funnel/MakeFile` and write. Run this part of the Makefile to make changes to all of the files for all of the dates. Then go to `gtfs_digest/merge_data`. Delete the lines below after I'm done.
-        `cardinal_dir_changes: 
-         --- python schedule_stats_by_route
-         --- python clean_route_naming`
-<s>* Makefile and installing requirements for gtfs digest?
-    * Find those versions and pin it down. 
-    * Maybe it should be moved to _shared_utils/requirements
-    * Amanda: done with this, found the latest version of `altair` and `altair_transform` that I download and update.</s>
-* Tiffany ran May later because LA Metro was missing.
-    * June's data will be run tomorrow.
-    * Data for the most current month is run on the 2nd Thursday of each month. 
-    * There are certain areas  of the `gtfs_funnel/MAKE_FILE` when you can actually open up a notebook and work. VP stuff gets close to the limit, but schedule takes a lot less memory.
+### Running to-do list
+* Portfolio:
+    * Figure out Makefile situation.
     
-### 6/7/2024
-* I have added my work into the right file and it runs pretty fast. However, now that I'm done with this step I have no idea what to do. 
-* Questions for Tiffany about adding Cardinal Direction into the pipeline
-> so i would definitely stand up a test portfolio + scripts that generate the time-series data. you will need to cover the complete pipeline:
-most upstream step (somewhere in gtfs_funnel)
-data processing (situate your steps somewhere, either in gtfs_funnel, but it may be elsewhere, and you'd want to slightly programmatically rename the file, maybe just +_test so you can grab the newly processed data easily through each stage)
-  * What does "upstream step" mean?
-  * What's the difference between all your work in `data-analyses/gtfs_funnel` and `gtfs_funnel/merge_data.py`. 
-> every output needs a new suffix while you're testing. and then you point your input to that.
-otherwise, you'd have to run all the dates (with schedule data, that's not a big deal, but 2 min here and there over 30-40 dates does add up).
-stop_times -> aggregate to route_dir -> schedule_data_for_date1 (AH note: this is how the dataset is constructed for one date)
-time-series = schedule_data_for_date1 , schedule_data_for_date2, schedule_data_for_date3 (AH note: )
-if you added a column in date3, that column isn't present in date1, date2, so time_series_utils would error because it's looking for all the columns you listed
-digest is displaying whatever is concatenated in time_series_utils
-* What do you mean by output and input? When you say input are you talking about the dataframes I add to make this into a time series?
+### 6/25/2024
+* Working on cardinal direction stuff. 
+    
+### 6/6/2024
+* Troubleshooting the # of unique routes an operator runs. BART seems really high, which is the impetus for this investigation. 
+    * Work is in `18_operator_profiles.ipynb`.
+    * BART splits the route into essentially 2 because it uses one Route ID when the train goes North and another Route ID when the train goes South.
+    * Also took a look at San Francisco Muni: we identify 68 unique routes and their website lists about 70. 
+    * IDEA: add verbiage that says "approximately":
+    <i>Route Typologies The following data presents an overview of GTFS statistics using data from the most recent date of April 2024. City and County of San Francisco ran <b>approximately</b> 68 unique routes.</i>
+* Continue working on adding Cardinal Direction to the pipeline.
+* Second draft of common definitions added into `methodology.md`.
+### 6/5/2024
+* Was working on adding Cardinal Dir to the Pipeline.
 
-> if you want to test a smaller set of dates to make sure it's working, i would start adding suffixes to everything.
-stop_times -> aggregate to route_dir -> schedule_data_for_date1_test
-time-series = schedule_data_for_date1_test , schedule_data_for_date2_test, schedule_data_for_date3_test
-digest can pull from a test file with just 3 dates to see if it has everything.
-once you're happy with it, you have to run all the scripts that are affected schedule_stats_by_route_direction, anything downstream that uses that intermediate output, all the way through to digest for all the dates in rt_dates.y2023_dates and rt_dates.y2024_dates
-* Where do I find `aggregate to route_dir`? 
-* `Test file`: is this like saving the outputs into GCS like 'may_2024_test.parquet'?
-* How do I know which scripts are affected by `schedule_stats_by_route_direction`?
+### 6/4/2024
+* Finish up writing the common definitions that will be added in the `methodology.md`.
+* <s>Rerun all of the districts for schedule+GTFS and schedule only operators for TTTF #4.</s>
 
-> yes, but before the meeting, can you go through and identify in a notebook or text file what you think is the "batch" from upstream to downstream?
-script 1, input file is data1, output file is data2
-script 2, input file is data2, output is data3
-and so forth, until you reach the digest, wherever you think the end script is
-* What is the "batch"?
-* What do you mean by "reach the digest?"
-* [Run everything using this Makefile](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/Makefile)
-* [schedule_stats_by_route_direction.py](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L15)
-    * `assemble_scheduled_trip_metrics` 
-        * Input:
-            * `import_scheduled_trips`
-            * `import stop times direction`
-        * Output:
-            *GTFS_DATA_DICT.rt_vs_schedule_tables.sched_trip_metrics
-    * `schedule_metrics_by_route_direction`
-        * Input:
-            * End result from `assemble_scheduled_trip_metrics` (for one date)
-        * Output
-            * GTFS_DATA_DICT.rt_vs_schedule_tables.sched_route_direction_metrics
-    * After this goes [here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_digest/merge_data.py#L25)
+### 6/3/2024
+* <s>Add back operators even if they don't have VP positions such as BART.</s>
+    * Updates made in `gtfs_digest/_operators_prep`
+    * Deployed the portfolio with only  D4 operators as a test [here](https://gtfs-digest-testing--cal-itp-data-analyses.netlify.app/district_04-oakland/0__03_report__district_04-oakland__organization_name_stanford-university).
+    * After deploying the D4 subset, I rearranged the organization names in the Table of Content to be alphabetical. 
+    * Bugs in the portfolio
+        <s> * The `try except` clause i put behind <i>Detailed Route Overview</i> doesn't show anything even for operators that have GTFS data. 
+            * For operators without RT data,  the area under <i>Detailed Route Overview</i> displays nothing when it's supposed to display the message I set.</s>
+            * Fixed: have to wrap `display` around the function that makes all the charts. 
+        * BART runs 12 lines according to the `operator_profile` but the map only displays one route.
+            * Same thing with Emeryville Transportation Management, runs 2 routes but only 1 route is on the map.
+        * City of Rio Vista's Route Typology Pie Chart isn't showing up
+            * Was missing the new category '# Coverage Route Types'
+        * <s>The 'longest vs shortest' route charts aren't appearing even in the actual portfolio.</s>
+            * Fixed: I was using a color_palette reference that was renamed awhile back.
+### 5/30/2024
+* <s>Rerun all the operators.</s>
+* Ideas on next steps (in order of priority)
+    * Update the methodology.
+    * <s>Add back operators even if they don't have VP positions such as BART.</s>
+    * Figure out how to add in the cardinal directions back to frequency/text tables as some of the routes switch directions. 
+    * Double check NTD stuff. 
+    * <s>Take out the subtitle for the following graphs since it looks repetitive and cluttered. 
+        * `Frequency of Trips in Minutes` 
+        * `Daily Scheduled Service Hours` charts following Weekday</s>
+### 5/29/2024
+* [Netlify test link I created 5/17.](https://gtfs-digest-testing--cal-itp-data-analyses.netlify.app/district_07-los-angeles/0__03_report__district_07-los-angeles__organization_name_los-angeles-county-metropolitan-transportation-authority)
 
-* What I need to change
-    * [Here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L118C19-L120) add `test` behind the name and [here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_funnel/schedule_stats_by_route_direction.py#L122) change the `analysis_date_list` to only a few dates.
-    * [Here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_digest/merge_data.py#L25) add _test 
-    * [Edit here](https://github.com/cal-itp/data-analyses/blob/ah_gtfs_portfolio/gtfs_digest/merge_data.py#L212) so I only run a few dates.
-* [Only run above here](https://github.com/cal-itp/data-analyses/blob/main/gtfs_digest/merge_data.py#L208-L268)
-* Once I'm happy with this, there's a GCS Public Bucket. That's the very, very late step.
-    * After I deploy everything. 
-* 
-#### Terms
-* Batch
-* Upstream: the least processed
-    * Warehouse: could be unzipped files.
-    * For me, it's something downloaded from the mart.
-    * WE process these unprocessed files with scripts. 
-    * Called by helper functions.
-* Downstream: the most final product.
-    * The most downstream is the digest. 
-    * Whatever is done in the GTFS Digest. 
-* Digest
-    * 
-* Funnel 
-    * When Tiffany is downloading stuff.
-    * Funneling the least processed tables through various scripts to trasnform.
-    * There are 5 tables that are transformed repeatedly into different products. 
-    * Everything that is in `gtfs_funnel`.
-    * 3 big workstreams: 
-        * RT Segment Speeds
-        * Schedule
-        * RT vs Schedule. 
-        * Schedule is also processed in GTFS Funnel. 
-    * Schedule data informs a lot of the interpreation of the vehicle positions
-        * We don't know anything about vehicle positions, what route, shape, direction it is. This data is all found in Schedule data that we connect with GTFS Key.
-        * Trips is the main table of the Schedule universe. 
-* Helper functions just pull dataframes that are downloaded.
-* Downloading happens in another step.
-* Tiffany runs the MAKEFILE in gtfs_funnel.
-* Then Tiffany goes to various other folders and runs everything (HQTA, RT Segment Speeds, etc)
-* Everything at the end goes into the GTFS Digest.
-* GTFS Digest is trying to represent everything through the grain of route-direction.
-* Every month Tiffany runs one day.
-* Batch: a combination of various scripts that are run together.
-* Look at the MAKEFILE and compare it to Mermaid. 
-* Digest: simply a compilation by dates, collects the columns TIffany wants
-    * Select the columns they want.
-* Not all the scripts in the Makefile need to be matched.
-* I can duplicate the files. 
+### 5/17/2024
+* State of the GTFS Digest Portfolio 
+    * All the tweaks in [Issue](https://github.com/cal-itp/data-analyses/issues/1101) except cardinal directions & mapping the routes based on the `route_colors` provided by operators have been addressed. 
+    * There is a rough estimate of the cardinal directions a route is headed.
+        * Cons:
+            * The function to grab the cardinal direction takes a long time. It will take about 2 hours for all the operators to run.
+            * The function looks across the route for all time periods, rather than looking at the direction per date. This is less accurate.
+            * Not all routes record data for both directions. There will be empty graphs for these routes. 
+        * Current tackling:
+            * `Route_id` and the associated names for routes change over time. I am still working on refining the function that attaches the most current `route_id` to the same routes across the entire time span of the dataset. 
+            * Ex: Main Street Route had the ID of 123 in April 2023 but ABC in April 2024. I have to go back and update the ID for April 2023 to be ABC. 
+            * The function is very slow. Grabbing all of the stops and finding the direction they points means the dataset is huge, especially because we need all the dates possible. I am working on using `dask deployed` to speed things up. 
+    * Service Hour Charts
+        * Finished. There are now 3 charts for daily weekday, Saturday, and Sunday total service hours across all the routes.
+        * Right now, we only have data for the entire weeks of April and October 2023. April 2024 to come.
+        * Added a new column `weekday_service_hours` to `_section1_utils.total_service_hours` that divides the sum of `service_hours` by 5 for an accurate count. Previously, this was done incorrectly. 
+
+### 5/16/2024
+To-Do
+* <s>Noticed a bug after running all of the operators...Figure out why the cardinal direction shows southbound and northbound even for the east/west directions.</s>
+* In the future, speed up the cardinal direction work? Or it'll be added to the pipeline? Right now it takes a very long time. 
+* Table of Contents on the portfolio site: the operators are not alphabetical. 
+    * D7: LA Metro is before City of Santa Monica/City of X/City of Y
+* <s>Fix service_hours chart-> divide weekday by 5</s>
+* <s>Add in dropdown menu to show only the first route</s>
+    * Found a solution through Stackoverflow. 
+### 5/15/2024
+* <s>Add explanations for why we chose these cutoffs in the `color_palette.yml`</s>
+* Continue cardinal directions work.
+* Rerun portfolio. 
+
+### 5/14/2024
+* Add back cardinal directions to `direction_id`. 
+    * I am done grabbing all the dates available, stacking them together, and aggregating for only one particular operator, let's call the dataframe `cardinal_dir_df`. 
+    * This is a big dataset, so I want to read in only the rows that are absolutely necessary. 
+    * When I merge this `cardinal_dir_df` with `sched_vp_df`, none of the routes match. I need to use [this script](https://github.com/cal-itp/data-analyses/blob/b1e5d4f870400251240eeba4a6515a0848e5d6f8/gtfs_funnel/clean_route_naming.py#L4) to clean up the names on the `cardinal_dir_df`
+* Displaying only the first route -> 
+    * Even after upgrading `altair` to the latest version of `5.3` I am still unable to accomplish this goal using the sample `cars` dataset. 
+### 5/13/2024
+* <s>For Service Hour Charts by weekday, Saturday, and Sunday.
+    * Added this to the target notebook for the GitHub site</s>
+* Didn't receive any answers to my question on  Stackoverflow yet about displaying only the first route. 
+* Add back cardinal directions to `direction_id`. 
+    * Met with Tiffany yesterday to understand how to aggregate everything properly. 
+* Section 2
+         * Vehicle Positions per Minute, % of RealTime Trips, % of Scheduled Trips, and Spatial Accuracy charts, figure out if there's a way to color the background so the bottom  red, middle is yellow, and the top is green to signify the different "zones/grades".
+        * <b> Note 4/16 </b> Having a hard time getting this to work. Facet doesn't allow for layering and it seems like the background impacts the colors of the main chart, making everything hard to view.
+        * <b> Note 5/13 </b>: I was able to get the background to be shaded perfectly for the `Service Hour Charts` but `faceting` charts causes this shading to become wonky. Therefore, this goal is now retired. 
+        <s>* Create an Altair chart with just a title/subtitle to divide out metrics about the quality of the rider's experience on a route vs the quality of the data collected about the route.</s>
+### 5/10/2024
+* How to display only the first value before filtering for charts. Right now, the charts show stuff for all months/routes and this is confusing.
+    * Still couldn't get this to work even with a very simple `cars` dataset from the Altair example. 
+    * Submitted a question onto StackOverflow for help. 
+* <s>Service Hour chart.</s>
+    * Show chart to Eric and Katrina & double check the aggregation with Tiffany before making it into functions.
+
+
+### 5/9/2024 To-Do
+* <s>Frequency Chart: make the colors a set range, so all routes will always be dark green if a bus going that route and direction comes by every 10 minutes, dark red if every 60 minutes.</s>
+* <s>Spatial Accuracy: Confirm with Tiffany about buffer and add the buffer into the subtitle.</s>
+    * The buffer is 35m.
+
+### 5/8/2024 To-Do 
+* <s>% RT Journey Chart with VP: delete</s>
+* <s>Total Monthly Scheduled Service Chart: delete</s>
+* <s>Speed Chart: use different colors. Red, green, and yellow suggest bad, good, and ok.</s>
+
+* <s>Route Typology Chart: remove the subtitle. Add in a blurb from the methodology.md about how routes are categorized. Add a hyperlink to NACTO Route guide.</s>
+### 5/6/2024
+<s>* Eric: the maps from .explore() look pretty overwhelming when an operator has many routes. 
+    * Can we modify the reports site maps to be used here too? 
+    * Check Total Service Hours charts.</s>
+    * 5/8: Not worth the effort and people probably won't even interact with the map to look at a singular/a few routes.
+* Streamline code, some of the code for my charts is redundant.
+* NTD
+    * Ask people for feedback on the NTD copy.
+    * Try to connect the agencies by ntd_id instead of name? 
+    * Tiffany:
+        * Explain NTD_ID situation again? 
+    * Change NTD copy so it doesn't run off the page
+    * Alternatively, set the max width for each cell so nothing runs off?
+* Update Makefile stuff.
+    * https://github.com/cal-itp/data-analyses/blob/main/ntd/Makefile#L4
+    * The goal is to write one line of code in the terminal and have the entire portfolio deploy each month.
+* When should this be updated every month? The beginning?
+* If I want to start on the bunching metric, which folder do I work out of? 
+
+### 5/2/2024
+* <s>Update README with some of the methodology FAQ.
+* Officially deploy portfolio
+    * https://github.com/cal-itp/data-analyses/blob/main/Makefile#L69</s>
+### 5/1/2024
+* <s>Add in NTD data.</s>
+* Update Readme.MD
+    * Cherry pick commit.
+    * Link to Methodology
+* <b>Consolidate the total service hours charts with Eric's findings.</b>
+* <s>Address Tiffany's comments
+    * can you change the thickness of the line chart, looking a bit thick, no?
+    * also in the text in the beginning, it's now reading like Apr, 2024, but should read Apr 2024
+    * semi-annoying that the legend label runs off the page, perhaps the chart width needs to shrink by a little. the alternative seems more cumbersome, which is to inject a list into the legend</s>
+        * Amanda: Changed the name of legend values that were running off. 
+    * <s>maybe work more headers in? there's just 2 main headers, but kind of a lot of sections, like "map of routes" (this one esp gets buried) probably can be its own, "route typology"</s>
+    * spacing after the map is really big - why?
+        * Amanda: Think this always happens with `.explore()` but I need to talk to Eric about using something else to display the maps because operators with a lot of routes gets very overwhelming. 
+    * <s>in the caption, pick a consistent spacing: Early AM:time vs Early AM: time</s>
+    * <s>monthly aggregation label Full Date actually refers to  Month</s>
+    *<s> spatial accuracy - static route shape -> scheduled shape (path)
+        * Amanda: Confirm with Tiffany what this means? </s>
+    * <s>GTFS always spelled like that, not Gtfs (in your text box for route dropdown)</s>
+    * <s><b>name of the portfolio should be GTFS Digest, not GTFS Exploratory</b></s>
+    * <s>colors for the average scheduled minutes for route...yellow/red may not be the best choice here, it's not a good or bad thing to be direction 0/1. the way yellow/red are used elsewhere does seem to indicate good vs bad.</s>
+    * <s>can you write the counties served as a sentence? LA Metro: Los Angeles, Ventura, Orange (alphabetized).</s>
+        
+### 4/30/2024
+* <s>Update readme.
+    * 5/1 Check with Tiffany that this is what she's looking for.</s>
+* <s>Rebase off of main and update the URL for service_hours</s>
+* <s>Add in divider charts to Section 2 that sort the charts thematically.</s>
+### 4/29/2024
+#### To-Do
+*  <s>Routes Pie Chart
+    * Confirm again that a route can fall into various categories.
+    * D3 UCD only runs 19 unique routes but the piechart has like 30+ routes.
+    * Same with D4 Central Contra Costa Transit Authority
+    * Update with new cols: 'it's like downtown_local, local, coverage, rapid, express, rail'</s>
+* <s>Section 1 Total Service Hours
+    * Dates should be sorted in descending order, so the most recent date is at the top
+    * Make a new daily chart, continue automating finding the number of each type of day in a year. 
+    * Refine total hours across the month chart.</s> 
+* Section 2
+    * <s>Need to update `spatial_accuracy` subtitle.</s>
+    * Continue troubleshooting the javascript message that has now appeared.
+        * Figured out the error was due to `def create_data_unavailable_chart():
+
+        chart = alt.LayerChart()
+    
+        return chart`
+    
+### 4/26/2024
+#### To-do Today
+* <s>Remove the mapping for the `Total Service Hours` with the weekday column that is in the dataset. </s>
+     * Create a new chart  chart names to Eric's suggestions.
+* <s>Reorder charts thematically. Add a little chart in between that explains the divide.</s>
+* <s>Double check that all the column names when injecting into charts/display are correct. I caught a mistake: I plugged in RT trips when I wanted to display Scheduled trips in section 3.</s>
+
+#### Notes 
+* Tried making a map that is controlled with an `ipywidget` dropdown menu so users can view one map at a time. This only works in the notebook and not when uploaded onto GH pages.
+    * Go back to using .explore()
+    * I tried using altair yesterday but altair can only plot geomtype of points, not lines. 
+* `Total Service Hours` doesn't match reports...still trying to debug.
+* Section2
+    * After updating the graphs for section 2, I now get this message `Javascript Error: Unrecognized signal name: "concat_1_width"
+This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`. 
+    * I noticed I have to run the same cell twice in order to get the charts to generate `for _ in range(2):` but this is not ideal because the error is not resolved and is still displayed. 
+    * Some operators aren't even running like Emeryville:
+        `Javascript Error: Unrecognized signal name: "concat_1_width"
+This usually means there's a typo in your chart specification. See the javascript console for the full traceback.
+Javascript Error: Unrecognized signal name: "concat_3_width"
+This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`
+    * All the charts generate fine on their own, error is coming from concating them? 
+    
+* Goals
+    * <s>Finish copy on readable.yml</s>
+    *<s> Convert all of the charts to read from the readable.yml. </s>
+        <s>* For charts in section 1, add subtitles and title.</s>
+    * <s>Change section3utils references back to section2.</s>
+   
+  
+   * <s>Double check section3.add_categories() is accurate. 
+       * Decided to take it out since I'm not using this in any of the charts.</s>
+### 4/24/2024 
+#### Questions for Tiffany
+* Operator Overview (section 1)
+    * The Pie Chart with Total Routes by Typology doesn't match the number of unique routes. 
+            * UC Davis runs 19 unique routes but there are 20 routes in the pie chart.
+            * Double check this w/ Tiffany.
+    * For the `Total Service Hours` month, I mapped 1 to be Monday, 2 to be Tuesday, etc. Double check and make sure it's correct.
+    * Confirm about total daily trips
+        * This is now only displaying "all_day" columns but some still seem very high?
+* Status on route classification?
+* Status on road classification?
+* Bunching metric game plan? 
+* Incorporate agency classification into this portfolio? 
+
+#### Comments from Tiffany
+##### Done
+* formatting for numbers, include the comma (like 1,000 instead of 1000)...like {,} (https://pbpython.com/styling-pandas.html)
+    * Done, rounded up the individual numbers since I'm not sure if you can grab values off of a styled dataframe.
+* First sentence: This section presents an overview of statistics for Los Angeles County Metropolitan Transportation Authority, using data from the most * recent date of 3/2024 ...replace the 3/2024 to display March 2024 as a more readable format
+    * Done, now displays month in string
+* add a map displaying all the routes, i think a gdf.explore() would work -- although let me know if this is what's breaking the map
+* vp per minute chart probably shouldn't run up to 5. it really only hits 3 as a max...so either 3.5 or 4 for y-axis
+    * 4/24: added it back in.
+* Total Scheduled Service Hours ....not blue for time-of-day. go with categorical scale? also set the colorscale manually because no color should be repeated
+    * I think I addressed this? Confirm with Tiffany.
+* Fill out your readable.yml for better displaying column names and captions -- you're already working on this    
+
+##### Having Issues
+* yes, leave out the chart unavailable. i've tried this: when you're concatenating altair charts but you're missing one, you'd basically do like chart2= alt.LayerChart() so that when you do
+ chart_list = [chart1, chart2, chart3]
+ chart = alt.vconcat(*chart_list)
+you're not missing any chart, but it's just an empty nothing, but there's no title, no df being read in</s>
+    * Still doesn't work once I concat the charts, I think the route dropdown is impacting this? 
+* have you tried this: https://stackoverflow.com/questions/70937066/make-dropdown-selection-responsive-for-y-axis-altair-python
+    * Having trouble getting it to work with our charts but it works in the Stack Overflow example.
+    `dropdown = alt.binding_select(
+    options=['Miles_per_Gallon', 'Displacement', 'Weight_in_lbs', 'Acceleration'],
+    name='X-axis column '
+)
+xcol_param = alt.param(
+    value='Miles_per_Gallon',
+    bind=dropdown
+)`
+#### Goals for today 
+* <s>Update frequency</s>
+* Incorporate comments from Tiffany.
+
+### 4/23/2024
+* <s>Check the # of daily trips again in section 3. Even after dropping duplicates, it still seems crazy high.</s>
+    * Solution: filter on `time_period == all_day`.
+* <s>"Operator Overview":
+    * Add a sentence about the Total Scheduled Service Hours and what it means.</s>
+* Reran all pages for all operators: this time it worked.
+    * I think it's because I dropped duplicates  when reading in `sched_vp`.
+    * Observations of wonky things.
+    * Organization - City of Eureka, Route - AMTRS Red Route
+        * Frequency of Trips Per Hour Chart: some of the charts look funky.
+        * Section 3
+        * <s>Still says "Scroll down to filter for a specific route" update it to something else since the dropdown menu is now on the right.</s>
+        * `Frequency of Trips per Hour` is kidn of confusing, when it's a low number like 0.04. What does that mean? Should it be X every X hours instead? 
+        * `Average Speed` charts' interactive legend doesn't work. I want people to be able to view one time period at a time because sometimes the lines overlap too closely to see anything.
+        * `Vehicle Postions per Minute`: set anything above 2 as green. Right now, the color scale maps to lowest and highest value. Some routes that record 3 vps per minute now have bars that red when only 2 vps were recorded, even though 2 is good.
+            * Ex: Mendocino Transity Authority 20 Willits/Ukiah 
+            * Same thing with `Spatial Accuracy` Chart: anything above 95 should be green...
+    * <s>Bring make the `explore` map maybe once all the other sections are done so we can visualize the reach of the transit agency?</s>
+* Notes from 1:1
+    * Who is the target audience?
+        * Local agencies 
+        * TTTF
+        * Advocates
+    * What is the transit background/knowledge of the audience?
+        * General public?
+        * Data enthusiasts? 
+        * Transit enthusiasts?
+    * The metrics presented cover both data quality metrics (spatial accuracy, density of GPS pings per minute) and the quality of the rider's experience (early/late/ontime trips and speed). How to incorporate these two themes seamlessly? 
+        * Themes are interrelated.
+        * Some audience members are interested more in one theme than the other. 
+        * Delineate Section 3 into these two themes? Section 2 is a snapshot...focus on quality of the experience?
+    * How to present this information?
+        * Too much information and too many charts is overwhelming, what's the perfect amount? 
+        * Perhaps to the general person, vehicle positions is not easily grasped. Explain what it is, why it's important to transit improvement, why it's relevant to the transit rider's experience.
+        * Work on captions/chart names/metric names/metric categories to make them more easily understandable.
+            * Use the readme.md as a "How to Understand" Guide? Glossary?
+    * Bunching: mostly relevant to agencies with lots of riders/frequent routes. 
+        * Do we run this metric for all agencies or only some? This metric wouldn't be meaningful to some agencies/routes...
+    
+### 4/22/2024
+* I updated the yaml because last week, I discovered there are multiple organization name-name combos and duplicates. This work is in `07_crosswalk.ipynb`. 
+    * The new yaml includes only one row for one organization.
+* Last week, I tried to run all the operators. However, the notebook would error out at AC Transit & SF Muni. 
+    * To test, I commented out a lot of the charts in the `section2.filtered_route(sched_vp_df)` part. 
+    * All the operators' github pages were successfully generated however this seems to hint that too many Altair charts causes things to go a bit wild. 
+    * Cut down on charts? Not sure. 
+* Comments on the new GitHub Pages
+    * Operator Overview (section 1)
+        * The Pie Chart with Total Routes by Typology doesn't match the number of unique routes. 
+            * UC Davis runs 19 unique routes but there are 20 routes in the pie chart.
+            * Double check this w/ Tiffany.
+        * <s>Double check the longest and shortest route. Some routes are VERY long.
+            * City of Eureka in D1 has a route that is almost 160 miles.
+            * Yes this is correct</s>
+        * For the "public transit provided in the following counties" style the dataframe instead of printing it. Maybe concat a bullet point to the county so it looks like a list?
+         * Need to add back stop information. </s>
+   * Detailed Route-Direction Overview (section 3)
+       * <s>What's that box that prints "None"?? Why is it generated for every page??
+           * Prints "None" because I wrapped the `great_table` with `display()`</s>
+       * <s>`create_data_unavailable_chart()` doesn't work  when adding a dropdown menu to allow for route selection...only works with one route example  in `01_section3.ipynb` 
+           * Test: Gold Route in City of Eureka 
+           * Test: 6 wellness express  "Palo Verde Valley Transit Agency"/'Desert Roadrunner GMV Schedule' in d8
+           * Tried returning a `print` statement but it didn't work. </s>
+        
+### 4/17/2024 Notes
+    * Example: just have one chart for speeds for both directions? 
+* For `operator_profiles` some organizations don't have any information for March. 
+    * in `04_gtfs_exploratory.ipynb` Blue Lake Rancheria's most recent information is from last September. 
+    * Some organizations don't have information at all such as Peninsula Corridor Joint Powers. 
+        * However this organization appears to have speed/trip data. 
+    * We want only one organization to map with one name
+        * Keep only the most recent name-row for the organization_name.
+* AC Transit & SF Muni always throws an error:
+    * "nbclient.exceptions.CellTimeoutError: A cell timed out while it was being executed, after 4 seconds.
+    The message was: Timeout waiting for IOPub output.
+    Here is a preview of the cell contents:
+    -------------------
+    section2.filtered_route(sched_vp_df)"
+    
+    * This didn't happen last time. 
+    * Test what is going wrong one element at a time. 
+* Readable.yml
+    * Operators -> what does it mean when you have `organization_name:Organization`. 
+        * Organization is a string. 
+        * Other column names have "" to avoid any special symbols like () or + being read in weird. 
+
+### 4/11/2024 Run 
+To-Do
+* YML
+    * How do I get the values from the `organization_name` column to show up on the left hand panel but I want to filter on  `name`?
+* Modify the `makefile`
+* Add in the different sections.
+* <s>Move all `read_parquet` to reference stuff grabbed from `catalog_utils.get_catalog("gtfs_analytics_data")`.</s>
+* <s>`Average Total Service Hours` chart </s>
+    * Rename as `Total` because it is not the average.
+    * Move the chart out of route-direction monthly overview
+    * Concat the dataframes together so users can filter for months in both 2023 and 2024.
+* Route-Direction Monthly Overview Section
+    * <s>Great tables: dates are a little different (minor). Move the great table to the bottom OR add another markdown line right before all the charts to instruct users to filter by route or else the charts won't make any sense.</s>
+    * Charts: 
+        * Test if making a simple chart then adding more encoding and domain ranges will work? This is for later.
+        * Make it a bit smaller.
+        * Add a function that resizes the charts instead of having the properties configured for each one? 
+        * <s>Move dropdown to the top</s>
+        * I got the `this exceeds the max rows allowed for Altair` error for AC Transit...I turned off the warning but I am worried this will backfire in the future. Figure out a way to summarize all the info without making files unbearably large.
+        * <s>Maybe update the color palette to something more meaningful? Like red to green to for `vehicle positions per minute` so the fewer the vps, the redder?</s>
+        <s>* If there are no values for a certain chart,display a message instead of a blank chart.</s>
+            * <b> Note 4/17</b>: Created a chart that returns "no chart available, not enough data."
+        * Maybe all_day can be a pink/red color while the peak and offpeak can remain blue? 
+        * <s>Add interactive() behind each chart.</s>
+        * <s>Minor but make sure all the dates are slanted at 45 degrees for readability.</s>
+        * What will happen once we add more dates?? 
+        * How to display only one route before you filter down to the route you choose. For now all the routes show and this is seriously confusing.
+            * <b> Note 4/17 </b> [The former method is no longer working.](https://github.com/cal-itp/data-analyses/blob/main/rt_segment_speeds/_threshold_utils.py)
+    * <s>Frequency of Route chart: change from heatmap because this is confusing to people.</s>
+        * <b> Note 4/16 </b>: switched to a faceted chart that repeats. 
+    * <s>Speed chart: how to make `all_day` speed more obvious.</s>
+            * <b> Note 4/16 </b>: switching over to a new color palette now makes `all_day` a red color so this is more obvious. 
+    * For Vehicle Positions per Minute, % of RealTime Trips, % of Scheduled Trips, and Spatial Accuracy charts, figure out if there's a way to color the background so the bottom  red, middle is yellow, and the top is green to signify the different "zones/grades".
+        * <b> Note 4/16 </b> Having a hard time getting this to work. Facet doesn't allow for layering and it seems like the background impacts the colors of the main chart, making everything hard to view.
+    * <s>Route Statistics for Route for Dir 0/1: Quite often nothing shows up...Figure out why?? Stuff shows up on the charts. 
+        * Example route: 652 Skyline High - Elmhurst Bay Area 511 AC Transit Schedule</s>
+            * <b> Note 4/17 </b>: Fixed this. The `_section2_utils.route_stats()` function needs outer merges. I also edited the `create_text_table()` function to drop duplicate rows. Without dropping duplicate rows, the text table overlays all the rows and you can't read the text. 
+

--- a/gtfs_digest/merge_data.py
+++ b/gtfs_digest/merge_data.py
@@ -11,18 +11,12 @@ from segment_speed_utils import gtfs_schedule_wrangling, time_series_utils
 from update_vars import GTFS_DATA_DICT, SEGMENT_GCS, RT_SCHED_GCS, SCHED_GCS
 
 route_time_cols = ["schedule_gtfs_dataset_key", 
-                   "route_id", "direction_id", "time_period"]
+                   "route_id", 
+                   "direction_id", 
+                   "time_period"]
 
 sort_cols = route_time_cols + ["service_date"]
-
-route_time_with_cardinal_dir_cols = [
-    "schedule_gtfs_dataset_key",
-    "route_id",
-    "direction_id",
-    "time_period",
-    "route_primary_direction",
-]
-
+route_time_with_cardinal_dir_cols = route_time_cols + ["route_primary_direction"]
 sort_cols_with_cardinal_dir_cols = route_time_with_cardinal_dir_cols + ["service_date"]
 
 def concatenate_schedule_by_route_direction(

--- a/gtfs_funnel/schedule_stats_by_route_direction.py
+++ b/gtfs_funnel/schedule_stats_by_route_direction.py
@@ -12,6 +12,72 @@ from segment_speed_utils import helpers, gtfs_schedule_wrangling
 from shared_utils.rt_utils import METERS_PER_MILE
 from update_vars import GTFS_DATA_DICT, SCHED_GCS, RT_SCHED_GCS
 
+def cardinal_direction_for_route_direction(analysis_date:str, dict_inputs:dict):
+    """
+    Get a cardinal direction (North, South, East, West) on the route grain.
+    """
+    STOP_TIMES_FILE = dict_inputs.rt_vs_schedule_tables.stop_times_direction
+    
+    stop_times_gdf = pd.read_parquet(
+    f"{RT_SCHED_GCS}{STOP_TIMES_FILE}_{analysis_date}.parquet",
+    filters=[[("stop_primary_direction", "!=", "Unknown")]
+    ])
+    
+    trip_scheduled_col = [
+    "route_id",
+    "trip_instance_key",
+    "gtfs_dataset_key",
+    "shape_array_key",
+    "direction_id",
+    "route_long_name",
+    "route_short_name",
+    "route_desc",
+    "name"
+    ]
+        
+    trips_df = helpers.import_scheduled_trips(analysis_date, 
+                                             columns = trip_scheduled_col,
+                                             get_pandas = True)
+
+    
+    # Merge dfs
+    merge_cols = ["trip_instance_key", 
+                  "schedule_gtfs_dataset_key", 
+                  "shape_array_key"]
+    
+    stop_times_with_trip = pd.merge(stop_times_gdf, trips_df, on = merge_cols)
+    
+    # Fill in missing direction id with 0, per our usual practice.
+    stop_times_with_trip.direction_id = stop_times_with_trip.direction_id.fillna(0)
+    
+    main_cols = [
+        "route_id",
+        "schedule_gtfs_dataset_key",
+        "direction_id"
+    ]
+    
+    agg1 = (
+        stop_times_with_trip.groupby(
+            main_cols + ["stop_primary_direction"]
+        )
+        .agg({"stop_sequence": "count"})
+        .reset_index()
+        .rename(columns={"stop_sequence": "total_stops"})
+    )
+    
+    # Sort and drop duplicates so that the
+    # largest # of stops by stop_primary_direction is at the top
+    agg2 = agg1.sort_values(
+        by= main_cols + ["total_stops"],
+        ascending=[True, True, True, False],
+    )
+    
+    # Drop duplicates so only the top stop_primary_direction is kept.
+    agg3 = agg2.drop_duplicates(subset= main_cols).reset_index(drop=True)
+    
+    agg3 = agg3.drop(columns=["total_stops"])
+    return agg3
+
 def assemble_scheduled_trip_metrics(
     analysis_date: str, 
     dict_inputs: dict
@@ -59,8 +125,8 @@ def assemble_scheduled_trip_metrics(
         how = "inner"
     )
     
-    display(median_stop_meters_df.info())
-    #median_stop_meters_df.direction_id = median_stop_meters_df.direction_id.fillna(0)
+    # display(median_stop_meters_df.info())
+    median_stop_meters_df.direction_id = median_stop_meters_df.direction_id.fillna(0)
    
     return median_stop_meters_df
     
@@ -68,18 +134,16 @@ def assemble_scheduled_trip_metrics(
 def schedule_metrics_by_route_direction(
     df: pd.DataFrame,
     analysis_date: str,
-    group_cols: list,
-    merge_cols:list
+    group_merge_cols: list,
 ) -> pd.DataFrame:
     """
     Aggregate trip-level metrics to route-direction, and 
     attach shape geometry for common_shape_id.
     """
-    
     service_freq_df = gtfs_schedule_wrangling.aggregate_time_of_day_to_peak_offpeak(
-        df, group_cols, long_or_wide = "long")
+        df, group_merge_cols, long_or_wide = "long")
         
-    metrics_df = (df.groupby(group_cols, 
+    metrics_df = (df.groupby(group_merge_cols, 
                              observed=True, group_keys=False)
                   .agg({
                       "median_stop_meters": "mean", 
@@ -108,11 +172,11 @@ def schedule_metrics_by_route_direction(
     df = pd.merge(
         common_shape,
         metrics_df,
-        on = merge_cols,
+        on = group_merge_cols,
         how = "inner"
     ).merge(
         service_freq_df,
-        on = group_cols,
+        on = group_merge_cols,
         how = "inner"
     )
     
@@ -130,43 +194,42 @@ if __name__ == "__main__":
     for date in analysis_date_list:
         start = datetime.datetime.now()
         
+        # Find metrics on the trip grain
         trip_metrics = assemble_scheduled_trip_metrics(date, GTFS_DATA_DICT)
         trip_metrics = trip_metrics.rename(columns = {"stop_primary_direction":"route_primary_direction"})
         
         trip_metrics.to_parquet(
             f"{RT_SCHED_GCS}{TRIP_EXPORT}_{date}.parquet")
         
-        route_group_cols = [
+       
+        route_group_merge_cols = [
             "schedule_gtfs_dataset_key", 
             "route_id", 
-            "direction_id",
-            "route_primary_direction"
-        ]
-        
-        route_merge_cols = [
-            "schedule_gtfs_dataset_key", 
-            "route_id", 
-            "direction_id",
+            "direction_id"
         ]
         
         route_dir_metrics = schedule_metrics_by_route_direction(
-            trip_metrics, date, route_group_cols, route_merge_cols)
+            trip_metrics, date, route_group_merge_cols)
         
         route_typologies = pd.read_parquet(
             f"{SCHED_GCS}{ROUTE_TYPOLOGIES}_{date}.parquet",
-            columns = route_merge_cols + [
+            columns = route_group_merge_cols + [
                 "is_coverage", "is_downtown_local", 
                 "is_local", "is_rapid", "is_express", "is_rail"]
         )
         
+         # Find cardinal direction on the route grain
+        cardinal_dir_df = cardinal_direction_for_route_direction(date,GTFS_DATA_DICT)
+        
+        # Merge cardinal direction & typology work
         route_dir_metrics2 = pd.merge(
             route_dir_metrics,
             route_typologies,
-            on = route_merge_cols,
+            on = route_group_merge_cols,
             how = "left"
-        )
-        
-        # ADD Cardinal direction here 
+        ).merge(cardinal_dir_df,
+            on = route_group_merge_cols,
+            how = "left")
         
         utils.geoparquet_gcs_export(
             route_dir_metrics2,


### PR DESCRIPTION
* In response to #1135.
* I made the changes detailed in #1145 
* Updated lists of columns for grouping and merging so there is less repetitiveness. 
* Separated the function that finds the cardinal_direction out of `assembled_scheduled_trip_metrics()` and into its own function, since it is on the route grain.
* Merged the results from the new `cardinal_direction_for_route_direction()` directly into `schedule_metrics_by_route_direction()`.
* Experimented with filling in the `nans` for the `direction_id` column in `cardinal_direction_for_route_direction()` and `assemble_scheduled_trip_metrics`: it only seems to add more rows for `assemble_scheduled_trip_metrics` when the dataframe gets grouped together.
* Deleted out group and merge_cols.