### PR TITLE
Quick Fix: Portfolio site checker

### DIFF
--- a/portfolio/portfolio_site_checker.py
+++ b/portfolio/portfolio_site_checker.py
@@ -6,7 +6,20 @@ import requests
 dds_url = "https://analysis.dds.dot.ca.gov/"
 calitp_url = "https://analysis.calitp.org/"
 
-portfolio_names =[
+dds_portfolio_names =[
+    "legislative_district_digest/",
+    "sb125_fund_split_analysis/",
+    "ntd_monthly_ridership/",
+    "ahsc/",
+    "rt/",
+    "ntd_annual_ridership_report/",
+    "gtfs_digest/",
+    "ha_starterkit_district/",
+    "new_transit_metrics/",
+    "district_digest/", 
+]
+
+calitp_portfolio_names =[
     "legislative-district-digest/",
     "sb125-fund-split-analysis/",
     "ntd-monthly-ridership/",
@@ -36,8 +49,8 @@ def portfolio_site_checker(base_url:str, site_names:list):
 
 if __name__ == "__main__":
     print("\nChecking dds.dot.ca.gov portfolio sites")
-    portfolio_site_checker(base_url= dds_url, site_names=portfolio_names)
+    portfolio_site_checker(base_url= dds_url, site_names=dds_portfolio_names)
     
     print("\nChecking calitp.org portfolio sites")
-    portfolio_site_checker(base_url= calitp_url, site_names=portfolio_names)
+    portfolio_site_checker(base_url= calitp_url, site_names=calitp_portfolio_names)
     


### PR DESCRIPTION
Noticed a difference in how `dds.dot.ca.gov` and `calitp.org` URLs were structured and was giving inaccurate results when running the script. 
- dds.dot.ca.gov uses underscore `_`
- calitp.org uses hyphen `-`

Adjust script to account for both differences. 