### PR TITLE
Netlify to GCS migration for Portfolio site

### DIFF
--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -231,7 +231,7 @@ class Site(BaseModel):
 
     @validator('readme', pre=True, always=True)
     def default_readme(cls, v, *, values, **kwargs):
-        if "./" in v: 
+        if "./" in v:
             return Path(v)
         else:
             return (values['directory'] / Path("README.md")) or (values['directory'] / Path(v))
@@ -282,24 +282,24 @@ class EngineWithParameterizedMarkdown(NBClientEngine):
             # hide input (i.e. code) for all cells
             if cell.cell_type == "code":
                 cell.metadata.tags.append("remove_input")
-                                
+
                 # Consider importing this name from calitp.magics
                 if '%%capture_parameters' in cell.source:
                     params = {**params, **json.loads(cell.outputs[0]['text'])}
-                        
+
                 if "%%capture" in cell.source:
                     cell.outputs = []
-                    
+
                 if no_stderr:
                     cell.outputs = [output for output in cell.outputs if 'name' not in output.keys() or output['name'] != 'stderr']
-                
-                # right side widget to add "tags" (it reverts to "tags": ["tags"]), 
-                if cell.metadata.get("tags"): 
+
+                # right side widget to add "tags" (it reverts to "tags": ["tags"]),
+                if cell.metadata.get("tags"):
                     #"%%full_width" in cell.source doesn't pick up
-                    # when Jupyterbook builds, it says 
+                    # when Jupyterbook builds, it says
                     # UsageError: Line magic function `%%full_width` not found.
                     cell.metadata.tags.append("full-width")
-                    
+
 papermill_engines.register("markdown", EngineWithParameterizedMarkdown)
 papermill_engines.register_entry_points()
 
@@ -316,7 +316,7 @@ def index(
             name = site.replace(".yml", "")
             site_output_dir = PORTFOLIO_DIR / Path(name)
             sites.append(Site(output_dir=site_output_dir, name=name, **yaml.safe_load(f)))
-            
+
     Path("./portfolio/index").mkdir(parents=True, exist_ok=True)
     for template in ["index.html", "_redirects"]:
         fname = f"./portfolio/index/{template}"
@@ -437,6 +437,6 @@ def build(
     if errors:
         typer.secho(f"{len(errors)} errors encountered during papermill execution", fg=typer.colors.RED)
         sys.exit(1)
-        
+
 if __name__ == "__main__":
     app()

--- a/portfolio/templates/index.html
+++ b/portfolio/templates/index.html
@@ -29,7 +29,7 @@
 <body style>
     <h1>Cal-ITP Data Analysis Portfolio</h1>
     {% for site in sites -%}
-    <p><a href="/{{ site.name }}/">{{ site.title }}</a></p>
+    <p><a href="{{ site.name }}/index.html">{{ site.title }}</a></p>
     {% endfor %}
 
     <p>Source code can be found <a href="https://github.com/cal-itp/data-analyses/">on GitHub.</a></p>


### PR DESCRIPTION
Update the portfolio.py script to deploy to Google Cloud Storage instead of Netlify. This is related to #849 and should be merged _after_ the steps in that issue are complete.

There is one process change in deploying: the updated script adds a `--prod` flag to the `build` command. If `--prod` is _not_ specified, the portfolio site being built will be deployed to a draft bucket instead of the production bucket. By default the production bucket is `calitp-data-analyses-portfolio` and the draft bucket is `calitp-data-analyses-portfolio-draft`.