### PR TITLE
Update `gtfs_funnel`'s clean route naming function

### DIFF
--- a/gtfs_funnel/clean_route_naming.py
+++ b/gtfs_funnel/clean_route_naming.py
@@ -4,7 +4,7 @@ Create file with cleaned up route info.
 import pandas as pd
 
 from segment_speed_utils import gtfs_schedule_wrangling, helpers
-from update_vars import GTFS_DATA_DICT, SCHED_GCS, all_dates
+from update_vars import GTFS_DATA_DICT, SCHED_GCS
 
 def concatenate_routes_across_dates(
     analysis_date_list: list
@@ -41,6 +41,8 @@ def concatenate_routes_across_dates(
     return df
 
 if __name__ == "__main__":
+    
+    from shared_utils.rt_dates import all_dates
     
     CLEANED_ROUTE_NAMING = GTFS_DATA_DICT.schedule_tables.route_identification
     

--- a/rt_segment_speeds/segment_speed_utils/time_series_utils.py
+++ b/rt_segment_speeds/segment_speed_utils/time_series_utils.py
@@ -70,7 +70,7 @@ def parse_route_combined_name(df: pd.DataFrame) -> pd.DataFrame:
     Clean up the double underscores and replace with a space.
     """
     df = df.assign(
-        recent_combined_name = df.recent_combined_name.str.replace("__", " "),
+        recent_combined_name = df.recent_combined_name.str.replace("__", " ").str.strip(),
     ).rename(
         columns = {
             # route_id2 has been cleaned within a single day (LA Metro removes suffix -191xx)


### PR DESCRIPTION
* Use `rt_dates.all_dates` so that script always finds route names from all available dates
* clean up route name string by stripping extra white spaces
* missed reference as part of #1432