### PR TITLE
Patch - `stop_times_direction` script 

### DIFF
--- a/gtfs_funnel/stop_times_with_direction.py
+++ b/gtfs_funnel/stop_times_with_direction.py
@@ -154,9 +154,9 @@ def find_prior_subseq_stop_info(
     gdf2 = gdf[keep_cols].assign(
         stop_primary_direction = stop_direction,
         stop_pair = gdf.stop_id.astype(str).str.cat(
-            gdf.subseq_stop_id.astype(str)),
+            gdf.subseq_stop_id.astype(str), sep = "__"),
         stop_pair_name = gdf.stop_name.astype(str).str.cat(
-            gdf.subseq_stop_name.astype(str)),
+            gdf.subseq_stop_name.astype(str), sep = "__"),
     )
     
     stop_times_geom_direction = pd.merge(


### PR DESCRIPTION
* Update how `stop_pair` and `stop_pair_name` is constructed...must use double underscores (`sep="__"`) within `str.cat`. This is already what's created, refactor in code should match what we do.
* #1315