### PR TITLE
add route identification notebook

### DIFF
--- a/gtfs_funnel/08_route_identification.ipynb
+++ b/gtfs_funnel/08_route_identification.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1c75d453-f988-40ce-bb25-770f4d0bc773",
+   "metadata": {},
+   "source": [
+    "# Route identification (time-series)\n",
+    "\n",
+    "Over time, even `route_ids` change. Pick out a couple of examples of this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f3d3984-e41e-4bf0-a496-9f17c08b70bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import yaml\n",
+    "\n",
+    "from update_vars import SCHED_GCS, GTFS_DATA_DICT\n",
+    "from shared_utils import portfolio_utils\n",
+    "from segment_speed_utils import time_series_utils\n",
+    "\n",
+    "with open(\n",
+    "    \"../_shared_utils/shared_utils/portfolio_organization_name.yml\", \"r\"\n",
+    ") as f:\n",
+    "    PORTFOLIO_ORGANIZATIONS_DICT = yaml.safe_load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcc3a1b8-e2ec-404c-a1bd-fd0360fb45ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CLEANED_ROUTE_NAMING = GTFS_DATA_DICT.schedule_tables.route_identification\n",
+    "\n",
+    "df = pd.read_parquet(\n",
+    "    f\"{SCHED_GCS}{CLEANED_ROUTE_NAMING}.parquet\"\n",
+    ").pipe(\n",
+    "    portfolio_utils.standardize_portfolio_organization_names, \n",
+    "    PORTFOLIO_ORGANIZATIONS_DICT\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d697087-c45f-43b1-a116-974b4f0e4571",
+   "metadata": {},
+   "source": [
+    "## LA Metro\n",
+    "\n",
+    "`route_id` has suffix added every time a new feed goes into effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1e13c5b-4e46-43c2-b105-7001c4ba8101",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "subset_cols = [\n",
+    "    \"name\", \"portfolio_organization_name\", \n",
+    "    \"route_id\", \"service_date\", \"combined_name\",\n",
+    "    \"recent_combined_name\", \"recent_route_id2\"\n",
+    "]\n",
+    "\n",
+    "df[(df.name.str.contains(\"LA Metro\")) & \n",
+    "   (df.recent_combined_name == \"2__Metro Local Line\")\n",
+    "][subset_cols]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f392041d-9e3b-46bb-a265-3ff556c7b6e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df[(df.name.str.contains(\"LA Metro\")) & \n",
+    "   (df.recent_combined_name == \"2__Metro Local Line\")\n",
+    "  ].route_id.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd18a6bf-4875-42c0-b2ee-d36c36f3c8d0",
+   "metadata": {},
+   "source": [
+    "## VCTC\n",
+    "\n",
+    "These were flagged as a complicated case where metrics were duplicated in GTFS Digest.\n",
+    "\n",
+    "Within [time_series_utils](https://github.com/cal-itp/data-analyses/blob/main/rt_segment_speeds/segment_speed_utils/time_series_utils.py#L84-L105), in Apr 2024, when this function was added, VCTC should only have route_long_names kept. \n",
+    "\n",
+    "Recently, since Sep 2024, it appears they've grouped a set of routes together, now it's appearing as 80-89 Coastal Express.\n",
+    "Given that, we should remove VCTC GMV from that list where we do extra route cleaning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504a670b-3dc9-4351-bd75-2fbb2d1d422e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "vctc_df = df[(df.name==\"VCTC GMV Schedule\") & \n",
+    "   (df.recent_combined_name.str.contains(\"Coastal Express\"))\n",
+    "  ]\n",
+    "vctc_df[subset_cols]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d38743ca-6775-422f-83a8-20568764e2f8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "vctc_df.pipe(\n",
+    "    time_series_utils.clean_standardized_route_names\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a2a75ae-588d-4220-8d73-151c1e6f64d6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "unique_routes = vctc_df.pipe(\n",
+    "    time_series_utils.clean_standardized_route_names\n",
+    ").route_id.unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13e3e1fb-f904-4045-bc41-f38ddd8d3d26",
+   "metadata": {},
+   "source": [
+    "The new `recent_combined_name` since Sep 2024-May 2025 is capturing so many route_ids!\n",
+    "\n",
+    "This confirms what was seen GTFS Digest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a02094-5a79-4d9d-8ac2-deab2b1a05b0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "vctc_df.pipe(\n",
+    "    time_series_utils.clean_standardized_route_names\n",
+    ").astype(str).groupby(\n",
+    "    [\"recent_combined_name\"]\n",
+    ").agg({\n",
+    "    \"route_id\": lambda x: list(set(x)),\n",
+    "    \"service_date\": [\"min\", \"max\"],\n",
+    "}).reset_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd558185-e6cd-4ea1-911a-744658c95c7e",
+   "metadata": {},
+   "source": [
+    "In Apr 2024, this looks ok, `recent_combined_name` is reasonable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a0c5963-ec27-4789-b2c9-5fdfb4b89120",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "vctc_df[vctc_df.service_date <= pd.to_datetime(\"2024-04-01\")].pipe(\n",
+    "    time_series_utils.clean_standardized_route_names\n",
+    ").astype(str).groupby(\n",
+    "    [\"recent_combined_name\"]\n",
+    ").agg({\n",
+    "    \"route_id\": lambda x: list(set(x)),\n",
+    "    \"service_date\": [\"min\", \"max\"],\n",
+    "}).reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd589988-26ba-4176-a239-01d68bd87483",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def display_subset(df: pd.DataFrame) -> tuple[pd.DataFrame]:\n",
+    "    \"\"\"\n",
+    "    Compare what happens when we pipe vs don't pipe for the operators in the list we\n",
+    "    do extra data wrangling on.\n",
+    "    \"\"\"\n",
+    "    cols = [\"route_id\", \"route_short_name\", \"route_long_name\", \n",
+    "         \"recent_combined_name\"\n",
+    "           ]\n",
+    "    with_pipe = df.pipe(\n",
+    "        time_series_utils.clean_standardized_route_names\n",
+    "    ).astype(str).groupby(\n",
+    "        [\"recent_combined_name\"]\n",
+    "    ).agg({\n",
+    "        \"route_id\": lambda x: list(set(x)),\n",
+    "        \"service_date\": [\"min\", \"max\"],\n",
+    "    }).reset_index()\n",
+    "\n",
+    "    no_pipe = df.astype(str).groupby(\n",
+    "        [\"recent_combined_name\"]\n",
+    "    ).agg({\n",
+    "        \"route_id\": lambda x: list(set(x)),\n",
+    "        \"service_date\": [\"min\", \"max\"],\n",
+    "    }).reset_index()\n",
+    "    \n",
+    "    print(f\"status quo, with time_series_utils.pipe affecting it\")\n",
+    "    display(with_pipe)\n",
+    "    \n",
+    "    print(f\"status quo, no pipe, no extra parsing affecting it\")\n",
+    "    display(no_pipe)\n",
+    "    \n",
+    "    return"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccf192e2-4d41-40d5-b249-a3b2a4d22bac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "display_subset(vctc_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a60ae23-c552-402e-9166-09e2a10d3dda",
+   "metadata": {},
+   "source": [
+    "## Check other operators\n",
+    "\n",
+    "Find other operators ones that might also have had changes and see if any can benefit from having extra parsing removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fc7f302-7419-4c6d-9654-a1c3ea53c619",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for operator in time_series_utils.operators_only_route_long_name:\n",
+    "    print(f\"Operator: {operator}\")\n",
+    "          \n",
+    "    display_subset(df[df.name==operator])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0c3b83a-d8da-4b75-ada3-39d8bf06bda1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
* Review how routes are getting standardized in time-series.
* VCTC could benefit from being removed from the list in `time_series_utils`: [operators_only_route_long_name](https://github.com/cal-itp/data-analyses/blob/9505ad4445de05119b78d4ad35ac89c23ed8a7dc/rt_segment_speeds/segment_speed_utils/time_series_utils.py#L84-L105) based on their more recent changes. Potentially others?
* #924 