### PR TITLE
Exclude private datasets from 6 geoportal datasets, GTFS digest

### DIFF
--- a/_shared_utils/setup.py
+++ b/_shared_utils/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 setup(
     name="shared_utils",
     packages=find_packages(),
-    version="2.5",
+    version="2.5.1",
     description="Shared utility functions for data analyses",
     author="Cal-ITP",
     license="Apache",

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -505,7 +505,7 @@ def get_stop_times(
     return stop_times
 
 
-def filter_to_public_schedule_feeds() -> list:
+def filter_to_public_schedule_gtfs_dataset_keys() -> list:
     """
     Return a list of schedule_gtfs_dataset_keys that have
     private_dataset == None.

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -505,18 +505,21 @@ def get_stop_times(
     return stop_times
 
 
-def filter_to_public_schedule_gtfs_dataset_keys() -> list:
+def filter_to_public_schedule_gtfs_dataset_keys(get_df: bool = False) -> list:
     """
     Return a list of schedule_gtfs_dataset_keys that have
     private_dataset == None.
     private_dataset holds values:True or None, no False.
     """
     dim_gtfs_datasets = schedule_rt_utils.filter_dim_gtfs_datasets(
-        keep_cols=["key", "private_dataset"],
+        keep_cols=["key", "name", "private_dataset"],
         custom_filtering={
             "type": ["schedule"],
         },
         get_df=True,
     ) >> filter(_.private_dataset != True)
 
-    return dim_gtfs_datasets.gtfs_dataset_key.unique().tolist()
+    if get_df:
+        return dim_gtfs_datasets
+    else:
+        return dim_gtfs_datasets.gtfs_dataset_key.unique().tolist()

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -503,3 +503,20 @@ def get_stop_times(
         )
 
     return stop_times
+
+
+def filter_to_public_schedule_feeds() -> list:
+    """
+    Return a list of schedule_gtfs_dataset_keys that have
+    private_dataset == None.
+    private_dataset holds values:True or None, no False.
+    """
+    dim_gtfs_datasets = schedule_rt_utils.filter_dim_gtfs_datasets(
+        keep_cols=["key", "private_dataset"],
+        custom_filtering={
+            "type": ["schedule"],
+        },
+        get_df=True,
+    ) >> filter(_.private_dataset != True)
+
+    return dim_gtfs_datasets.gtfs_dataset_key.unique().tolist()

--- a/_shared_utils/shared_utils/publish_utils.py
+++ b/_shared_utils/shared_utils/publish_utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Union
 
 import gcsfs
+import pandas as pd
 
 fs = gcsfs.GCSFileSystem()
 PUBLIC_BUCKET = "gs://calitp-publish-data-analysis/"
@@ -47,3 +48,14 @@ def if_exists_then_delete(filepath: str):
             fs.rm(filepath)
 
     return
+
+
+def exclude_private_datasets(
+    df: pd.DataFrame,
+    col: str = "schedule_gtfs_dataset_key",
+    public_gtfs_dataset_keys: list = [],
+) -> pd.DataFrame:
+    """
+    Filter out private datasets.
+    """
+    return df[df[col].isin(public_gtfs_dataset_keys)].reset_index(drop=True)

--- a/gtfs_digest/merge_data.py
+++ b/gtfs_digest/merge_data.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from calitp_data_analysis import utils
 from segment_speed_utils import gtfs_schedule_wrangling, time_series_utils
-from shared_utils import gtfs_utils_v2
+from shared_utils import gtfs_utils_v2, publish_utils
 from update_vars import GTFS_DATA_DICT, SEGMENT_GCS, RT_SCHED_GCS, SCHED_GCS
 
 route_time_cols = ["schedule_gtfs_dataset_key", 
@@ -222,19 +222,6 @@ def set_primary_typology(df: pd.DataFrame) -> pd.DataFrame:
     return df3
 
 
-def exclude_private_datasets(
-    df: pd.DataFrame, 
-    col: str = "schedule_gtfs_dataset_key",
-    public_gtfs_dataset_keys: list = [],
-) -> pd.DataFrame:
-    """
-    Filter out private datasets.
-    """
-    return df[
-        df[col].isin(public_gtfs_dataset_keys)
-    ].reset_index(drop=True)
-
-
 if __name__ == "__main__":
     
     from shared_utils import rt_dates
@@ -298,7 +285,8 @@ if __name__ == "__main__":
         gtfs_schedule_wrangling.top_cardinal_direction
     ).pipe(
         # Drop any private datasets before exporting
-        exclude_private_datasets, public_gtfs_dataset_keys= public_feeds
+        publish_utils.exclude_private_datasets, 
+        public_gtfs_dataset_keys= public_feeds
     )
      
     integrify = [
@@ -326,7 +314,9 @@ if __name__ == "__main__":
         primary_typology,
         on = route_time_cols,
         how = "left"
-    ).pipe(exclude_private_datasets, public_gtfs_dataset_keys= public_feeds)
+    ).pipe(
+        publish_utils.exclude_private_datasets, 
+        public_gtfs_dataset_keys= public_feeds)
 
     utils.geoparquet_gcs_export(
         segment_speeds2,

--- a/gtfs_digest/merge_operator_data.py
+++ b/gtfs_digest/merge_operator_data.py
@@ -8,7 +8,8 @@ import pandas as pd
 
 from calitp_data_analysis import utils
 from segment_speed_utils import time_series_utils
-from merge_data import merge_in_standardized_route_names, exclude_private_datasets
+from shared_utils import publish_utils
+from merge_data import merge_in_standardized_route_names
 from update_vars import GTFS_DATA_DICT, SCHED_GCS, RT_SCHED_GCS
 
 sort_cols = ["schedule_gtfs_dataset_key", "service_date"]
@@ -154,7 +155,7 @@ if __name__ == "__main__":
     # Drop duplicates created after merging
     op_profiles_df2 = (op_profiles_df1
                        .pipe(
-                           exclude_private_datasets, 
+                           publish_utils.exclude_private_datasets, 
                            col = "schedule_gtfs_dataset_key", 
                            public_gtfs_dataset_keys = public_feeds
                        ).drop_duplicates(subset = list(op_profiles_df1.columns))
@@ -169,7 +170,7 @@ if __name__ == "__main__":
     ).pipe(
         merge_in_standardized_route_names
     ).pipe(
-        exclude_private_datasets, 
+        publish_utils.exclude_private_datasets, 
         col = "schedule_gtfs_dataset_key", 
         public_gtfs_dataset_keys = public_feeds
     )
@@ -181,7 +182,7 @@ if __name__ == "__main__":
     )
     
     operator_category_counts = operator_category_counts_by_date().pipe(
-        exclude_private_datasets, 
+        publish_utils.exclude_private_datasets, 
         col = "schedule_gtfs_dataset_key", 
         public_gtfs_dataset_keys = public_feeds    
     )

--- a/gtfs_digest/merge_operator_service.py
+++ b/gtfs_digest/merge_operator_service.py
@@ -1,12 +1,3 @@
-import pandas as pd
-import numpy as np
-from segment_speed_utils import helpers, time_series_utils, gtfs_schedule_wrangling
-from segment_speed_utils.project_vars import (COMPILED_CACHED_VIEWS, RT_SCHED_GCS, SCHED_GCS)
-
-from shared_utils import catalog_utils, rt_dates
-
-GTFS_DATA_DICT = catalog_utils.get_catalog("gtfs_analytics_data")
-
 """
 Finding the total number of scheduled service hours for 
 an operator across its routes for a full week. The data is
@@ -14,6 +5,17 @@ downloaded every 1/2 a year.
 
 Grain is operator-service_date-route
 """
+import pandas as pd
+
+from merge_data import exclude_private_datasets
+from segment_speed_utils import (gtfs_schedule_wrangling, helpers, 
+                                 time_series_utils) 
+from segment_speed_utils.project_vars import (
+    COMPILED_CACHED_VIEWS, weeks_available)
+from shared_utils import gtfs_utils_v2, rt_dates
+from update_vars import GTFS_DATA_DICT, RT_SCHED_GCS
+
+
 def concatenate_trips(
     date_list: list,
 ) -> pd.DataFrame:
@@ -44,29 +46,6 @@ def concatenate_trips(
 
     return df
 
-def get_day_type(date):
-    """
-    Function to return the day type (e.g., Monday, Tuesday, etc.) from a datetime object.
-    """
-    days_of_week = ["Monday", 
-                    "Tuesday", 
-                    "Wednesday", 
-                    "Thursday", 
-                    "Friday", 
-                    "Saturday", 
-                    "Sunday"]
-    return days_of_week[date.weekday()]
-
-def weekday_or_weekend(row):
-    """
-    Tag if a day is a weekday or Saturday/Sunday
-    """
-    if row.day_type == "Sunday":
-        return "Sunday"
-    if row.day_type == "Saturday":
-        return "Saturday"
-    else:
-        return "Weekday"
 
 def total_service_hours(date_list: list) -> pd.DataFrame:
     """
@@ -76,67 +55,79 @@ def total_service_hours(date_list: list) -> pd.DataFrame:
     # Combine all the days' data for a week.
     df = concatenate_trips(date_list)
     
-    # Find day type aka Monday, Tuesday, Wednesday based on service date.
-    df['day_type'] = df['service_date'].apply(get_day_type)
+    WEEKDAY_DICT = {
+        **{k: "Weekday" for k in ["Monday", "Tuesday", "Wednesday",
+                             "Thursday", "Friday"]},
+        "Saturday": "Saturday",
+        "Sunday": "Sunday"
+    }
     
-    # Tag if the day is a weekday, Saturday, or Sunday.
-    df["weekday_weekend"] = df.apply(weekday_or_weekend, axis=1)
+    # Find day type (Monday, Tuesday, etc), departure hour, month_year, and weekday_weekend
+    df = df.assign(
+        day_type = df.service_date.dt.day_name(),
+        departure_hour = df.trip_first_departure_datetime_pacific.dt.hour.astype("Int64"),
+        # get month_year that's 2024-04 for Apr2024 format
+        month_year = (df.service_date.dt.year.astype(str) + 
+                      "-" +  df.service_date.dt.month.astype(str).str.zfill(2)),
+    ).pipe(
+        gtfs_schedule_wrangling.add_weekday_weekend_column, WEEKDAY_DICT
+    )
     
-    # df = gtfs_schedule_wrangling.add_weekday_weekend_column(df)
     
-    # Find the minimum departure hour.
-    df["departure_hour"] = df.trip_first_departure_datetime_pacific.dt.hour
-    
-    # Delete out the specific day, leave only month & year.
-    df["month"] = df.service_date.astype(str).str.slice(stop=7)
-    
-    # Total up service hours by weekday, Sunday, and Saturday.
+    # Total up hourly service hours by weekday, Sunday, and Saturday.
     df2 = (
         df.groupby(["name", 
-                    "month", 
+                    "month_year", 
                     "weekday_weekend", 
                     "departure_hour"])
-        .agg(
-            {
-                "service_hours": "sum",
-            }
-        )
+        .agg({"service_hours": "sum"})
         .reset_index()
     )
     
-    # For weekday hours, divide by 5.
-    df2["weekday_service_hours"] = df2.service_hours/5
+    # weekday hours should be divided by 5, while keeping sat/sun intact
+    df2 = df2.assign(
+        daily_service_hours = df2.apply(
+            lambda x: round(x.service_hours / 5, 2) 
+            if x.weekday_weekend=="Weekday"
+            else round(x.service_hours, 2), axis=1
+        ),
+        service_hours = df2.service_hours.round(2),
+    )
     
-    # Rename projects.
-    df2 = df2.rename(columns = {'service_hours':'weekend_service_hours'})
     return df2
 
-def total_service_hours_all_months() -> pd.DataFrame:
+
+def total_service_hours_all_months(week_list: list[list]) -> pd.DataFrame:
     """
     Find service hours for a full week for one operator
     and for the months we have a full week's worth of data downloaded.
-    As of 5/2024, we have April 2023 and October 2023.
-    """
-    # Grab the dataframes with a full week's worth of data. 
-    apr_23week = rt_dates.get_week(month="apr2023", exclude_wed=False)
-    oct_23week = rt_dates.get_week(month="oct2023", exclude_wed=False)
-    apr_24week = rt_dates.get_week(month="apr2024", exclude_wed=False)
-    
-    # Sum up total service_hours
-    apr_23df = total_service_hours(apr_23week)
-    oct_23df = total_service_hours(oct_23week)
-    apr_24df = total_service_hours(apr_24week)
+    As of 5/2024, we have April 2023, October 2023, and April 2024.
+    """   
+    public_datasets = gtfs_utils_v2.filter_to_public_schedule_gtfs_dataset_keys(get_df=True)
+    public_feeds = public_datasets.gtfs_dataset_name.unique().tolist()
     
     # Combine everything
-    all_df = pd.concat([apr_23df, oct_23df, apr_24df])
-   
+    all_df = pd.concat(
+        [total_service_hours(one_week) for one_week in week_list]
+    ).pipe(
+        exclude_private_datasets, 
+        col = "name", 
+        public_gtfs_dataset_keys = public_feeds
+    )
+
     return all_df
 
 
 if __name__ == "__main__":
     
-    # Save service hours.
-    SERVICE_EXPORT = f"{GTFS_DATA_DICT.digest_tables.dir}{GTFS_DATA_DICT.digest_tables.scheduled_service_hours}.parquet"
-    service_hours = total_service_hours_all_months()
-    service_hours.to_parquet(SERVICE_EXPORT) 
+    print(f"Aggregating for dates: {weeks_available}")
+    
+    # Save service hours
+    SERVICE_EXPORT = GTFS_DATA_DICT.digest_tables.scheduled_service_hours
+    
+    service_hours = total_service_hours_all_months(weeks_available)
+    
+    service_hours.to_parquet(
+        f"{RT_SCHED_GCS}{SERVICE_EXPORT}.parquet"
+    ) 
     

--- a/gtfs_digest/merge_operator_service.py
+++ b/gtfs_digest/merge_operator_service.py
@@ -7,12 +7,11 @@ Grain is operator-service_date-route
 """
 import pandas as pd
 
-from merge_data import exclude_private_datasets
 from segment_speed_utils import (gtfs_schedule_wrangling, helpers, 
                                  time_series_utils) 
 from segment_speed_utils.project_vars import (
     COMPILED_CACHED_VIEWS, weeks_available)
-from shared_utils import gtfs_utils_v2, rt_dates
+from shared_utils import gtfs_utils_v2, publish_utils, rt_dates
 from update_vars import GTFS_DATA_DICT, RT_SCHED_GCS
 
 
@@ -103,14 +102,16 @@ def total_service_hours_all_months(week_list: list[list]) -> pd.DataFrame:
     and for the months we have a full week's worth of data downloaded.
     As of 5/2024, we have April 2023, October 2023, and April 2024.
     """   
-    public_datasets = gtfs_utils_v2.filter_to_public_schedule_gtfs_dataset_keys(get_df=True)
+    public_datasets = gtfs_utils_v2.filter_to_public_schedule_gtfs_dataset_keys(
+        get_df=True
+    )
     public_feeds = public_datasets.gtfs_dataset_name.unique().tolist()
     
     # Combine everything
     all_df = pd.concat(
         [total_service_hours(one_week) for one_week in week_list]
     ).pipe(
-        exclude_private_datasets, 
+        publish_utils.exclude_private_datasets, 
         col = "name", 
         public_gtfs_dataset_keys = public_feeds
     )

--- a/high_quality_transit_areas/D2_assemble_hqta_polygons.py
+++ b/high_quality_transit_areas/D2_assemble_hqta_polygons.py
@@ -15,6 +15,7 @@ import C1_prep_pairwise_intersections as prep_clip
 import D1_assemble_hqta_points as assemble_hqta_points
 from calitp_data_analysis import utils, geography_utils
 from D1_assemble_hqta_points import (EXPORT_PATH, add_route_info)
+from shared_utils import gtfs_utils_v2
 from update_vars import GCS_FILE_PATH, analysis_date, PROJECT_CRS
 
 catalog = intake.open_catalog("*.yml")
@@ -108,6 +109,7 @@ def final_processing(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     Drop extra columns, get sorting done.
     Used to drop bad stops, but these all look ok.
     """
+    public_feeds = gtfs_utils_v2.filter_to_public_schedule_gtfs_dataset_keys()
     
     keep_cols = [
         "agency_primary", "agency_secondary",
@@ -118,7 +120,8 @@ def final_processing(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     ]
     
     # Drop bad stops, subset columns
-    gdf2 = (gdf[keep_cols]
+    gdf2 = (
+        gdf[gdf.schedule_gtfs_dataset_key.isin(public_feeds)][keep_cols]
             .drop_duplicates()
             .sort_values(["hqta_type", "agency_primary", 
                           "agency_secondary",

--- a/rt_segment_speeds/scripts/publish_open_data.py
+++ b/rt_segment_speeds/scripts/publish_open_data.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pathlib import Path
 
 from calitp_data_analysis import utils
+from shared_utils import gtfs_utils_v2
 from update_vars import GTFS_DATA_DICT, SEGMENT_GCS
 
 
@@ -16,6 +17,8 @@ def stage_open_data_exports(analysis_date: str):
     export them to a stable GCS URL so we can always 
     read it in open_data/catalog.yml.
     """
+    public_feeds = gtfs_utils_v2.filter_to_public_schedule_gtfs_dataset_keys()
+    
     datasets = [
         GTFS_DATA_DICT.stop_segments.route_dir_single_segment,
         #GTFS_DATA_DICT.speedmap_segments.route_dir_single_segment,
@@ -24,7 +27,8 @@ def stage_open_data_exports(analysis_date: str):
 
     for d in datasets:
         gdf = gpd.read_parquet(
-            f"{SEGMENT_GCS}{d}_{analysis_date}.parquet"
+            f"{SEGMENT_GCS}{d}_{analysis_date}.parquet",
+            filters = [[("schedule_gtfs_dataset_key", "in", public_feeds)]]
         )
         
         utils.geoparquet_gcs_export(

--- a/rt_segment_speeds/scripts/publish_public_gcs.py
+++ b/rt_segment_speeds/scripts/publish_public_gcs.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pathlib import Path
 
 from calitp_data_analysis import utils
-from shared_utils import rt_dates
+from shared_utils import rt_dates, gtfs_utils_v2
 from update_vars import GTFS_DATA_DICT, SEGMENT_GCS, PUBLIC_GCS
 
 if __name__ == "__main__":
@@ -19,11 +19,16 @@ if __name__ == "__main__":
         GTFS_DATA_DICT.speedmap_segments.route_dir_single_segment,
     ]
     
+    public_feeds = gtfs_utils_v2.filter_to_public_schedule_gtfs_dataset_keys()
+    
     for d in datasets:
         
         start = datetime.datetime.now()
 
-        df = gpd.read_parquet(f"{SEGMENT_GCS}{d}_{analysis_date}.parquet")
+        df = gpd.read_parquet(
+            f"{SEGMENT_GCS}{d}_{analysis_date}.parquet",
+            filters = [[("schedule_gtfs_dataset_key", "in", public_feeds)]]
+        )
                 
         utils.geoparquet_gcs_export(
             df,

--- a/rt_segment_speeds/segment_speed_utils/gtfs_schedule_wrangling.py
+++ b/rt_segment_speeds/segment_speed_utils/gtfs_schedule_wrangling.py
@@ -109,9 +109,13 @@ def add_peak_offpeak_column(df: pd.DataFrame) -> pd.DataFrame:
     
     return df
 
-def add_weekday_weekend_column(df: pd.DataFrame) -> pd.DataFrame:
+def add_weekday_weekend_column(df: pd.DataFrame, category_dict: dict = time_helpers.WEEKDAY_DICT) -> pd.DataFrame:
+    """
+    Add a single weekday_weekend column based on a service date's day_name.
+    day_name gives values like Monday, Tuesday, etc.
+    """
     df = df.assign(
-        weekday_weekend = df.service_date.dt.day_name().map(time_helpers.WEEKDAY_DICT)
+        weekday_weekend = df.service_date.dt.day_name().map(category_dict)
     )
     
     return df


### PR DESCRIPTION
* Add a function in `gtfs_utils_v2` to grab either a list or the df of public datasets - normally, this is preferred because we get a list of `schedule_gtfs_dataset_keys` we can keep.
   * Add function to filter df down in `publish_utils` -- sometimes in GTFS digest, we do not have `schedule_gtfs_dataset_key`, so we use `schedule_gtfs_dataset_name` to filter.
* high quality transit areas and open data - do this in last steps before exporting
* speeds - do this in `publish_open_data` via parquet filtering and `publish_public_gcs`
* GTFS digest - do this in `merge_*` scripts so that all the dates are concatenated, and before exporting, private datasets are dropped. This should allow the portfolio yaml to build and report to run as usual.
* Run Sep monthly publishing and double check results are as expected (exclude `Big Blue Bus Swiftly Schedule`)
* #1220 

TODO related GTFS Digest:
some redundancies were noticed while updating merge scripts.  wherever references are shared, adapted functions to take additional uses.
- [ ] this affects `service hours`, having weekday / weekend columns in addition to rows holding those values is confusing, since column values are mixing normalized (per day) and not normalized (sums). also `month` changed to `month_year` because `month` typically holds month values (1-12 or Jan-Dec).
- [ ] need to rerun all the `merge_*` scripts to create new concatenated digest tables