### PR TITLE
Add `dask.from_map` in `dask_utils/time_series_utils` 

### DIFF
--- a/_shared_utils/shared_utils/dask_utils.py
+++ b/_shared_utils/shared_utils/dask_utils.py
@@ -106,3 +106,44 @@ def concatenate_list_of_files(
     full_df = pd.concat(results, axis=0).reset_index(drop=True)
 
     return full_df
+
+
+def func(
+    path: str,
+    one_date: str,
+    data_type: Literal["df", "gdf"] = "df",
+    **kwargs,
+):
+    """
+    Set up function with little modifications based on
+    the dask docs. Modifications are that we want to read in
+    pandas or geopandas df for a single date.
+
+    https://docs.dask.org/en/latest/generated/dask.dataframe.from_map.html
+    https://blog.dask.org/2023/04/12/from-map
+    """
+    if data_type == "gdf":
+        df = gpd.read_parquet(
+            f"{path}_{one_date}.parquet",
+            **kwargs,
+        ).drop_duplicates()
+
+    else:
+        df = pd.read_parquet(
+            f"{path}_{one_date}.parquet",
+            **kwargs,
+        ).drop_duplicates()
+
+    return df
+
+
+def get_ddf(paths, date_list, data_type, **kwargs):
+    """
+    Set up function with little modifications based on
+    the dask docs. Modifications are that we want to read in
+    a list of dates.
+
+    https://docs.dask.org/en/latest/generated/dask.dataframe.from_map.html
+    https://blog.dask.org/2023/04/12/from-map
+    """
+    return dd.from_map(func, paths, date_list, data_type=data_type, **kwargs).drop_duplicates()

--- a/_shared_utils/shared_utils/gtfs_analytics_data.yml
+++ b/_shared_utils/shared_utils/gtfs_analytics_data.yml
@@ -81,13 +81,15 @@ stop_segments:
   shape_stop_cols: ["shape_array_key", "shape_id", "stop_sequence"]
   stop_pair_cols: ["stop_pair", "stop_pair_name"]
   route_dir_cols: ["route_id", "direction_id"]
-  segment_cols: ["schedule_gtfs_dataset_key", "route_id", "direction_id", "stop_pair", "geometry"]
+  segment_cols: ["route_id", "direction_id", "stop_pair", "geometry"]
   shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" #-- stop after Oct 2024
   route_dir_single_segment: "rollup_singleday/speeds_route_dir_segments"
   route_dir_single_segment_detail: "rollup_singleday/speeds_route_dir_segments_detail" # interim for speedmaps
   route_dir_multi_segment: "rollup_multiday/speeds_route_dir_segments"
   segments_file: "segment_options/shape_stop_segments"
   max_speed: ${speed_vars.max_speed}
+  route_dir_quarter_segment: "rollup_multiday/quarter_speeds_route_dir_segments"
+  route_dir_year_segment: "rollup_multiday/year_speeds_route_dir_segments"
 
 rt_stop_times:
   dir: ${gcs_paths.SEGMENT_GCS}

--- a/_shared_utils/shared_utils/time_helpers.py
+++ b/_shared_utils/shared_utils/time_helpers.py
@@ -92,5 +92,11 @@ def add_quarter(df: pd.DataFrame, date_col: str = "service_date") -> pd.DataFram
     Parse a date column for the year, quarter it is in.
     Pipe this function when we want to use dask_utils.
     """
-    df = df.assign(year=df[date_col].dt.year, quarter=df[date_col].dt.quarter)
+    df = df.assign(
+        year=df[date_col].dt.year,
+        quarter=df[date_col].dt.quarter,
+    )
+
+    df = df.assign(year_quarter=df.year.astype(str) + "_Q" + df.quarter.astype(str))
+
     return df

--- a/_shared_utils/shared_utils/time_helpers.py
+++ b/_shared_utils/shared_utils/time_helpers.py
@@ -76,3 +76,21 @@ def add_time_span_columns(df: pd.DataFrame, time_span_num: str) -> pd.DataFrame:
     )
 
     return df
+
+
+def add_service_date(df: pd.DataFrame, date: str) -> pd.DataFrame:
+    """
+    Add a service date column for GTFS data.
+    Pipe this function when we want to use dask_utils.
+    """
+    df = df.assign(service_date=pd.to_datetime(date))
+    return df
+
+
+def add_quarter(df: pd.DataFrame, date_col: str = "service_date") -> pd.DataFrame:
+    """
+    Parse a date column for the year, quarter it is in.
+    Pipe this function when we want to use dask_utils.
+    """
+    df = df.assign(year=df[date_col].dt.year, quarter=df[date_col].dt.quarter)
+    return df

--- a/rt_segment_speeds/41_dask_from_map.ipynb
+++ b/rt_segment_speeds/41_dask_from_map.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "90a5f6e6-01ea-4466-b120-e810173b718b",
+   "metadata": {},
+   "source": [
+    "## Update `time_series_utils` and `dask_utils` with `dask.from_map` instead of delayed\n",
+    "\n",
+    "`time_series_utils` concatenating a bunch of months using `dask.delayed` is taking longer to do so. For segment geometries, this gdf is getting really big and using a lot of memory. In reality, we don't need to full gdf, we want to look across many dates and then dedupe.\n",
+    "\n",
+    "Dask delayed docs mentions the use of `from_map` as a way to read in parquets and do something with it.\n",
+    "\n",
+    "Dask docs: https://docs.dask.org/en/latest/generated/dask.dataframe.from_map.html\n",
+    "\n",
+    "Tutorial: https://blog.dask.org/2023/04/12/from-map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b80bacc-f2ce-4ff9-8ab6-161a1e55bbed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "\n",
+    "from typing import Literal\n",
+    "\n",
+    "from segment_speed_utils.project_vars import GTFS_DATA_DICT, SEGMENT_GCS\n",
+    "from shared_utils import rt_dates\n",
+    "\n",
+    "analysis_date_list = rt_dates.y2024_dates\n",
+    "\n",
+    "segment_type = \"stop_segments\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04676acc-0306-43c0-b8ad-77b512637fc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def func(\n",
+    "    path: str,\n",
+    "    one_date: str, \n",
+    "    data_type: Literal[\"df\", \"gdf\"] = \"df\",\n",
+    "    **kwargs, \n",
+    "):\n",
+    "    if data_type == \"gdf\":\n",
+    "        \n",
+    "        df = gpd.read_parquet(\n",
+    "            f\"{path}_{one_date}.parquet\", \n",
+    "            **kwargs,\n",
+    "        ).drop_duplicates()\n",
+    "\n",
+    "    else:\n",
+    "        df = pd.read_parquet(\n",
+    "            f\"{path}_{one_date}.parquet\", \n",
+    "            **kwargs,\n",
+    "        ).drop_duplicates()\n",
+    "    \n",
+    "    return df\n",
+    "\n",
+    "def get_ddf(paths, analysis_date_list, data_type, **kwargs):\n",
+    "\n",
+    "    return dd.from_map(\n",
+    "        func, paths, \n",
+    "        analysis_date_list, \n",
+    "        data_type = data_type, \n",
+    "        **kwargs\n",
+    "    ).drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f717278b-eb1b-4ff5-abc5-d52306806f7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segment_file = GTFS_DATA_DICT[segment_type][\"segments_file\"]\n",
+    "segment_cols = [\"schedule_gtfs_dataset_key\", \"route_id\", \"geometry\"]\n",
+    "\n",
+    "segment_paths = [f\"{SEGMENT_GCS}{segment_file}\" for date in analysis_date_list]\n",
+    "\n",
+    "segment_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cd3b5e9-03b8-442f-9e68-ce6ca7448d10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segment_gddf = get_ddf(\n",
+    "    segment_paths, \n",
+    "    analysis_date_list, \n",
+    "    data_type = \"gdf\",\n",
+    "    columns = segment_cols\n",
+    ")  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0286691c-10ce-40d5-ac72-d08077aa0661",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segment_gddf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcd1dd94-6335-4501-9b80-42a95eb75845",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segment_gddf.compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "070ff8c3-18dd-4d14-81b3-59a584a4c4df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_file = GTFS_DATA_DICT[segment_type][\"route_dir_single_segment\"]\n",
+    "speed_cols = [\"schedule_gtfs_dataset_key\", \"route_id\"]\n",
+    "\n",
+    "speed_paths = [f\"{SEGMENT_GCS}{speed_file}\" for date in analysis_date_list]\n",
+    "speed_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02247d42-0a9d-4f06-b619-541ce61c9056",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_ddf = get_ddf(\n",
+    "    speed_paths, \n",
+    "    analysis_date_list, \n",
+    "    data_type = \"df\",\n",
+    "    columns = speed_cols\n",
+    ")  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0de3f973-e5b5-4018-ad3a-7b2e647143ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_df = speed_ddf.compute()\n",
+    "print(speed_df.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f28315e-4e8c-435a-b501-34db94435d1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def concatenate_datasets_across_dates(\n",
+    "    gcs_bucket: str,\n",
+    "    dataset_name: str,\n",
+    "    date_list: list,\n",
+    "    data_type: Literal[\"df\", \"gdf\"],\n",
+    "    get_pandas: bool = True,\n",
+    "    **kwargs\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Concatenate parquets across all months of available data.\n",
+    "    \"\"\"  \n",
+    "    paths = [f\"{gcs_bucket}{dataset_name}\" for date in date_list]\n",
+    "\n",
+    "    df = get_ddf(\n",
+    "        paths, \n",
+    "        date_list, \n",
+    "        data_type = data_type,\n",
+    "        **kwargs\n",
+    "    )  \n",
+    "    if get_pandas:\n",
+    "        df = df.compute()\n",
+    "    \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c58061d0-6670-48fb-aafe-b271a35e1ea1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_ddf2 = concatenate_datasets_across_dates(\n",
+    "    SEGMENT_GCS,\n",
+    "    speed_file,\n",
+    "    analysis_date_list,\n",
+    "    data_type = \"df\",\n",
+    "    columns = speed_cols,\n",
+    "    get_pandas = False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56a32dee-5179-4835-ab4d-5a2d20f78a77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_df2 = speed_ddf2.compute()\n",
+    "print(speed_df2.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "192689d5-bec2-4c0f-857f-741f7f7366f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_df3 = concatenate_datasets_across_dates(\n",
+    "    SEGMENT_GCS,\n",
+    "    speed_file,\n",
+    "    analysis_date_list,\n",
+    "    data_type = \"df\",\n",
+    "    get_pandas = True,\n",
+    "    columns = speed_cols,\n",
+    ")\n",
+    "\n",
+    "speed_df3.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cce5ea5c-ba9a-4110-956c-7acab35dee2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from segment_speed_utils import time_series_utils\n",
+    "\n",
+    "speed_df4 = time_series_utils.concatenate_datasets_across_dates(\n",
+    "    SEGMENT_GCS,\n",
+    "    speed_file,\n",
+    "    analysis_date_list,\n",
+    "    data_type = \"df\",\n",
+    "    get_pandas = True,\n",
+    "    columns = speed_cols,\n",
+    ")\n",
+    "\n",
+    "speed_df4.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7caf46d9-f4d1-4a79-99f6-b06792b3d5a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speed_df4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4e0fd9e-15b3-43aa-aaea-d5b279d9c7f8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rt_segment_speeds/scripts/quarter_year_averages.py
+++ b/rt_segment_speeds/scripts/quarter_year_averages.py
@@ -3,62 +3,20 @@ Average segment speeds over longer time periods,
 a quarter or a year.
 """
 import dask.dataframe as dd
+import dask_geopandas as dg
+import datetime
 import geopandas as gpd
 import pandas as pd
 
-from dask import delayed, compute
+from typing import Literal
 
 from calitp_data_analysis import utils
-from segment_speed_utils import time_series_utils
+from shared_utils import dask_utils, rt_dates, time_helpers
+from segment_speed_utils import helpers
 from update_vars import SEGMENT_GCS, GTFS_DATA_DICT
 
-def segment_speeds_one_day(
-    segment_type: str,
-    analysis_date: list,
-    segment_cols: list,
-    org_cols: list
-):
-    """
-    Concatenate segment geometry (from rt_segment_speeds)
-    for all the dates we have 
-    and get it to route-direction-segment grain
-    """
-    speed_file = GTFS_DATA_DICT[segment_type]["route_dir_single_segment"]
-    segment_file = GTFS_DATA_DICT[segment_type]["segments_file"]
-    
-    speeds_df = pd.read_parquet(
-        f"{SEGMENT_GCS}{speed_file}_{analysis_date}.parquet",
-        columns = segment_cols + org_cols + [
-            "schedule_gtfs_dataset_key",
-            "p20_mph", "p50_mph", "p80_mph", "n_trips"]
-    ).assign(
-        service_date = pd.to_datetime(analysis_date)
-    )
-    
-    segment_gdf = gpd.read_parquet(
-        f"{SEGMENT_GCS}{segment_file}_{analysis_date}.parquet",
-        columns = segment_cols + [
-            "schedule_gtfs_dataset_key", "geometry"]
-    ).drop_duplicates().reset_index(drop=True)
 
-    merge_cols = [c for c in speeds_df.columns if c in segment_gdf.columns]
-    
-    df = pd.merge(
-        segment_gdf[merge_cols + ["geometry"]].drop_duplicates(),
-        speeds_df,
-        on = merge_cols,
-        how = "inner"
-    )
-    
-    df = df.assign(
-        year = df.service_date.dt.year,
-        quarter = df.service_date.dt.quarter,
-    )
-    
-    return df
-
-
-def get_aggregation(df: pd.DataFrame, group_cols: list):
+def get_aggregation(df: pd.DataFrame, group_cols: list) -> pd.DataFrame:
     """
     Aggregating across days, take the (mean)p20/p50/p80 speed
     and count number of trips across those days.
@@ -75,51 +33,137 @@ def get_aggregation(df: pd.DataFrame, group_cols: list):
     
     return df2
 
-def average_by_time(date_list: list, time_cols: list):
+
+def get_segment_speed_ddf(
+    segment_type: str,
+    analysis_date_list: list, 
+    time_cols: list
+) -> dd.DataFrame:
     """
+    Import segment speeds (p20/p50/p80) speeds
+    across a list of dates.
+    Prep the df for aggregation by year-quarter or year.
     """
-    # These define segments, it's route-dir-stop_pair
-    segment_stop_cols = [
-        "route_id", "direction_id", 
-        "stop_pair", 
+    speed_file = GTFS_DATA_DICT[segment_type]["route_dir_single_segment"]
+    paths = [f"{SEGMENT_GCS}{speed_file}" for _ in analysis_date_list]
+
+    SEGMENT_COLS = [*GTFS_DATA_DICT[segment_type]["segment_cols"]]
+    SEGMENT_COLS = [i for i in SEGMENT_COLS if i != "geometry"]
+    
+    OPERATOR_COLS = [
+        "name", 
+        "caltrans_district", 
+        # TODO: in future, moving how we choose organization
+        # to another approach, so let's not even include it here
     ]
     
-    # These are the other columns we need, from speeds, but not in segments
-    org_cols = [
-        "stop_pair_name",
-        "time_period",
-        "name",
-        'caltrans_district', 'organization_source_record_id',
-        'organization_name', 'base64_url'
-    ]
+    group_cols = helpers.unique_list(OPERATOR_COLS + SEGMENT_COLS + ["stop_pair_name"])
     
-    delayed_dfs = [
-        delayed(segment_speeds_one_day)(
-            "stop_segments", 
-            one_date,
-            segment_stop_cols,
-            org_cols
-       ) for one_date in date_list
-    ]
+    ddf = dask_utils.get_ddf(
+        paths, 
+        analysis_date_list, 
+        data_type = "df",
+        add_date = True,
+        columns = group_cols + [
+            "p20_mph", "p50_mph", "p80_mph", "n_trips",
+            "time_period"
+        ]
+    )
     
-    ddf = dd.from_delayed(delayed_dfs)
+    ddf = time_helpers.add_quarter(ddf).sort_values(
+        "year_quarter", ascending=False)
     
-    group_cols = [
-        c for c in segment_stop_cols + org_cols 
-        if c not in ["schedule_gtfs_dataset_key"]
-    ] + time_cols
+    ddf2 = get_aggregation(
+        ddf, 
+        group_cols + time_cols
+    )
     
-    speed_averages = get_aggregation(ddf, group_cols)
-    speed_averages = speed_averages.compute()
+    return ddf2
+
+
+def get_segment_geom_gddf(
+    segment_type: str,
+    analysis_date_list: list, 
+    time_cols: list
+) -> dg.GeoDataFrame:
+    """
+    Import segment geometry gdf
+    across a list of dates.
+    Dedupe the df for aggregation by year-quarter or year.
+    """
+    segment_file = GTFS_DATA_DICT[segment_type]["segments_file"]
+    segment_cols = [*GTFS_DATA_DICT[segment_type]["segment_cols"]]
+    paths = [f"{SEGMENT_GCS}{segment_file}" for _ in analysis_date_list]
+
+    # From the speed file, we want schedule_gtfs_dataset_key and name
+    # so we can dedupe by name over a longer time period
+    # name may not change, but key can change
+    speed_file = GTFS_DATA_DICT[segment_type]["route_dir_single_segment"]
+    operator_paths = [f"{SEGMENT_GCS}{speed_file}" for _ in analysis_date_list]
+
+    operator_ddf = dask_utils.get_ddf(
+        operator_paths, 
+        analysis_date_list, 
+        data_type = "df",
+        add_date = True,
+        columns = ["schedule_gtfs_dataset_key", "name"]
+    )
     
-    segment_geom = ddf[
-        ["name", "geometry"] + segment_stop_cols + time_cols
-    ].drop_duplicates().compute()
+    segment_gddf = dask_utils.get_ddf(
+        paths, 
+        analysis_date_list, 
+        data_type = "gdf",
+        add_date = True,
+        columns = ["schedule_gtfs_dataset_key"] + segment_cols
+    )
     
+    gddf = dd.merge(
+        segment_gddf,
+        operator_ddf,
+        on = ["schedule_gtfs_dataset_key", "service_date"],
+        how = "inner"
+    )
+    
+    gddf = time_helpers.add_quarter(gddf).sort_values(
+        "year_quarter", ascending=False)
+    
+    gddf2 = gddf[
+        ["name"] + segment_cols + time_cols
+    ].drop_duplicates()
+    
+    return gddf2
+
+
+def average_segment_speeds_by_time_grain(
+    segment_type: str,
+    analysis_date_list: list, 
+    time_grain: Literal["quarter", "year"]
+) -> gpd.GeoDataFrame:
+    """
+    Average segment speeds (tabular) by time grain
+    and attach the geometry for segment that's been deduped at
+    that time grain.
+    """    
+    if time_grain == "quarter":
+        time_cols = ["year", "quarter"]
+    elif time_grain == "year":
+        time_cols = ["year"]
+    
+    SEGMENT_COLS = [*GTFS_DATA_DICT[segment_type]["segment_cols"]]
+    SEGMENT_COLS = [c for c in SEGMENT_COLS if c != "geometry"]
+    
+    speeds = get_segment_speed_ddf(
+        segment_type, analysis_date_list, time_cols
+    ).compute()
+    
+    segment_geom = get_segment_geom_gddf(
+        segment_type, analysis_date_list, time_cols
+    ).compute()
+
     speed_gdf = pd.merge(
         segment_geom,
-        speed_averages,
-        on = ["name"] + segment_stop_cols + time_cols,
+        speeds,
+        on = ["name"] + SEGMENT_COLS + time_cols,
         how = "inner"
     )
     
@@ -127,31 +171,46 @@ def average_by_time(date_list: list, time_cols: list):
 
 
 if __name__ == "__main__":
-    import datetime
     from shared_utils import rt_dates
 
+    start = datetime.datetime.now()
+    
     segment_type = "stop_segments"
-    EXPORT = GTFS_DATA_DICT[segment_type]["route_dir_multi_segment"]
+    QUARTER_EXPORT = GTFS_DATA_DICT[segment_type]["route_dir_quarter_segment"]
+    YEAR_EXPORT = GTFS_DATA_DICT[segment_type]["route_dir_year_segment"]
+    
     all_dates = rt_dates.y2024_dates + rt_dates.y2023_dates
-    '''
-    # quarter averages take x min
-    speeds_by_quarter = average_by_time(all_dates, ["year", "quarter"])
+    
+    # quarter averages take 11 min
+    speeds_by_quarter = average_segment_speeds_by_time_grain(
+        segment_type,
+        all_dates, 
+        time_grain = "quarter"
+    )
 
     utils.geoparquet_gcs_export(
         speeds_by_quarter,
         SEGMENT_GCS,
-        f"{EXPORT}_quarter"
+        QUARTER_EXPORT
     )
     del speeds_by_quarter
-    '''
-    # year averages take 14 min
-    t0 = datetime.datetime.now()
-    speeds_by_year = average_by_time(all_dates, ["year"])
+    
+    time1 = datetime.datetime.now()
+    print(f"quarter averages: {time1 - start}")
+    
+    # year averages take 10 min  
+    speeds_by_year =  average_segment_speeds_by_time_grain(
+        segment_type,  
+        all_dates, 
+        time_grain = "year"
+    )
 
     utils.geoparquet_gcs_export(
         speeds_by_year,
         SEGMENT_GCS,
-        f"{EXPORT}_year"
+        YEAR_EXPORT
     )    
-    t1 = datetime.datetime.now()
-    print(f"execution: {t1 - t0}")
+    
+    end = datetime.datetime.now()
+    print(f"year averages: {end - time1}")
+    print(f"execution time: {end - start}")

--- a/rt_segment_speeds/segment_speed_utils/time_series_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/time_series_utils.py
@@ -4,54 +4,37 @@ by concatenating aggregated data across multiple months.
 """
 import datetime
 import geopandas as gpd
-import gcsfs
 import pandas as pd
 
-from dask import delayed, compute
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Union
 
 from segment_speed_utils import helpers
 from segment_speed_utils.project_vars import SCHED_GCS, SEGMENT_GCS
+from shared_utils import dask_utils
 
-fs = gcsfs.GCSFileSystem()
 
 def concatenate_datasets_across_dates(
     gcs_bucket: str,
     dataset_name: str,
     date_list: list,
-    data_type: Literal["df", "gdf"] = "gdf",
+    data_type: Literal["df", "gdf"],
     get_pandas: bool = True,
     **kwargs
 ) -> pd.DataFrame:
     """
     Concatenate parquets across all months of available data.
     """  
-    if data_type == "gdf":
-        dfs = [
-            delayed(gpd.read_parquet)(
-                f"{gcs_bucket}{dataset_name}_{d}.parquet",
-                **kwargs
-            ).assign(
-                service_date = pd.to_datetime(d)
-            ) for d in date_list
-        ]
-    else:
-        dfs = [
-            delayed(pd.read_parquet)(
-                f"{gcs_bucket}{dataset_name}_{d}.parquet",
-                **kwargs
-            ).assign(
-                service_date = pd.to_datetime(d)
-            ) for d in date_list
-        ]
-    
-    df = delayed(pd.concat)(
-        dfs, axis=0, ignore_index=True
-    ) 
-    
+    paths = [f"{gcs_bucket}{dataset_name}" for date in date_list]
+
+    df = dask_utils.get_ddf(
+        paths, 
+        date_list, 
+        data_type = data_type,
+        **kwargs
+    )  
     if get_pandas:
-        df = compute(df)[0]    
+        df = df.compute()
     
     return df
 

--- a/rt_segment_speeds/segment_speed_utils/time_series_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/time_series_utils.py
@@ -31,10 +31,9 @@ def concatenate_datasets_across_dates(
         paths, 
         date_list, 
         data_type = data_type,
+        get_pandas=get_pandas,
         **kwargs
     )  
-    if get_pandas:
-        df = df.compute()
     
     return df
 


### PR DESCRIPTION
* Start with a notebook in `rt_segment_speeds/41_dask_from_map.ipynb` testing how to use `dask.from_map`
* Follow `dask` tutorial example and add the necessary functions into `shared_utils.dask_utils` and make sure it supports necessary args/kwargs for `time_series_utils`
* Add functions into `shared_utils.time_helpers` for adding `service_date`, `year`, `quarter`, since these used to be part of `time_series_utils`. For `dask.from_map`, put these functions here so we can pipe these additional functions through.
* Refactor `quarter_year_averages.py` for segment speed averaging and use these functions
   * Quarterly and yearly averages each take ~10 min, down from 25 min before for yearly averages (quarterly averages blew the kernel)
   * This is better. This can still get refactored to simplify the logic and see if we can stack yearly on top of quarterly so we don't have two, independent, 10 minute steps.