### PR TITLE
Aggregate HOV pems dataset to station-weekday-hour and station-weekday-peak/offpeak

### DIFF
--- a/traffic_ops/aggregate.py
+++ b/traffic_ops/aggregate.py
@@ -1,0 +1,251 @@
+"""
+Aggregate to various grains.
+"""
+import dask.dataframe as dd
+import datetime
+import gcsfs
+import pandas as pd
+import uuid
+
+from dask import delayed, compute
+from pathlib import Path
+from typing import Literal
+
+import utils
+from utils import RAW_GCS, PROCESSED_GCS
+
+fs = gcsfs.GCSFileSystem()
+
+
+station_id_cols = [
+    'station_id',
+    'freeway_id',
+    'freeway_dir',
+    'city_id',
+    'county_id',
+    'district_id',
+    'station_type',
+    'param_set', 
+    #'length',
+    #'abs_postmile', 
+    #'physical_lanes'
+]
+
+def create_station_crosswalk(df: dd.DataFrame) -> pd.DataFrame:
+    """
+    Put in a set of columns that identify the 
+    station + freeway + postmile position.
+    Create a uuid that we can use to get back all 
+    the columns we may want later.
+    """
+    crosswalk = df[
+        station_id_cols
+    ].drop_duplicates().reset_index(drop=True)
+    
+    
+    crosswalk = crosswalk.compute()
+    
+    crosswalk["station_uuid"] = crosswalk.apply(
+        lambda _: str(uuid.uuid4()), axis=1, 
+    )
+      
+    crosswalk.to_parquet(
+        f"{PROCESSED_GCS}station_crosswalk.parquet"
+    )
+    
+    return
+
+
+def read_filepart_merge_crosswalk(
+    filename: str,
+    filepart: str, 
+    **kwargs
+) -> pd.DataFrame:
+    """
+    Import onen partition and merge in crosswalk
+    """
+    filepart_name = Path(filepart).name
+    
+    df = pd.read_parquet(
+        f"{RAW_GCS}{filename}/{filepart_name}",
+        **kwargs
+    )
+    
+    crosswalk = pd.read_parquet(
+        f"{PROCESSED_GCS}station_crosswalk.parquet"
+    )
+    
+    df2 = pd.merge(
+        df,
+        crosswalk,
+        on = station_id_cols,
+        how = "inner",
+    ).drop(columns = station_id_cols)
+    
+    return df2
+
+
+def aggregate_metric(
+    df: pd.DataFrame, 
+    group_cols: list, 
+    metric_name: Literal["flow", "truck_flow", "occ", "obs", "speed"] 
+) -> pd.DataFrame:
+    
+    metric_cols = [c for c in df.columns if metric_name in c]
+    
+    if metric_name == "speed":
+        metric_agg = "mean"
+    else:
+        metric_agg = "sum"
+    
+    if metric_name in ["occ", "speed", "obs_speed"]:
+        metric_dtypes = {c: "Float64" for c in metric_cols}
+    
+    else:
+        metric_dtypes = {c: "Int64" for c in metric_cols}
+    
+    df2 = (
+        df
+        .groupby(group_cols, 
+                 group_keys=False)
+        .agg(
+            {**{c: metric_agg for c in metric_cols}}
+        ).reset_index()
+        .astype({
+            **metric_dtypes,
+            "year": "int16",
+            "month": "int8",
+            "weekday": "int8",
+        })
+    )
+    
+    if "hour" in df2.columns:
+        df2 = df2.astype({"hour": "int8"})
+    
+    return df2
+
+
+def metric_prep(metric: str) -> list:
+    """
+    Grab subset of columns related to a given metric.
+    Merge in crosswalk.
+    Do this across each partition, and return a list
+    of delayed dfs that are have time columns, 
+    ready to be aggregated.
+    """
+    filename = "hov_portion"
+    list_of_files = fs.ls(f"{RAW_GCS}{filename}")
+    
+    all_columns = dd.read_parquet(
+        f"{RAW_GCS}{filename}/",
+        engine="pyarrow"
+    ).columns.tolist()
+    
+    exclude_dict = {
+        "flow": ["obs", "truck"],
+        "occ": ["avg_occ"],
+        "truck_flow": [],
+        "obs_flow": [],
+        "obs_speed": [],
+        "speed": ["avg_speed", "obs"],
+        "pts_obs": [],
+    }
+    
+    metric_cols = [
+        c for c in all_columns if f"_{metric}" in c and not
+        any(word in c for word in exclude_dict[metric])
+    ]
+
+    import_dfs = [
+        delayed(read_filepart_merge_crosswalk)(
+            filename, 
+            part_i, 
+            columns = station_id_cols + ["time_id"] + metric_cols
+        ) for part_i in list_of_files
+    ]               
+
+    time_dfs = [
+        delayed(utils.parse_for_time_components)(i) for i in import_dfs
+    ]
+    
+    time_dfs = [delayed(utils.add_peak_offpeak_column)(i, "hour") for i in time_dfs]
+        
+    return time_dfs
+
+
+def compute_and_export(
+    metric: str,
+    metric_dfs: list,
+    export_filename: str,
+    **kwargs
+):
+    """
+    Compute list of delayed aggregations,
+    concatenate and export metric as parquet.
+    """
+    metric_dfs = [compute(i)[0] for i in metric_dfs]
+    results = pd.concat(metric_dfs, axis=0, ignore_index=True)
+
+    results.to_parquet(
+        f"{PROCESSED_GCS}{export_filename}_{metric}.parquet",
+        **kwargs
+    )
+    
+    return
+    
+    
+if __name__ == "__main__":
+    
+    start = datetime.datetime.now()
+    
+    metric_list = [
+        "flow", "truck_flow", "obs_flow",
+        "occ", 
+        "speed", "obs_speed", # mean
+        "pts_obs",
+    ] 
+
+    
+    station_cols = ["station_uuid"]
+    weekday_hour_cols = ["year", "month", "weekday", "hour"]
+    weekday_peak_cols = ["year", "month", "weekday", "peak_offpeak"]
+
+    for metric in metric_list:
+        
+        time0 = datetime.datetime.now()
+        
+        time_dfs = metric_prep(metric)
+        
+        hour_dfs = [
+            delayed(aggregate_metric)(i, station_cols + weekday_hour_cols, metric)
+            for i in time_dfs
+        ]
+        
+        compute_and_export(
+            metric, 
+            hour_dfs, 
+            "station_weekday_hour",
+            partition_cols = ["weekday", "hour"]
+        )
+        
+        time1 = datetime.datetime.now()
+        print(f"{metric} hourly aggregation: {time1 - time0}")
+    
+        peak_dfs = [
+            delayed(aggregate_metric)(i, station_cols + weekday_peak_cols, metric)
+            for i in time_dfs
+        ]
+                
+        compute_and_export(
+            metric,
+            peak_dfs,
+            "station_weekday_peak",
+            partition_cols = ["weekday", "peak_offpeak"]
+        )
+
+        time2 = datetime.datetime.now()
+        print(f"{metric} peak/offpeak aggregation: {time2 - time1}")
+        print(f"{metric} aggregation: {time2 - time0}")
+    
+    end = datetime.datetime.now()
+    print(f"execution time: {end - start}")

--- a/traffic_ops/research_agenda.md
+++ b/traffic_ops/research_agenda.md
@@ -1,0 +1,38 @@
+# Research Questions
+
+## Olympic Lanes
+* Andrew Quinn (Roadway Pricing) had idea to pitch Olympic Lanes.
+* Henry presented Olympic Lanes research related to I-10 and I-110 by hour.
+    * Mean flows per lane, lane-by-lane for peak periods (6-9 AM and 4-7 PM)
+    * Sum of flows per lane, over 3 month period, by hour (then aggregated)
+    * Totals will look better, but question was by lane. --> what about per GP lane vs per HOT/HOV lane, so we use totals and then normalize?
+    * x-axis is postmile (test whether we can join this to SHN lines)
+* Way Traffic Ops treated express lanes is confusing
+    * Lanes 1-2 = HOV (sensor is coded this). HOT and HOV classification are mutually exclusive.
+    * Lanes 4-6 are General Purpose
+    * 110 looks better than 10.
+* Data quality concerns because number of sensors may matter, whether they're working or not matter    
+    * a lane can drop out, because at each postmile, there can be varying number of lanes
+    * it does appear that lane volumes drop down, only to pick up later on at a much higher volume
+    * we know that sensors aren't always working, and sometimes they impute stuff. Maybe try only using sensors that are working and then interpolate in between?
+    * also removing ramps, since ramps include something different (already excluded in the analysis)
+ 
+    
+
+## Related Questions
+Gather a list of typical questions that are asked around this dataset. Let's see what other datasets we can produce.
+* How speed affects throughput
+* How occupancy differs
+* Speed, throughput together
+* Occupany of lanes (person throughput). Less vehicles go through HOT/HOV, but can carry more people?
+* flow, occupancy, avg speed in a quadrant table
+* nonpeak non-congested, peak congested, congested-peak, noncongested offpeak
+   * we know that HOT/HOV more efficient during congested times
+   * avg lane mile speed, avg lane mile throughput, avg lane mile occupancy
+   * do this at corridor level (maybe not 50 mile corridor, but can we chunk this into shorter corridors)
+   * under congestion, if GP and HOT/HOV have same flow, then a conversion has no impact on it, and in theory, would improve throughput and occupancy
+      * right now, ppl don't want to switch from GP to HOT, but are willing to switch from HOV to HOT. they don't want to wreck GP lanes. if flow is actually the same, then there's no impact.
+   * add a lane during traffic really is not a good idea, because traffic does occur at certain bottlenecks
+   * express lanes pick up 18.5 - 47.5 (look along this length), how many ppl do you move, vehicles you move, speed at which you move them, across congested vs non-congested time (peak vs offpeak)
+   * 4 GP lanes move Y1 ppl vs 2 HOT lanes move Y2 ppl
+   * 10 has 1 lane on some part, 2 lanes on other parts

--- a/traffic_ops/utils.py
+++ b/traffic_ops/utils.py
@@ -1,0 +1,47 @@
+import pandas as pd
+
+GCS_FILE_PATH = (
+    "gs://calitp-analytics-data/data-analyses/"
+    "traffic_ops_raw_data/"
+)
+RAW_GCS = f"{GCS_FILE_PATH}hov_pems/"
+PROCESSED_GCS = f"{GCS_FILE_PATH}hov_pems_processed/"
+
+peak_hours = [7, 8, 9, 15, 16, 17, 18]
+
+def parse_for_time_components(
+    df: pd.DataFrame,
+    time_col: str = "time_id"
+) -> pd.DataFrame:
+    
+    df2 = df.assign(
+        year = pd.to_datetime(df[time_col]).dt.year,
+        month = pd.to_datetime(df[time_col]).dt.month,
+        # 0 = Monday; 6 = Sunday
+        weekday = pd.to_datetime(df[time_col]).dt.weekday,
+        # instead of day_name(), which is string, int easier to compress
+        hour = pd.to_datetime(df[time_col]).dt.hour
+    )
+        
+    return df2
+
+def add_peak_offpeak_column(
+    df: pd.DataFrame,
+    hour_col: str = "hour"
+) -> pd.DataFrame:
+    
+    hours_in_day = range(0, 24)
+    
+    peak_offpeak_dict = {
+        **{k: "peak" for k in peak_hours},
+        **{k: "offpeak" for k in [i for i in hours_in_day 
+                                  if i not in peak_hours]}
+    }
+    
+    df = df.assign(
+        peak_offpeak = df[hour_col].map(peak_offpeak_dict)
+    )
+    
+    return df
+    
+    


### PR DESCRIPTION
## PeMS lane dataset
* Create a crosswalk to store `station_id` + accompanying geography info (`district_id, city_id, etc etc`)
* Break apart several metrics that seem to be available
   * `flow`, `truck_flow`, `obs_flow` -- what is `obs_flow`? is it the sum of cars and trucks or raw observations?
   * `speed`, `obs_speed` -- what are the differences?
   * `occ` occupancy (what scale is this, some of these are decimals...)
   *  `pts_obs` -- are these number of observations by the detector?
* Aggregate the raw csvs into 2 grains to start:
* (1) `station_id-weekday (Monday/Tuesday/Wednesday)-hour` 
* (2) `station-id-weekday-peak/offpeak`
* Set `utils` to list which hours are peak hours, and everything else is offpeak
* Start with sums for flow, mean for occ and speed
* Save these outputs in our GCS bucket: `data-analyses/traffic_ops_raw_data/hov_pems_processed/` @hhmckay 
* #1177