### PR TITLE
Speed averages

### DIFF
--- a/_shared_utils/shared_utils/gtfs_analytics_data.yml
+++ b/_shared_utils/shared_utils/gtfs_analytics_data.yml
@@ -81,7 +81,7 @@ stop_segments:
   shape_stop_cols: ["shape_array_key", "shape_id", "stop_sequence"]
   stop_pair_cols: ["stop_pair", "stop_pair_name"]
   route_dir_cols: ["route_id", "direction_id"]
-  #shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" -- stop after Oct 2024
+  shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" #-- stop after Oct 2024
   route_dir_single_segment: "rollup_singleday/speeds_route_dir_segments"
   route_dir_multi_segment: "rollup_multiday/speeds_route_dir_segments"
   segments_file: "segment_options/shape_stop_segments"

--- a/_shared_utils/shared_utils/gtfs_analytics_data.yml
+++ b/_shared_utils/shared_utils/gtfs_analytics_data.yml
@@ -80,7 +80,8 @@ stop_segments:
   trip_stop_cols: ["trip_instance_key", "stop_sequence"]
   shape_stop_cols: ["shape_array_key", "shape_id", "stop_sequence"]
   stop_pair_cols: ["stop_pair", "stop_pair_name"]
-  shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments"
+  route_dir_cols: ["route_id", "direction_id"]
+  #shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" -- stop supporting long-term
   route_dir_single_segment: "rollup_singleday/speeds_route_dir_segments"
   route_dir_multi_segment: "rollup_multiday/speeds_route_dir_segments"
   segments_file: "segment_options/shape_stop_segments"
@@ -96,6 +97,7 @@ rt_stop_times:
   trip_stop_cols: ["trip_instance_key", "stop_sequence"]
   shape_stop_cols: ["shape_array_key", "shape_id", "stop_sequence"]
   stop_pair_cols: ["stop_pair", "stop_pair_name"]
+  route_dir_cols: ["route_id", "direction_id"]
   segments_file: "segment_options/stop_segments"
   trip_speeds_single_summary: "rollup_singleday/speeds_trip"
   route_dir_single_summary: "rollup_singleday/speeds_route_dir"
@@ -115,8 +117,9 @@ speedmap_segments:
   stage3b: "speedmap/stop_arrivals"
   stage4: "speedmap/speeds"
   trip_stop_cols: ["trip_instance_key", "stop_sequence", "stop_sequence1"]
-  shape_stop_cols: ["shape_array_key", "shape_id", "route_short_name", "route_id"]
+  shape_stop_cols: ["shape_array_key", "shape_id"]
   stop_pair_cols: ["stop_pair", "stop_pair_name", "segment_id"]
+  route_dir_cols: ["route_id", "route_short_name"]
   segments_file: "segment_options/speedmap_segments"
   shape_stop_single_segment: "rollup_singleday/speeds_shape_speedmap_segments"
   route_dir_single_segment: "rollup_singleday/speeds_route_dir_speedmap_segments"

--- a/_shared_utils/shared_utils/gtfs_analytics_data.yml
+++ b/_shared_utils/shared_utils/gtfs_analytics_data.yml
@@ -81,7 +81,7 @@ stop_segments:
   shape_stop_cols: ["shape_array_key", "shape_id", "stop_sequence"]
   stop_pair_cols: ["stop_pair", "stop_pair_name"]
   route_dir_cols: ["route_id", "direction_id"]
-  #shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" -- stop supporting long-term
+  #shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" -- stop after Oct 2024
   route_dir_single_segment: "rollup_singleday/speeds_route_dir_segments"
   route_dir_multi_segment: "rollup_multiday/speeds_route_dir_segments"
   segments_file: "segment_options/shape_stop_segments"

--- a/rt_segment_speeds/logs/avg_speeds.log
+++ b/rt_segment_speeds/logs/avg_speeds.log
@@ -518,3 +518,6 @@
 2024-10-23 10:59:19.182 | INFO     | __main__:multi_day_summary_averages:238 - multi day summary speed ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:01:22.942788
 2024-10-23 11:08:26.734 | INFO     | __main__:multi_day_segment_averages:258 - multi day segment ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:07:11.157851
 2024-10-23 11:31:26.653 | INFO     | average_segment_speeds:multi_day_segment_averages:257 - multi day segment ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:09:00.289570
+2024-10-25 10:32:19.827 | INFO     | __main__:single_day_segment_averages:186 - single day segment 2024-10-16 execution time: 0:03:41.907953
+2024-10-25 11:16:58.463 | INFO     | __main__:segment_averages:169 - segment speed averaging for ['2024-10-16'] execution time: 0:04:11.264225
+2024-10-25 11:25:19.667 | INFO     | __main__:segment_averages:169 - segment speed averaging for ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:07:12.533597

--- a/rt_segment_speeds/logs/avg_speeds.log
+++ b/rt_segment_speeds/logs/avg_speeds.log
@@ -524,3 +524,6 @@
 2024-10-25 12:03:33.918 | INFO     | __main__:summary_average_speeds:120 - trip avg 0:00:15.263512
 2024-10-25 12:03:46.569 | INFO     | __main__:summary_average_speeds:154 - summary speed averaging for ['2024-10-16'] execution time: 0:00:27.913940
 2024-10-25 12:06:25.916 | INFO     | __main__:summary_average_speeds:154 - summary speed averaging for ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:01:55.082631
+2024-10-25 12:52:26.403 | INFO     | average_segment_speeds:segment_averages:169 - speedmap_segments segment averaging for ['2024-10-16'] execution time: 0:05:57.735912
+2024-10-25 12:57:18.229 | INFO     | average_segment_speeds:segment_averages:169 - speedmap_segments segment averaging for ['2024-10-16'] execution time: 0:04:51.480238
+2024-10-25 13:16:11.221 | INFO     | average_segment_speeds:segment_averages:169 - speedmap_segments segment averaging for ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:09:08.182403

--- a/rt_segment_speeds/logs/avg_speeds.log
+++ b/rt_segment_speeds/logs/avg_speeds.log
@@ -527,3 +527,10 @@
 2024-10-25 12:52:26.403 | INFO     | average_segment_speeds:segment_averages:169 - speedmap_segments segment averaging for ['2024-10-16'] execution time: 0:05:57.735912
 2024-10-25 12:57:18.229 | INFO     | average_segment_speeds:segment_averages:169 - speedmap_segments segment averaging for ['2024-10-16'] execution time: 0:04:51.480238
 2024-10-25 13:16:11.221 | INFO     | average_segment_speeds:segment_averages:169 - speedmap_segments segment averaging for ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:09:08.182403
+2024-10-28 09:52:30.939 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-16'] execution time: 0:04:41.036914
+2024-10-28 10:12:36.654 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-14'] execution time: 0:04:30.593328
+2024-10-28 10:16:48.758 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-15'] execution time: 0:04:11.920050
+2024-10-28 10:21:05.581 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-17'] execution time: 0:04:16.731009
+2024-10-28 10:25:32.613 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-18'] execution time: 0:04:26.943776
+2024-10-28 10:28:46.725 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-19'] execution time: 0:03:14.004012
+2024-10-28 10:31:47.037 | INFO     | __main__:segment_averages:182 - stop_segments segment averaging for ['2024-10-20'] execution time: 0:03:00.245588

--- a/rt_segment_speeds/logs/avg_speeds.log
+++ b/rt_segment_speeds/logs/avg_speeds.log
@@ -521,3 +521,6 @@
 2024-10-25 10:32:19.827 | INFO     | __main__:single_day_segment_averages:186 - single day segment 2024-10-16 execution time: 0:03:41.907953
 2024-10-25 11:16:58.463 | INFO     | __main__:segment_averages:169 - segment speed averaging for ['2024-10-16'] execution time: 0:04:11.264225
 2024-10-25 11:25:19.667 | INFO     | __main__:segment_averages:169 - segment speed averaging for ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:07:12.533597
+2024-10-25 12:03:33.918 | INFO     | __main__:summary_average_speeds:120 - trip avg 0:00:15.263512
+2024-10-25 12:03:46.569 | INFO     | __main__:summary_average_speeds:154 - summary speed averaging for ['2024-10-16'] execution time: 0:00:27.913940
+2024-10-25 12:06:25.916 | INFO     | __main__:summary_average_speeds:154 - summary speed averaging for ['2024-10-14', '2024-10-15', '2024-10-16', '2024-10-17', '2024-10-18', '2024-10-19', '2024-10-20'] execution time: 0:01:55.082631

--- a/rt_segment_speeds/scripts/average_segment_speeds.py
+++ b/rt_segment_speeds/scripts/average_segment_speeds.py
@@ -96,8 +96,8 @@ def merge_in_segment_geometry(
     
     # The merge columns list should be all the columns that are in common
     # between averaged speeds and segment gdf
-    segment_file_cols = segment_geom.columns.tolist()
-    merge_cols = list(set(col_order).intersection(segment_file_cols))
+    geom_file_cols = segment_geom.columns.tolist()
+    merge_cols = list(set(col_order).intersection(geom_file_cols))
     
     gdf = pd.merge(
         segment_geom[merge_cols + ["geometry"]].drop_duplicates(),
@@ -151,16 +151,16 @@ def segment_averages(
         analysis_date = analysis_date_list[0]
         time_span_str = analysis_date
       
-    avg_speeds_by_segment = delayed(merge_in_segment_geometry)(
+    avg_speeds_with_geom = delayed(merge_in_segment_geometry)(
         avg_speeds,
         analysis_date, 
         segment_type
     )
         
-    avg_speeds_by_segment = compute(avg_speeds_by_segment)[0]
+    avg_speeds_with_geom = compute(avg_speeds_with_geom)[0]
     
     utils.geoparquet_gcs_export(
-        avg_speeds_by_segment,
+        avg_speeds_with_geom,
         SEGMENT_GCS,
         f"{export_file}_{time_span_str}"
     )
@@ -204,7 +204,7 @@ if __name__ == "__main__":
     
     ROUTE_SEG_FILE = dict_inputs["route_dir_multi_segment"]
 
-    for one_week in weeks_available[:1]:
+    for one_week in weeks_available:
         
         segment_averages(
             one_week, 

--- a/rt_segment_speeds/scripts/average_segment_speeds.py
+++ b/rt_segment_speeds/scripts/average_segment_speeds.py
@@ -137,7 +137,7 @@ def segment_averages(
         gtfs_schedule_wrangling.merge_operator_identifiers, 
         analysis_date_list,
         columns = CROSSWALK_COLS
-    ).persist()
+    )
 
     if len(analysis_date_list) > 1:
         # If a week (date list) is put in, use Wednesday for segment geometry
@@ -166,7 +166,10 @@ def segment_averages(
     )
         
     end = datetime.datetime.now()
-    logger.info(f"segment speed averaging for {analysis_date_list} execution time: {end - start}")
+    logger.info(
+        f"{segment_type} segment averaging for {analysis_date_list} "
+        f"execution time: {end - start}"
+    )
     
     return    
         

--- a/rt_segment_speeds/scripts/average_speedmap_segment_speeds.py
+++ b/rt_segment_speeds/scripts/average_speedmap_segment_speeds.py
@@ -7,7 +7,8 @@ import sys
 
 from loguru import logger
 
-from average_segment_speeds import single_day_segment_averages, multi_day_segment_averages
+from update_vars import GTFS_DATA_DICT, SEGMENT_GCS
+from average_segment_speeds import segment_averages, OPERATOR_COLS
 
 if __name__ == "__main__":
     
@@ -21,13 +22,42 @@ if __name__ == "__main__":
     
     segment_type = "speedmap_segments"
     
+    dict_inputs = GTFS_DATA_DICT[segment_type]
+    
+    SHAPE_STOP_COLS = [*dict_inputs["shape_stop_cols"]]
+    ROUTE_DIR_COLS = [*dict_inputs["route_dir_cols"]]
+    STOP_PAIR_COLS = [*dict_inputs["stop_pair_cols"]]
+    
+    SHAPE_SEG_FILE = dict_inputs["shape_stop_single_segment"]
+    ROUTE_SEG_FILE = dict_inputs["route_dir_single_segment"]
+    
     for analysis_date in analysis_date_list:
                 
-        single_day_segment_averages(analysis_date, segment_type)
+        segment_averages(
+            [analysis_date], 
+            segment_type, 
+            group_cols = OPERATOR_COLS + SHAPE_STOP_COLS + ROUTE_DIR_COLS + STOP_PAIR_COLS,
+            export_file = SHAPE_SEG_FILE
+        )
+        
+        segment_averages(
+            [analysis_date], 
+            segment_type, 
+            group_cols = OPERATOR_COLS + ROUTE_DIR_COLS + STOP_PAIR_COLS,
+            export_file = ROUTE_SEG_FILE
+        )
     
     '''
     from segment_speed_utils.project_vars import weeks_available
+    
+    ROUTE_SEG_FILE = dict_inputs["route_dir_multi_segment"]
+    
     for one_week in weeks_available:
         
-        multi_day_segment_averages(one_week, segment_type)
+         segment_averages(
+            one_week, 
+            segment_type, 
+            group_cols = OPERATOR_COLS + ROUTE_DIR_COLS + STOP_PAIR_COLS + ["weekday_weekend"],
+            export_file = ROUTE_SEG_FILE
+        )    
     '''

--- a/rt_segment_speeds/scripts/average_summary_speeds.py
+++ b/rt_segment_speeds/scripts/average_summary_speeds.py
@@ -151,7 +151,11 @@ def summary_average_speeds(
     
     
     end = datetime.datetime.now()
-    logger.info(f"summary speed averaging for {analysis_date_list} execution time: {end - start}")
+    
+    logger.info(
+        f"{segment_type} summary speed averaging for {analysis_date_list} "
+        f"execution time: {end - start}"
+    )
     
     return
 

--- a/rt_segment_speeds/scripts/average_summary_speeds.py
+++ b/rt_segment_speeds/scripts/average_summary_speeds.py
@@ -8,43 +8,68 @@ import sys
 
 from dask import delayed, compute
 from loguru import logger
-from pathlib import Path
 from typing import Literal
 
 from calitp_data_analysis.geography_utils import WGS84
 from calitp_data_analysis import utils
 from segment_speed_utils import (gtfs_schedule_wrangling, 
-                                 helpers, 
                                  metrics,
-                                 segment_calcs,
                                  time_helpers, 
-                                 time_series_utils
                                  )
+from segment_speed_utils.project_vars import SEGMENT_TYPES
 from update_vars import SEGMENT_GCS, GTFS_DATA_DICT
-from segment_speed_utils.time_series_utils import ROUTE_DIR_COLS
+from average_segment_speeds import (OPERATOR_COLS, CROSSWALK_COLS, 
+                                    concatenate_trip_segment_speeds)
 
-OPERATOR_COLS = [
-    "schedule_gtfs_dataset_key", 
-]    
 
-CROSSWALK_COLS = [
-    "schedule_gtfs_dataset_key", "name",
-    "caltrans_district",
-    "organization_source_record_id", "organization_name",
-    "base64_url"
-]
+def merge_in_common_shape_geometry(
+    speeds: pd.DataFrame,
+    analysis_date: str,
+) -> gpd.GeoDataFrame:
+    """
+    Import the shape geometry. Since route-direction can have many 
+    shape combinations, we'll use the shape that had the most trips
+    to represent average speeds for that route-direction.
+    
+    For a week's worth of data, we'll just use Wed shapes.
+    """
+    # Use Wednesday to select a shape
+    common_shape_geom = gtfs_schedule_wrangling.most_common_shape_by_route_direction(
+        analysis_date
+    ).to_crs(WGS84)
+        
+    col_order = [c for c in speeds.columns]
 
-def single_day_summary_averages(analysis_date: str, dict_inputs: dict):
+    # The merge columns list should be all the columns that are in common
+    geom_file_cols = common_shape_geom.columns.tolist()
+    merge_cols = list(set(col_order).intersection(geom_file_cols))
+    
+    speeds_with_geom = pd.merge(
+        common_shape_geom,
+        speeds,
+        on = merge_cols,
+        how = "inner"
+    ).reset_index(drop=True).reindex(
+        columns = col_order + ["route_name", "geometry"]
+    )
+    
+    return speeds_with_geom
+
+
+def summary_average_speeds(
+    analysis_date_list: list, 
+    segment_type: Literal[SEGMENT_TYPES],
+    group_cols: list,
+    export_file: str
+):
     """
     Main function for calculating average speeds.
     Start from single day segment-trip speeds and 
     aggregate by peak_offpeak, weekday_weekend.
     """
-    SPEED_FILE = dict_inputs["stage4"]
-    MAX_SPEED = dict_inputs["max_speed"]
+    dict_inputs = GTFS_DATA_DICT[segment_type]
     
     TRIP_FILE = dict_inputs["trip_speeds_single_summary"]
-    ROUTE_DIR_FILE = dict_inputs["route_dir_single_summary"]
     
     METERS_CUTOFF = dict_inputs["min_meters_elapsed"]
     MAX_TRIP_SECONDS = dict_inputs["max_trip_minutes"] * 60
@@ -52,42 +77,48 @@ def single_day_summary_averages(analysis_date: str, dict_inputs: dict):
     
     start = datetime.datetime.now()
     
-    trip_group_cols = OPERATOR_COLS + ROUTE_DIR_COLS + [
+    trip_group_cols = group_cols + [
         "shape_array_key", "shape_id",
         "trip_instance_key",
         "time_of_day"
     ]
     
-    df = time_series_utils.concatenate_datasets_across_dates(
-        SEGMENT_GCS,
-        SPEED_FILE,
-        [analysis_date],
-        data_type  = "df",
-        get_pandas = True,
-        columns = trip_group_cols + ["meters_elapsed", "sec_elapsed"],
-        filters = [[("speed_mph", "<=", MAX_SPEED)]]
-    ).pipe(
-        gtfs_schedule_wrangling.add_peak_offpeak_column
-    ).pipe(
-        gtfs_schedule_wrangling.add_weekday_weekend_column
+    df = concatenate_trip_segment_speeds(
+        analysis_date_list,
+        segment_type
     )
-    print("concatenated files") 
     
     trip_avg = metrics.weighted_average_speeds_across_segments(
         df,
         trip_group_cols + ["peak_offpeak"],
     ).pipe(
         gtfs_schedule_wrangling.merge_operator_identifiers, 
-        [analysis_date],
+        analysis_date_list,
         columns = CROSSWALK_COLS
     ).reset_index(drop=True)
     
-    trip_avg.to_parquet(
-        f"{SEGMENT_GCS}{TRIP_FILE}_{analysis_date}.parquet"
-    )
     
-    time1 = datetime.datetime.now()
-    logger.info(f"trip avg {time1 - start}")
+    if len(analysis_date_list) > 1:
+        # If a week (date list) is put in, use Wednesday for segment geometry
+        time_span_str, _ = time_helpers.time_span_labeling(
+            analysis_date_list)
+        
+        analysis_date = analysis_date_list[2]
+    
+    else:
+        # If a single day is put in, use that date for segment geometry
+        analysis_date = analysis_date_list[0]
+        time_span_str = analysis_date
+        
+        trip_avg = compute(trip_avg)[0]
+        
+        trip_avg.to_parquet(
+            f"{SEGMENT_GCS}{TRIP_FILE}_{analysis_date}.parquet"
+        )
+    
+        time1 = datetime.datetime.now()
+        logger.info(f"trip avg {time1 - start}")
+    
     
     trip_avg_filtered = trip_avg[
         (trip_avg.meters_elapsed >= METERS_CUTOFF) & 
@@ -95,147 +126,32 @@ def single_day_summary_averages(analysis_date: str, dict_inputs: dict):
         (trip_avg.sec_elapsed <= MAX_TRIP_SECONDS)
     ]
     
-    route_dir_avg = metrics.concatenate_peak_offpeak_allday_averages(
+    avg_speeds = delayed(metrics.concatenate_peak_offpeak_allday_averages)(
         trip_avg_filtered,
-        OPERATOR_COLS + ROUTE_DIR_COLS,
+        group_cols,
         metric_type = "summary_speeds"
-    ).pipe(
-        gtfs_schedule_wrangling.merge_operator_identifiers, 
-        [analysis_date],
-        columns = CROSSWALK_COLS
-
-    ).reset_index(drop=True)
-    
-    col_order = [c for c in route_dir_avg.columns]
-    
-    common_shape_geom = gtfs_schedule_wrangling.most_common_shape_by_route_direction(
-        analysis_date).to_crs(WGS84)
-    
-    route_dir_avg = pd.merge(
-        common_shape_geom,
-        route_dir_avg,
-        on = OPERATOR_COLS + ROUTE_DIR_COLS,
-        how = "inner"
-    ).reset_index(drop=True).reindex(
-        columns = col_order + ["route_name", "geometry"]
-    )
-        
-    utils.geoparquet_gcs_export(
-        route_dir_avg,
-        SEGMENT_GCS,
-        f"{ROUTE_DIR_FILE}_{analysis_date}"
-    )
-    
-    del route_dir_avg, common_shape_geom
-    
-    time2 = datetime.datetime.now()
-    logger.info(f"route dir avg: {time2 - time1}")
-    logger.info(f"single day summary speed {analysis_date} execution time: {time2 - start}")
-    
-    return
-
-
-def multi_day_summary_averages(analysis_date_list: list, dict_inputs: dict):
-    """
-    Main function for calculating average speeds.
-    Start from single day segment-trip speeds and 
-    aggregate by peak_offpeak, weekday_weekend.
-    The main difference from a single day average is that
-    the seven days is concatenated first before averaging,
-    so that we get weighted averages.
-    """        
-    SPEED_FILE = dict_inputs["stage4"]
-    MAX_SPEED = dict_inputs["max_speed"]
-    ROUTE_DIR_FILE = dict_inputs["route_dir_multi_summary"]
-    
-    METERS_CUTOFF = dict_inputs["min_meters_elapsed"]
-    MAX_TRIP_SECONDS = dict_inputs["max_trip_minutes"] * 60
-    MIN_TRIP_SECONDS = dict_inputs["min_trip_minutes"] * 60
-    
-    start = datetime.datetime.now()
-    
-    trip_group_cols = OPERATOR_COLS + ROUTE_DIR_COLS + [
-        "trip_instance_key",
-        "time_of_day"
-    ]
-    
-    df = time_series_utils.concatenate_datasets_across_dates(
-        SEGMENT_GCS,
-        SPEED_FILE,
-        analysis_date_list,
-        data_type  = "df",
-        get_pandas = False,
-        columns = trip_group_cols + ["meters_elapsed", "sec_elapsed"],
-        filters = [[("speed_mph", "<=", MAX_SPEED)]]
-    ).pipe(
-        gtfs_schedule_wrangling.add_peak_offpeak_column
-    ).pipe(
-        gtfs_schedule_wrangling.add_weekday_weekend_column
-    )
-    print("concatenated files") 
-    
-    trip_avg = delayed(metrics.weighted_average_speeds_across_segments)(
-        df,
-        trip_group_cols + ["peak_offpeak", "weekday_weekend"],
     ).pipe(
         gtfs_schedule_wrangling.merge_operator_identifiers, 
         analysis_date_list,
         columns = CROSSWALK_COLS
     ).reset_index(drop=True)
-
-    trip_avg_filtered = trip_avg[
-        (trip_avg.meters_elapsed >= METERS_CUTOFF) & 
-        (trip_avg.sec_elapsed >= MIN_TRIP_SECONDS) & 
-        (trip_avg.sec_elapsed <= MAX_TRIP_SECONDS)
-    ]
     
-    time_span_str, time_span_num = time_helpers.time_span_labeling(
-        analysis_date_list)
-    
-    route_dir_avg = delayed(metrics.concatenate_peak_offpeak_allday_averages)(
-        trip_avg_filtered,
-        OPERATOR_COLS + ROUTE_DIR_COLS + ["weekday_weekend"],
-        metric_type = "summary_speeds"
-    ).pipe(
-        gtfs_schedule_wrangling.merge_operator_identifiers, 
-        analysis_date_list,
-        columns = [
-            "schedule_gtfs_dataset_key", "name",
-            "caltrans_district",
-            "organization_source_record_id", "organization_name",
-            "base64_url"]
+    avg_speeds_with_geom = delayed(merge_in_common_shape_geometry)(
+        avg_speeds,
+        analysis_date
+    )
         
-    ).reset_index(drop=True)
-    
-    route_dir_avg = compute(route_dir_avg)[0]
-    
-    route_dir_avg = time_helpers.add_time_span_columns(
-        route_dir_avg, time_span_num
-    )
-    
-    col_order = [c for c in route_dir_avg.columns]
-    
-    # Use Wednesday to select a shape
-    common_shape_geom = gtfs_schedule_wrangling.most_common_shape_by_route_direction(
-        analysis_date_list[2]).to_crs(WGS84)
-    
-    route_dir_avg = pd.merge(
-        common_shape_geom,
-        route_dir_avg,
-        on = OPERATOR_COLS + ROUTE_DIR_COLS,
-        how = "inner"
-    ).reset_index(drop=True).reindex(
-        columns = col_order + ["route_name", "geometry"]
-    )
+    avg_speeds_with_geom = compute(avg_speeds_with_geom)[0]
     
     utils.geoparquet_gcs_export(
-        route_dir_avg,
+        avg_speeds_with_geom,
         SEGMENT_GCS,
-        f"{ROUTE_DIR_FILE}_{time_span_str}"
+        f"{export_file}_{time_span_str}"
     )
+    
     
     end = datetime.datetime.now()
-    logger.info(f"multi day summary speed {analysis_date_list} execution time: {end - start}")
+    logger.info(f"summary speed averaging for {analysis_date_list} execution time: {end - start}")
     
     return
 
@@ -251,18 +167,33 @@ if __name__ == "__main__":
                format="{time:YYYY-MM-DD at HH:mm:ss} | {level} | {message}", 
                level="INFO")
     
-    RT_DICT = GTFS_DATA_DICT.rt_stop_times
+    segment_type = "rt_stop_times"
+    
+    dict_inputs = GTFS_DATA_DICT[segment_type]
+    ROUTE_DIR_COLS = [*dict_inputs["route_dir_cols"]]
+    
+    ROUTE_DIR_FILE = dict_inputs["route_dir_single_summary"]
     
     for analysis_date in analysis_date_list:
               
-        single_day_summary_averages(analysis_date, RT_DICT)
-        
+        summary_average_speeds(
+            [analysis_date], 
+            segment_type,
+            group_cols = OPERATOR_COLS + ROUTE_DIR_COLS,
+            export_file = ROUTE_DIR_FILE
+        )
         
     '''
     from segment_speed_utils.project_vars import weeks_available
+    
+    ROUTE_DIR_FILE = dict_inputs["route_dir_multi_summary"]
 
     for one_week in weeks_available:
             
-        multi_day_summary_averages(one_week, RT_DICT)
+        summary_average_speeds(
+            one_week, 
+            segment_type,
+            group_cols = OPERATOR_COLS + ROUTE_DIR_COLS + ["weekday_weekend"],
+            export_file = ROUTE_DIR_FILE
+        )    
     '''
-    

--- a/rt_segment_speeds/scripts/quarter_year_averages.py
+++ b/rt_segment_speeds/scripts/quarter_year_averages.py
@@ -1,0 +1,91 @@
+import geopandas as gpd
+import pandas as pd
+
+from dask import delayed, compute
+
+from update_vars import SEGMENT_GCS, GTFS_DATA_DICT
+from segment_speed_utils import time_series_utils
+
+from average_segment_speeds import concatenate_trip_segment_speeds
+
+def concatenate_single_day_summaries(
+    speed_file: str,
+    analysis_date_list: list,
+    group_cols: list
+):
+    """
+    Concatenate several single day averages
+    and we'll take the average over that.
+    
+    If we have 6 dates of segment p20/p50/p80 speeds,
+    we'll treat each date as an independent entity
+    and average the p20/p50/p80 speeds over that time period.
+    
+    We will not go back to trip segment speeds for each date
+    and do a weighted average.
+    In an extreme case, if one date had 1,000 trips and another date
+    had 100 trips, one date would have 10x the weight of another date,
+    and here, we just want to see where the p20 speed typically is.
+    """
+    df = time_series_utils.concatenate_datasets_across_dates(
+        SEGMENT_GCS,
+        speed_file,
+        analysis_date_list,
+        data_type  = "df",
+        columns = group_cols + ["p20_mph", "p50_mph", "p80_mph", "n_trips"],
+        get_pandas = False
+    )
+    
+    df = df.assign(
+        year = df.service_date.dt.year,
+        quarter = df.service_date.dt.quarter,
+    )
+
+    return df
+
+def get_aggregation(df: pd.DataFrame, group_cols: list):
+    speed_cols = [c for c in df.columns if "_mph" in c]
+
+    df2 = (df
+           .groupby(group_cols, group_keys=False)
+           .agg(
+               {**{c: "mean" for c in speed_cols},
+                "n_trips": "sum"})
+           .reset_index()
+          )
+    
+    return df2
+
+if __name__ == "__main__":
+    
+    from shared_utils import rt_dates
+
+    group_cols = [
+        "route_id", "direction_id", 
+        "stop_pair", "stop_pair_name", 
+        "time_period",
+        'name', # do not use schedule_gtfs_dataset_key, which can differ over time
+        'caltrans_district', 'organization_source_record_id',
+        'organization_name', 'base64_url'
+    ] 
+    
+    FILE = GTFS_DATA_DICT["stop_segments"]["route_dir_single_segment"]
+
+    quarter_df = concatenate_single_day_summaries(
+        FILE,
+        all_dates,
+        group_cols
+    ).pipe(get_aggregation, group_cols + ["year", "quarter"])
+
+    quarter_df = compute(quarter_df)[0]
+    quarter_df.to_parquet(f"{SEGMENT_GCS}{FILE}_quarter.parquet")
+    
+    year_df = concatenate_single_day_summaries(
+        FILE,
+        all_dates,
+        group_cols
+    ).pipe(get_aggregation, group_cols + ["year"])
+    
+    year_df = compute(year_df)[0]
+    year_df.to_parquet(f"{SEGMENT_GCS}{FILE}_year.parquet")
+    

--- a/rt_segment_speeds/segment_speed_utils/time_series_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/time_series_utils.py
@@ -16,16 +16,9 @@ from segment_speed_utils.project_vars import SCHED_GCS, SEGMENT_GCS
 
 fs = gcsfs.GCSFileSystem()
 
-OPERATOR_COLS = ["schedule_gtfs_dataset_key", "name",
-                 "organization_source_record_id", "organization_name",
-                 "base64_url", "caltrans_district"]
-STOP_PAIR_COLS = ["stop_pair", "stop_pair_name"] 
-ROUTE_DIR_COLS = ["route_id", "direction_id"]
-
-
 def concatenate_datasets_across_dates(
     gcs_bucket: str,
-    dataset_name: Literal["speeds_route_dir_segments", "speeds_route_dir"],
+    dataset_name: str,
     date_list: list,
     data_type: Literal["df", "gdf"] = "gdf",
     get_pandas: bool = True,


### PR DESCRIPTION
## segment speeds
* refactor `average_segment_speeds` and `average_summary_speeds` script for clarity, extended uses, and more generalizability:
   *  use the same function for single day or multi-day averages
   * allow weighted averages for peak/offpeak/all_day calculations (which changes the grain and stacks the time periods as extra rows) or simple averages (aggregated at the grain it is at)
* since the segment geometry is fairly stable across time, start averaging speeds over longer time spans to get a quarter (year-quarter) and year grain and test results for `stop_segments` 
* add more entries into `gtfs_analytics_data.yml` to explicitly define which columns are ones to group over and allow various grouping columns
* note that the `stop_segments.shape_stop_singleday` entry could be deprecated or swapped out to support time-of-day averages - do a little exploratory work to decide 
* #1202