### PR TITLE
Caltrans district renaming

### DIFF
--- a/_shared_utils/shared_utils/portfolio_utils.py
+++ b/_shared_utils/shared_utils/portfolio_utils.py
@@ -159,3 +159,25 @@ def create_portfolio_yaml_chapters_with_sections(
     print(f"{portfolio_site_yaml} generated")
 
     return
+
+
+CALTRANS_DISTRICT_DICT = {
+    # old name variations (key): portfolio name displayed (value)
+    "03 - Marysville": "03 - Marysville / Sacramento",
+    "04 - Oakland": "04 - Bay Area / Oakland",
+    "05 - San Luis Obispo": "05 - San Luis Obispo / Santa Barbara",
+    "06 - Fresno": "06 - Fresno / Bakersfield",
+    "07 - Los Angeles": "07 - Los Angeles / Ventura",
+    "08 - San Bernardino": "08 - San Bernardino / Riverside",
+    "12 - Irvine": "12 - Santa Ana",
+    **{
+        k: k
+        for k in [
+            "01 - Eureka",
+            "02 - Redding",
+            "09 - Bishop",
+            "10 - Stockton",
+            "11 - San Diego",
+        ]
+    },
+}

--- a/_shared_utils/shared_utils/schedule_rt_utils.py
+++ b/_shared_utils/shared_utils/schedule_rt_utils.py
@@ -13,14 +13,6 @@ from shared_utils import gtfs_utils_v2
 from siuba import *
 
 PACIFIC_TIMEZONE = "US/Pacific"
-RENAME_DISTRICT_DICT = {
-    "Marysville / Sacramento": "Marysville",  # D3
-    "Bay Area / Oakland": "Oakland",  # D4
-    "San Luis Obispo / Santa Barbara": "San Luis Obispo",  # D5
-    "Fresno / Bakersfield": "Fresno",  # D6
-    "San Bernardino / Riverside": "San Bernardino",  # D8
-    "Orange County": "Irvine",  # D12
-}
 
 
 def localize_timestamp_col(df: dd.DataFrame, timestamp_col: Union[str, list]) -> dd.DataFrame:
@@ -203,18 +195,6 @@ def filter_dim_county_geography(
         >> rename(county_geography_key=_.key)
         >> gtfs_utils_v2.subset_cols(keep_cols2)
         >> collect()
-    )
-
-    # Several caltrans_district values in mart_transit_database
-    # now contain slashes.
-    # Use dict to standardize these against how previous versions were
-    dim_county_geography = dim_county_geography.assign(
-        caltrans_district_name=dim_county_geography.apply(
-            lambda x: RENAME_DISTRICT_DICT[x.caltrans_district_name]
-            if x.caltrans_district_name in RENAME_DISTRICT_DICT.keys()
-            else x.caltrans_district_name,
-            axis=1,
-        )
     )
 
     bridge_orgs_county_geog = localize_timestamp_col(bridge_orgs_county_geog, ["_valid_from", "_valid_to"])

--- a/gtfs_digest/_operators_prep.py
+++ b/gtfs_digest/_operators_prep.py
@@ -1,4 +1,4 @@
-from shared_utils import catalog_utils
+from shared_utils import catalog_utils, potfolio_utils
 import pandas as pd
 
 GTFS_DATA_DICT = catalog_utils.get_catalog("gtfs_analytics_data")
@@ -10,17 +10,23 @@ def operators_schd_vp_rt()->pd.DataFrame:
     """
     schd_vp_url = f"{GTFS_DATA_DICT.digest_tables.dir}{GTFS_DATA_DICT.digest_tables.route_schedule_vp}.parquet"
     
-    schd_vp_df = (pd.read_parquet(schd_vp_url, 
-                       filters=[[("sched_rt_category", "in", ["schedule_and_vp", "schedule_only"])]],
-                       columns = [ "schedule_gtfs_dataset_key",
-                                    "caltrans_district",
-                                    "organization_name",
-                                    "name",
-                                    "sched_rt_category",
-                                    "service_date",]
-                                     )
-                     )
-
+    schd_vp_df = pd.read_parquet(
+        schd_vp_url, 
+        filters=[[("sched_rt_category", "in", ["schedule_and_vp", "schedule_only"])]],
+        columns = ["schedule_gtfs_dataset_key",
+                   "caltrans_district", 
+                   "organization_name", 
+                   "name", 
+                   "sched_rt_category", 
+                   "service_date"]
+    )
+    
+    schd_vp_df = schd_vp_df.assign(
+        caltrans_district = schd_vp_df.caltrans_district.map(portfolio_utils.CALTRANS_DISTRICT_DICT)
+    )
+    
+    # TODO: Check what the next step is doing? -
+    # The line before got rid of 07 - Los Angeles and now uses new name 
    
     schd_vp_df = schd_vp_df.loc[schd_vp_df.caltrans_district != '07 - Los Angeles']
     

--- a/gtfs_digest/deploy_district_yaml.py
+++ b/gtfs_digest/deploy_district_yaml.py
@@ -41,7 +41,14 @@ def overwrite_yaml(
             f"{RT_SCHED_GCS}{OPERATOR_FILE}.parquet",
             columns = ["caltrans_district"]
         ).dropna(subset="caltrans_district").drop_duplicates()
-                
+        
+        # We have several values for Caltrans District as the names slightly 
+        # change (ex: D7 Los Angeles is now Los Angeles / Ventura).
+        df = df.assign(
+            caltrans_district = df.caltrans_district.map(
+                portfolio_utils.CALTRANS_DISTRICT_DICT)
+        )
+        
         portfolio_utils.create_portfolio_yaml_chapters_no_sections(
             DISTRICT_SITE, 
             chapter_name = "district",


### PR DESCRIPTION
## `shared_utils`
* In `portfolio_utils`, create a dictionary that maps the caltrans district to the desired values for the portfolio. 
* Remove `schedule_rt_utils` where we re-mapped it back to the old name.
* Now the various names will show up in time-series data, but that's desired, and at whatever downstream point before visualization, it can be standardized
* Closes #1349

## gtfs digest
* this duplication of names shows up in GTFS digest when the table of contents is created
* this adds a step to map it to the standardized values #1405
   * @amandaha8 : there's a comment for you to fix stuff because I mapped the new values before you filtered, so please make changes to achieve what you were trying to do.

``` 
schd_vp_df = schd_vp_df.assign(
     caltrans_district = schd_vp_df.caltrans_district.map(portfolio_utils.CALTRANS_DISTRICT_DICT)
)

# TODO: Check what the next step is doing? -
# The line before got rid of 07 - Los Angeles and now uses new name 
schd_vp_df = schd_vp_df.loc[schd_vp_df.caltrans_district != '07 - Los Angeles']
```