### PR TITLE
Create time-of-day segment speed aggregations

### DIFF
--- a/_shared_utils/shared_utils/dask_utils.py
+++ b/_shared_utils/shared_utils/dask_utils.py
@@ -142,6 +142,35 @@ def import_df_func(
     return df
 
 
+def import_ddf_func(path, date_list, data_type, **kwargs):
+    """
+    Equivalent to improt_df_func, except uses dask to read in the dataframe
+    instead of pandas.
+    Concatenates the various dates.
+    """
+    if data_type == "df":
+        ddf = dd.multi.concat(
+            [
+                dd.read_parquet(f"{path}_{one_date}.parquet", **kwargs).assign(service_date=one_date)
+                for one_date in date_list
+            ],
+            axis=0,
+            ignore_index=True,
+        )
+
+    elif data_type == "gdf":
+        ddf = dd.multi.concat(
+            [
+                dg.read_parquet(f"{path}_{one_date}.parquet", **kwargs).assign(service_date=one_date)
+                for one_date in date_list
+            ],
+            axis=0,
+            ignore_index=True,
+        )
+
+    return ddf
+
+
 def get_ddf(paths, date_list, data_type, get_pandas: bool = False, **kwargs):
     """
     Set up function with little modifications based on

--- a/_shared_utils/shared_utils/gtfs_analytics_data.yml
+++ b/_shared_utils/shared_utils/gtfs_analytics_data.yml
@@ -80,10 +80,14 @@ stop_segments:
   stop_pair_cols: ["stop_pair", "stop_pair_name"]
   route_dir_cols: ["route_id", "direction_id"]
   segment_cols: ["route_id", "direction_id", "stop_pair", "geometry"]
+  segment_timeofday: "rollup_singleday/speeds_route_dir_timeofday_segments"
+  # segment_peakoffpeak
+  # segment_weekday_timeofday
+  # -- cache segment_timeofday first and use this to build other layers? other keys to make peak/offpeak, weekday/weekend grains clear?
   #shape_stop_single_segment: "rollup_singleday/speeds_shape_stop_segments" #-- stop after Oct 2024
   route_dir_single_segment: "rollup_singleday/speeds_route_dir_segments"
   route_dir_single_segment_detail: "rollup_singleday/speeds_route_dir_segments_detail" # interim for speedmaps
-  route_dir_multi_segment: "rollup_multiday/speeds_route_dir_segments"
+  route_dir_multi_segment: "rollup_multiday/speeds_route_dir_segments" # -- this one should be replaced with weekday/weekend, make clear the grain
   segments_file: "segment_options/shape_stop_segments"
   max_speed: ${speed_vars.max_speed}
   route_dir_quarter_segment: "rollup_multiday/quarter_speeds_route_dir_segments"

--- a/_shared_utils/shared_utils/rt_dates.py
+++ b/_shared_utils/shared_utils/rt_dates.py
@@ -96,7 +96,7 @@ def get_week(month: Literal[[*valid_weeks]], exclude_wed: bool) -> list:
 apr2023_week = get_week(month="apr2023", exclude_wed=False)
 oct2023_week = get_week(month="oct2023", exclude_wed=False)
 apr2024_week = get_week(month="apr2024", exclude_wed=False)
-oct2024_week = get_week(month="oct2024", exclude_wed=False)
+oct2024_week = [d for d in get_week(month="oct2024", exclude_wed=False) if d != DATES["oct2024g"]]
 
 MONTH_DICT = {
     1: "January",

--- a/_shared_utils/shared_utils/time_helpers.py
+++ b/_shared_utils/shared_utils/time_helpers.py
@@ -38,6 +38,11 @@ WEEKDAY_DICT = {
     **{k: "weekend" for k in ["Saturday", "Sunday"]},
 }
 
+WEEKDAY_DICT2 = {
+    **{k: "Weekday" for k in ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]},
+    **{k: k for k in ["Saturday", "Sunday"]},
+}
+
 
 def time_span_labeling(date_list: list) -> tuple[str]:
     """

--- a/rt_segment_speeds/scripts/time_of_day_averages.py
+++ b/rt_segment_speeds/scripts/time_of_day_averages.py
@@ -1,0 +1,39 @@
+"""
+Mock up time-of-day averages across multiple Oct 2024 dates
+"""
+import geopandas as gpd
+import pandas as pd
+
+from dask import delayed, compute
+
+from update_vars import SEGMENT_GCS, GTFS_DATA_DICT
+
+from quarter_year_averages import concatenate_single_day_summaries, get_aggregation
+
+if __name__ == "__main__":
+    
+    from shared_utils import rt_dates 
+    
+    FILE2 = GTFS_DATA_DICT["stop_segments"]["shape_stop_single_segment"] + "_test"
+
+    time_of_day_cols = [
+        "route_id", "direction_id", 
+        "stop_pair", "stop_pair_name", 
+        'name', 
+        "time_of_day"
+    ] 
+    
+    quarter_timeofday_df = concatenate_single_day_summaries(
+        FILE2,
+        rt_dates.oct2024_week, 
+        time_of_day_cols
+    ).pipe(
+        get_aggregation, 
+        time_of_day_cols + ["year", "quarter"]
+    )
+    
+    quarter_timeofday_df = quarter_timeofday_df.compute()
+    quarter_timeofday_df.to_parquet(
+        f"{SEGMENT_GCS}{FILE2}_quarter_time_of_day.parquet"
+    )
+    

--- a/rt_segment_speeds/segment_speed_utils/project_vars.py
+++ b/rt_segment_speeds/segment_speed_utils/project_vars.py
@@ -16,9 +16,9 @@ PUBLIC_GCS = GTFS_DATA_DICT.gcs_paths.PUBLIC_GCS
 oct2023_week = rt_dates.get_week("oct2023", exclude_wed=True)
 apr2023_week = rt_dates.get_week("apr2023", exclude_wed=True)
 apr2024_week = rt_dates.get_week("apr2024", exclude_wed=True)
-oct2024_week = rt_dates.get_week("oct2024", exclude_wed=True)
+oct2024_week = [d for d in rt_dates.get_week("oct2024", exclude_wed=True) 
+                if d != rt_dates.DATES["oct2024g"]]
 
-# One file wasn't found for October 21 2024 
 all_dates = (
     rt_dates.y2024_dates + rt_dates.y2023_dates + 
     oct2024_week + apr2024_week + oct2023_week + apr2023_week
@@ -29,7 +29,7 @@ weeks_available = [
     rt_dates.oct2023_week, rt_dates.apr2023_week, 
 ]
 
-analysis_date_list =  apr2024_week + oct2023_week + apr2023_week
+analysis_date_list = apr2024_week + oct2023_week + apr2023_week
                      
 
 PROJECT_CRS = "EPSG:3310"


### PR DESCRIPTION
* Implement a time-of-day aggregation. In `gtfs_analytics_data.yml`, this is `segment_timeofday` key.
* TODO: weighted averages for single day peak/offpeak.
* Backfill all dates for `stop_segments`
* Add a function in `shared_utils/dask_utils` where we can read in multiple dask dataframes by date and do some kind of aggregation (`dd.from_map` reading from `pandas` can get really big)
* #1372 