### PR TITLE
fund split analysis fix. add MTC

### DIFF
--- a/portfolio/sb125_fund_split_analysis/00__sb125_fund_split_analysis__.ipynb
+++ b/portfolio/sb125_fund_split_analysis/00__sb125_fund_split_analysis__.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bace6dedcebfc90cec8d840954092a1edbe2bb3e7f4efb5f53ed46f8da9aefd
-size 314107
+oid sha256:7373dcb865ff7bcbcb7c284e6f47d4c01a4f4bd48b23bd0c39d21edcbeb997ab
+size 351846

--- a/sb125_analyses/sb125_fund_split_analysis/fund_split.py
+++ b/sb125_analyses/sb125_fund_split_analysis/fund_split.py
@@ -569,6 +569,7 @@ def concat_everything():
         lassen_cleaned,
         ventura_cleaned,
         kern_cleaned,
+        mtc_cleaned
     ],
     ignore_index=True,
     )

--- a/sb125_analyses/sb125_fund_split_analysis/fund_split.py
+++ b/sb125_analyses/sb125_fund_split_analysis/fund_split.py
@@ -619,11 +619,12 @@ def fund_request_melt(df):
 
 
 if __name__ == "__main__":
-    
+    print("running fund_request_checker_v3()")
     good_list, review_list = fund_request_checker_v3(file_list)
     
     cleaned_fund_request = cleaner_loop(good_list)
     
+    print("running individual cleaning scripts")
     #these functions clean specific values (DFs) in the cleaned_fund_request dict
     clean_humboldt()
     
@@ -658,8 +659,10 @@ if __name__ == "__main__":
     
     # concat all values (DFs) from cleaned_fund_request dict to be a single DF and concat the rest of the DFs
     
+    print("running concat_everything")
     all_fund_requests = concat_everything()
     
+    print("saving data as .parquet and .csv to GCS")
     # SAVING TO GCS!
     all_fund_requests.to_parquet(f"{GCS_PATH}all_fund_requests_concat.parquet")
 
@@ -668,3 +671,8 @@ if __name__ == "__main__":
     
     #saving to gcs
     all_melt.to_parquet(f"{GCS_PATH}all_fund_requests_melt.parquet")
+    
+    # saving all_melt to csv
+    all_melt.to_csv(f"{GCS_PATH}all_fund_requests_melt.csv", index=False)
+    
+    print("end of script")

--- a/sb125_analyses/sb125_fund_split_analysis/fund_split_explore.ipynb
+++ b/sb125_analyses/sb125_fund_split_analysis/fund_split_explore.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 2,
    "id": "f1acbbd9-87dd-47bb-b1d1-7f94296a1b4b",
    "metadata": {},
    "outputs": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 21,
    "id": "c041c6eb-cda1-47fd-aecf-7dd04b6f52e7",
    "metadata": {},
    "outputs": [],
@@ -101,39 +101,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 22,
    "id": "6460a800-8204-46ed-9cbc-4861f1114791",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 2424 entries, 0 to 2423\n",
+      "Data columns (total 8 columns):\n",
+      " #   Column                     Non-Null Count  Dtype \n",
+      "---  ------                     --------------  ----- \n",
+      " 0   rtpa                       2424 non-null   object\n",
+      " 1   implementing agenc-y/-ies  2424 non-null   object\n",
+      " 2   project                    2416 non-null   object\n",
+      " 3   fund source                2424 non-null   object\n",
+      " 4   capital/operation fy       2424 non-null   object\n",
+      " 5   fund amount                2424 non-null   int64 \n",
+      " 6   project type               2424 non-null   object\n",
+      " 7   fiscal year                2424 non-null   object\n",
+      "dtypes: int64(1), object(7)\n",
+      "memory usage: 151.6+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pre-MTC fix, 2296 rows\n",
+    "all_melt.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "17b27a11-cba8-426e-9f5e-3afd4ac988f2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(2296, 8)"
+       "Bay Area Rapid Transit Authority (BART)                    24\n",
+       "San Francisco Municipal Transportation Authority           16\n",
+       "Santa Clara Valley Transportation Authority (VTA)           8\n",
+       "MTC                                                         8\n",
+       "Alameda-Contra Costa Transit District                       8\n",
+       "Golden Gate Bridge, Highway and Transportation District     8\n",
+       "Peninsula Corridor Joint Powers Board (Caltrain)            8\n",
+       "Altamont Corridor Express (ACE)                             8\n",
+       "Eastern Contra Costa Transit Authority (ECCTA)              8\n",
+       "Livermore-Amador Valley Transit Authority (LAVTA)           8\n",
+       "Napa Valley Transportation Authority (NVTA)                 8\n",
+       "Solano County Transit (SolTrans)                            8\n",
+       "Western Contra Costa Transit Authority (WestCAT)            8\n",
+       "Name: implementing agenc-y/-ies, dtype: int64"
       ]
      },
+     "execution_count": 25,
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "rtpa                         object\n",
-       "implementing agenc-y/-ies    object\n",
-       "project                      object\n",
-       "fund source                  object\n",
-       "capital/operation fy         object\n",
-       "fund amount                   int64\n",
-       "project type                 object\n",
-       "fiscal year                  object\n",
-       "dtype: object"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "display(all_melt.shape, all_melt.dtypes)"
+    "# confirming MTC is now in the melt dataset!\n",
+    "all_melt[all_melt[\"rtpa\"]==\"MTC\"][\"implementing agenc-y/-ies\"].value_counts()"
    ]
   },
   {


### PR DESCRIPTION
Was informed that MTC was not showing up in the fund split analysis data.
Checked the `all_fund_requets_melt` dataset in GCS and confirmed MTC was not part of the dataset. Double checked the the `concat_everything()` function and found `cleaned_mtc` df was missing from the concat list. Added MTC to the list, re-ran the script, checked the `all_fund_requests_melt` df and confirmed MTC is now part of the dataset.

Then deployed the fund split analysis portfolio site and confirmed MTC now appears in the filter selection of the visuals. 

Added a line in `fund_split.py` to save the dataset as a .csv file.