### PR TITLE
aggregate Pems detectors to station-weekday-hour and station-weekday-peak/offpeak

### DIFF
--- a/traffic_ops/aggregate.py
+++ b/traffic_ops/aggregate.py
@@ -13,47 +13,9 @@ from typing import Literal
 
 import utils
 from utils import RAW_GCS, PROCESSED_GCS
+from crosswalks import station_id_cols
 
 fs = gcsfs.GCSFileSystem()
-
-
-station_id_cols = [
-    'station_id',
-    'freeway_id',
-    'freeway_dir',
-    'city_id',
-    'county_id',
-    'district_id',
-    'station_type',
-    'param_set', 
-    #'length',
-    #'abs_postmile', 
-    #'physical_lanes'
-]
-
-def create_station_crosswalk(df: dd.DataFrame) -> pd.DataFrame:
-    """
-    Put in a set of columns that identify the 
-    station + freeway + postmile position.
-    Create a uuid that we can use to get back all 
-    the columns we may want later.
-    """
-    crosswalk = df[
-        station_id_cols
-    ].drop_duplicates().reset_index(drop=True)
-    
-    
-    crosswalk = crosswalk.compute()
-    
-    crosswalk["station_uuid"] = crosswalk.apply(
-        lambda _: str(uuid.uuid4()), axis=1, 
-    )
-      
-    crosswalk.to_parquet(
-        f"{PROCESSED_GCS}station_crosswalk.parquet"
-    )
-    
-    return
 
 
 def read_filepart_merge_crosswalk(

--- a/traffic_ops/aggregate.py
+++ b/traffic_ops/aggregate.py
@@ -17,7 +17,6 @@ from crosswalks import station_id_cols
 
 fs = gcsfs.GCSFileSystem()
 
-
 def read_filepart_merge_crosswalk(
     filename: str,
     filepart: str, 
@@ -154,6 +153,60 @@ def compute_and_export(
     )
     
     return
+
+
+def import_detector_status(
+    filename: str = "hov_portion_detector_status_time_window",
+) -> pd.DataFrame:
+    """
+    Import detector partitioned df,
+    parse time_id, and merge in crosswalk to get station_uuid.
+    """
+    df = pd.read_parquet(
+        f"{RAW_GCS}{filename}/",
+        columns = ["time_id", "station_id", "all_samples"],
+    ).pipe(
+        utils.parse_for_time_components
+    ).pipe(
+        utils.add_peak_offpeak_column, "hour"
+    )
+    
+    # Merge in station_uuid
+    crosswalk = pd.read_parquet(
+        f"{PROCESSED_GCS}station_crosswalk.parquet",
+        columns = ["station_id", "station_uuid"]
+    )
+    
+    df2 = pd.merge(
+        df,
+        crosswalk,
+        on = "station_id",
+        how = "inner"
+    ).drop(columns = "station_id")
+    
+    return df2
+
+
+def aggregate_detector_samples(
+    df: pd.DataFrame,
+    group_cols: list
+) -> pd.DataFrame:
+    """
+    Right now, only all_samples is a column that's understood
+    all_samples = diag_samples, so we'll keep just one column.
+    
+    We want to know other metrics like:
+    status (0/1) - which one is good and which one is bad?
+    suspected_err (integers, 0-9 inclusive)
+    certain errors like high_flow, zero_occ, etc, but not sure how to interpret
+    """
+    df2 = (df.groupby(group_cols, group_keys=False)
+           .agg({
+               "all_samples": "sum",
+           }).reset_index()
+    )
+    
+    return df2
     
     
 if __name__ == "__main__":
@@ -171,7 +224,7 @@ if __name__ == "__main__":
     station_cols = ["station_uuid"]
     weekday_hour_cols = ["year", "month", "weekday", "hour"]
     weekday_peak_cols = ["year", "month", "weekday", "peak_offpeak"]
-
+    
     for metric in metric_list:
         
         time0 = datetime.datetime.now()
@@ -208,6 +261,27 @@ if __name__ == "__main__":
         time2 = datetime.datetime.now()
         print(f"{metric} peak/offpeak aggregation: {time2 - time1}")
         print(f"{metric} aggregation: {time2 - time0}")
+    
+    
+    detector_df = import_detector_status()
+    
+    detector_station_hour = aggregate_detector_samples(
+        detector_df, 
+        station_cols + weekday_hour_cols
+    )
+    
+    detector_station_hour.to_parquet(
+        f"{PROCESSED_GCS}station_weekday_hour_detectors.parquet"
+    )
+    
+    detector_station_weekday = aggregate_detector_samples(
+        detector_df,
+        station_cols + weekday_peak_cols
+    )
+    
+    detector_station_weekday.to_parquet(
+        f"{PROCESSED_GCS}station_weekday_peak_detectors.parquet"
+    )
     
     end = datetime.datetime.now()
     print(f"execution time: {end - start}")

--- a/traffic_ops/crosswalks.py
+++ b/traffic_ops/crosswalks.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import uuid
+
+from utils import RAW_GCS, PROCESSED_GCS
+
+station_id_cols = [
+    'station_id',
+    'freeway_id',
+    'freeway_dir',
+    'city_id',
+    'county_id',
+    'district_id',
+    'station_type',
+    'param_set', 
+    #'length',
+    #'abs_postmile', 
+    #'physical_lanes'
+]
+
+def create_station_crosswalk(filename: str = "hov_portion") -> pd.DataFrame:
+    """
+    Put in a set of columns that identify the 
+    station + freeway + postmile position.
+    Create a uuid that we can use to get back all 
+    the columns we may want later.
+    """
+    df = pd.read_parquet(
+        f"{RAW_GCS}{filename}",
+        columns = station_id_cols
+    ).drop_duplicates().reset_index(drop=True)
+      
+    df["station_uuid"] = df.apply(
+        lambda _: str(uuid.uuid4()), axis=1, 
+    )
+      
+    df.to_parquet(
+        f"{PROCESSED_GCS}station_crosswalk.parquet"
+    )
+    
+    return
+
+
+def create_station_detector_crosswalk(
+    filename: str = "hov_portion_detector_status_time_window"
+):
+    df = pd.read_parquet(
+        f"{RAW_GCS}{filename}",
+        columns = ["station_id", "detector_id"]
+    ).drop_duplicates().reset_index(drop=True)
+    
+    df.to_parquet(
+        f"{PROCESSED_GCS}station_detector_crosswalk.parquet"
+    )
+    
+    return
+
+if __name__ == "__main__":
+    create_station_crosswalk()
+    create_station_detector_crosswalk()

--- a/traffic_ops/research_agenda.md
+++ b/traffic_ops/research_agenda.md
@@ -36,3 +36,9 @@ Gather a list of typical questions that are asked around this dataset. Let's see
    * express lanes pick up 18.5 - 47.5 (look along this length), how many ppl do you move, vehicles you move, speed at which you move them, across congested vs non-congested time (peak vs offpeak)
    * 4 GP lanes move Y1 ppl vs 2 HOT lanes move Y2 ppl
    * 10 has 1 lane on some part, 2 lanes on other parts
+   
+## References
+* [detector status report](https://github.com/cagov/caldata-mdsa-caltrans-pems/issues/269)
+* [high flows GH issue](https://github.com/cagov/caldata-mdsa-caltrans-pems/issues/278)
+* [dbt models sources.yml](https://github.com/cagov/caldata-mdsa-caltrans-pems/blob/main/transform/models/_sources.yml)
+* [grains naming conventions](https://github.com/cagov/caldata-mdsa-caltrans-pems/issues/241)


### PR DESCRIPTION
## PeMS lane dataset
* There was a second dataset provided by Traffic Ops that captured detector status health
* Dig into what other columns we can use, initial skimming of user guide didn't yield a data dictionary that could be used
   * `status = 0/1` which one is good vs bad?
   * `suspected_err` what are these suspected errors?
* Henry wants to have a filter to remove "bad data" 
* Aggregate this to the same grain as lane flows, occ, speed 
* Break out crosswalks into separate `crosswalks.py` script
* TODO: add exploratory notebook putting some of this together to see how Henry can filter out some of the rows he doesn't want. Ignore the fact that there's probably imputation going on (some `caldata` GH issues linked in `research_agenda.md` can be used as references for how complicated this can easily get). Go with the simplest, broadest sketch we can for an aggregation and refine filtering later.
* #1177 