### PR TITLE
Fix percent change function for NTD monthly ridership report.

### DIFF
--- a/ntd/_01_ntd_ridership_utils.py
+++ b/ntd/_01_ntd_ridership_utils.py
@@ -1,4 +1,5 @@
-"""Fucntions for the Monthly/Annual NTD Ridership reports.
+"""
+Fucntions for the Monthly/Annual NTD Ridership reports.
 """
 
 import gcsfs
@@ -65,7 +66,7 @@ def get_percent_change(
     """
     df["pct_change_1yr"] = (
         (df["upt"] - df[change_col])
-        .divide(df["upt"])
+        .divide(df[change_col])
         .round(4)
     )
     

--- a/ntd/monthly_ridership_report/explore_percent_change_formula_update.ipynb
+++ b/ntd/monthly_ridership_report/explore_percent_change_formula_update.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "81d17211-f9f3-4a63-a081-621ac9486c7c",
+   "metadata": {},
+   "source": [
+    "# RE: [Bug: Monthly NTD Ridership data miscalculation #1612](https://github.com/cal-itp/data-analyses/issues/1612)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fdd2215-e869-4c60-a9a6-14b6420dc347",
+   "metadata": {},
+   "source": [
+    "current `01_ntd_ridership_utils.get_percent_change`\n",
+    "uses `(new-old)/new` logic for %change calc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f094cd9c-4437-4d1b-91ef-95ea23a68a15",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "def get_percent_change(\n",
+    "    df: pd.DataFrame,\n",
+    "    change_col: str\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    updated to work with the warehouse `dim_monthly_ntd_ridership_with_adjustments` long data format. Used with add_change_col to make a new column to calc % change from previous period.\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    df[\"pct_change_1yr\"] = (\n",
+    "        (df[\"upt\"] - df[change_col])\n",
+    "        .divide(df[\"upt\"])\n",
+    "        .round(4)\n",
+    "    )\n",
+    "    \n",
+    "    return df\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79717a5d-53d3-4597-97c1-04637a29b897",
+   "metadata": {},
+   "source": [
+    "updated current `01_ntd_ridership_utils.get_percent_change`\n",
+    "uses `(new-old)/OLD` logic for %change calc\n",
+    "\n",
+    "updated to `.divide(df[change_col])`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94a79c4d-e218-493c-8470-bf0b4f1e4d7d",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "def get_percent_change_2(\n",
+    "    df: pd.DataFrame,\n",
+    "    change_col: str\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    updated to work with the warehouse `dim_monthly_ntd_ridership_with_adjustments` long data format. Used with add_change_col to make a new column to calc % change from previous period.\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    df[\"pct_change_1yr\"] = (\n",
+    "        (df[\"upt\"] - df[change_col])\n",
+    "        .divide(df[change_col])\n",
+    "        .round(4)\n",
+    "    )\n",
+    "    \n",
+    "    return df\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c954656-7eec-4fe3-a8c6-ba4d8ec22954",
+   "metadata": {},
+   "source": [
+    "Made updates to `get_percent_change` function in `01_ntd_ridership_utils`\n",
+    "Checking if chagnes worked"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e2a97de6-1d1f-47e3-9c9c-4a8f75b4958f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../\")  # up one level\n",
+    "import _01_ntd_ridership_utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b3b0b152-9937-4bcc-b583-f1d3ac89021f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "both          29370\n",
+      "left_only         0\n",
+      "right_only        0\n",
+      "Name: _merge, dtype: int64\n",
+      "Index(['ntd_id', 'agency', 'reporter_type', 'period_year_month', 'period_year',\n",
+      "       'period_month', 'mode', 'tos', 'Status', 'uza_name', 'upt',\n",
+      "       'source_agency', 'last_report_year', 'ntd_id_2022', 'rtpa_name',\n",
+      "       '_merge', 'previous_y_m_upt', 'change_1yr', 'pct_change_1yr',\n",
+      "       'Mode_full', 'TOS_full'],\n",
+      "      dtype='object')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jovyan/data-analyses/ntd/monthly_ridership_report/../_01_ntd_ridership_utils.py:45: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
+      "To preserve the previous behavior, use\n",
+      "\n",
+      "\t>>> .groupby(..., group_keys=False)\n",
+      "\n",
+      "To adopt the future behavior and silence this warning, use \n",
+      "\n",
+      "\t>>> .groupby(..., group_keys=True)\n",
+      "  .apply(lambda x: x.shift(1))\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = _01_ntd_ridership_utils.produce_ntd_monthly_ridership_by_rtpa(\"2025\", \"May\")\n",
+    "print(df.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "54b01df3-9d91-4600-bc14-4b61e1fc0d2e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ntd_id</th>\n",
+       "      <th>agency</th>\n",
+       "      <th>reporter_type</th>\n",
+       "      <th>period_year_month</th>\n",
+       "      <th>period_year</th>\n",
+       "      <th>period_month</th>\n",
+       "      <th>mode</th>\n",
+       "      <th>tos</th>\n",
+       "      <th>Status</th>\n",
+       "      <th>uza_name</th>\n",
+       "      <th>...</th>\n",
+       "      <th>source_agency</th>\n",
+       "      <th>last_report_year</th>\n",
+       "      <th>ntd_id_2022</th>\n",
+       "      <th>rtpa_name</th>\n",
+       "      <th>_merge</th>\n",
+       "      <th>previous_y_m_upt</th>\n",
+       "      <th>change_1yr</th>\n",
+       "      <th>pct_change_1yr</th>\n",
+       "      <th>Mode_full</th>\n",
+       "      <th>TOS_full</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>20363</th>\n",
+       "      <td>90043</td>\n",
+       "      <td>City of Commerce</td>\n",
+       "      <td>Full Reporter</td>\n",
+       "      <td>2024-03</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>3</td>\n",
+       "      <td>MB</td>\n",
+       "      <td>DO</td>\n",
+       "      <td>Active</td>\n",
+       "      <td>Los Angeles--Long Beach--Anaheim, CA</td>\n",
+       "      <td>...</td>\n",
+       "      <td>City of Commerce (CCT) - Transportation</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>90043</td>\n",
+       "      <td>Los Angeles County Metropolitan Transportation...</td>\n",
+       "      <td>both</td>\n",
+       "      <td>38829.0</td>\n",
+       "      <td>9421.0</td>\n",
+       "      <td>0.2426</td>\n",
+       "      <td>Bus</td>\n",
+       "      <td>Directly Operated</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20350</th>\n",
+       "      <td>90043</td>\n",
+       "      <td>City of Commerce</td>\n",
+       "      <td>Full Reporter</td>\n",
+       "      <td>2025-03</td>\n",
+       "      <td>2025</td>\n",
+       "      <td>3</td>\n",
+       "      <td>MB</td>\n",
+       "      <td>DO</td>\n",
+       "      <td>Active</td>\n",
+       "      <td>Los Angeles--Long Beach--Anaheim, CA</td>\n",
+       "      <td>...</td>\n",
+       "      <td>City of Commerce (CCT) - Transportation</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>90043</td>\n",
+       "      <td>Los Angeles County Metropolitan Transportation...</td>\n",
+       "      <td>both</td>\n",
+       "      <td>48250.0</td>\n",
+       "      <td>-14985.0</td>\n",
+       "      <td>-0.3106</td>\n",
+       "      <td>Bus</td>\n",
+       "      <td>Directly Operated</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2 rows × 21 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      ntd_id            agency  reporter_type period_year_month  period_year  \\\n",
+       "20363  90043  City of Commerce  Full Reporter           2024-03         2024   \n",
+       "20350  90043  City of Commerce  Full Reporter           2025-03         2025   \n",
+       "\n",
+       "       period_month mode tos  Status                              uza_name  \\\n",
+       "20363             3   MB  DO  Active  Los Angeles--Long Beach--Anaheim, CA   \n",
+       "20350             3   MB  DO  Active  Los Angeles--Long Beach--Anaheim, CA   \n",
+       "\n",
+       "       ...                            source_agency last_report_year  \\\n",
+       "20363  ...  City of Commerce (CCT) - Transportation             2023   \n",
+       "20350  ...  City of Commerce (CCT) - Transportation             2023   \n",
+       "\n",
+       "       ntd_id_2022                                          rtpa_name _merge  \\\n",
+       "20363        90043  Los Angeles County Metropolitan Transportation...   both   \n",
+       "20350        90043  Los Angeles County Metropolitan Transportation...   both   \n",
+       "\n",
+       "      previous_y_m_upt  change_1yr  pct_change_1yr  Mode_full  \\\n",
+       "20363          38829.0      9421.0          0.2426        Bus   \n",
+       "20350          48250.0    -14985.0         -0.3106        Bus   \n",
+       "\n",
+       "                TOS_full  \n",
+       "20363  Directly Operated  \n",
+       "20350  Directly Operated  \n",
+       "\n",
+       "[2 rows x 21 columns]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# dataframe after corrected function\n",
+    "df[\n",
+    "    (df[\"ntd_id\"]==\"90043\")\n",
+    "    & (df[\"period_month\"]==3)\n",
+    "    & (df[\"period_year\"].isin([2024,2025]))\n",
+    "    & (df[\"mode\"]==\"MB\")\n",
+    "    & (df[\"tos\"]==\"DO\")\n",
+    "].head().sort_values(by=\"period_year\",ascending=True) "
+   ]
+  },
+  {
+   "attachments": {
+    "d384b318-0d97-4c6c-bf6b-775c099dbb24.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAABdAAAACSCAYAAABFY+hRAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAFLfSURBVHhe7d19dBzVnSf8r0T+cnKWvJxksiFYxkgOY+kQJzgcIqFRwsvakgeDgHVghMcwTiTCLEiLxyTOOiu848EbPMYSfoZgJUxCZCdZnwQbM5bMgYTRONbDIU4icmyPYwmwRMhkNidDyOBMyJv23qpb3VXVt966u7q7qr4fnwJ1VXdX33t/devWrapbdQsWLJhHGf3xH/8x/vmf/1m9yp6sp5/CYZwkD8uMSsUYqj6WQXJlveyY/mym351u1mHkhbGRDixHqiTGW3yYt+EkLZ/q1f/L5pxz3qT+yqasp5/CYZwkD8uMSsUYqj6WQXJlveyY/mym351u1mHkhbGRDixHqiTGW3yYt+EkLZ9i6EA/R/2VTVlPP4XDOEkelhmVijFUfSyD5Mp62TH92Uy/O92sw8gLYyMdWI5USYy3+DBvw0laPvEK9DLjmSYKg3GSPCwzKhVjqPpYBsmV9bJj+rOZfne6WYeRF8ZGOrAcqZIYb/Fh3oaTtHwquQN98eLF6i9T1s+08EwThcE4SR6WGZWKMVR9LIPkynrZMf3ZTL873azDyAtjIx1YjlRJjLf4MG/DSVo+ldSBLjvPL7vsMvXKlPUzLTzTRGEwTpKHZUalYgxVH8sgubJedkx/NtPvTjfrMPLC2EgHliNVEuMtPszbcJKWT0V3oOs6z6U3val6ZxC6d01hamoKu7rVjCqoZvprSzM2HDTLIz/tQhWLpqakMk6aN+CgvbwPbhBRkB7ctnV023l16+BaltwY0pfzwQ3J28LTuh1b7R/7lLbtsGpl5963VSlvK59+c7t3b+fNGw5WZf9e7W3X2MaqUPDudKe1DgursK7jsYUl1bFRI/VwJWR9G4+G/Q2lSky8de9ylHMStv/ayNtu7LLlm3OqjW2l8vlk1hsFMSRjLET7tqgOdK/Oc6l6ZxC6cUX7HI4cmUP7FdULBZ5pcpob7cGyZcvE1IPRuXYMprW1E1Hq4kRWOHs7MNEjy9qceiY6sC2BHWxeuG17y2/nYtpyBO2DyexcjVvSY+jIlvz2LafVO06oJcmR5u3YsR2K6c79akFKVKXsjH3bWsw6Yn8LRGOm4gcdWd8HZTX97nRnPQ4ke13XM9qAQXaYGVIbG5pjjGU9o2gQbc00HlZyG4/OXidsOcL+higSEW/yBNpgu+04RLTDbqv9C/VqI2/3405bvTkn/o3m6tI7xdLqS1qdF7kD3a/zXKraGDbdV6B9bgIPPzyBufYrqtaQ4lhHXk7g8MQc0LC45iu7SkhXnHRjl7FTWw17f9qJHasT2cHmhdt2SPvvNDrRF669nQe0Loyh6mMZJFfly87at7lPRsiDkcofdGQ9drOafne6WYc5ndjxJRxBO6p47VTNSGds6I8xRMFj0+gc2hPQiRYVt/HS7P/2EfY3RJCceJvDmdPqT9kOW70Dtd7LwG05nKTlU6QO9KDOc6laZxC6r2jH3MRhnDhxGBNz7bitSlc/8qyxl2as7FholpGak2WpipPmxWgQhy/fTtnVjm7ctiPY/20e0GowhqqPZZBcFS87eWFGDe3bsh67WU2/O92sw1yMNqi9YyW7UhkbPuV74vAE5hZ2YGXKekq5jZeiGRtuawdmX2R/Q0iJiDejf28h1u49iCTd4MxtOZyk5VPoDvQwnedSVc4gNG/Abe1zmDgsq0rzSueFHSurcuaRZ5qcFq7dq8ZY2ou1C60yolTFyZJFWKj+TDNu21SqpMeQHJqn1sbNiyrN23F+f5vc8vFT7bIzxv6uYv5WK/3OuJrC3rXV2eNndR/sTndW88FL9+1rsXBuAjy8SGlsGMcYs3gxQ+XLbTw6e39Dx0QPlqVtDLsYJSPeTmDHajk8j+xEl+WcjI50bsvhJC2fQnWgh+08l6pxBqF5ZYej8VTNM9I80+TkHBt5NnFnDuPCOEkelhmVKukx5BwDvTbGzYsqzduxcwz0ZJaPn2qXnRyWzGzLHFFzKqta6XePrd8zOqeWVFZW98HudGc1H+zsJ3UGG0bRk4Bb+SshlbFx+gzm0IDFGTp25DYeXW4/xSEkI0tSvO2/02qHIBF9StyWw0laPgV2oEfpPJcqfwbBHBpE1JbYqxpT8oFPC8W/jir0oPNMkw9jWIeFWLREvc6wVMVJRobr4LYdQY0NfVArGEPVxzJIroqXXY3t27Ieu1lNvzvdrMNcJ3XYeZ6Tytg48SJmPY4d3RfQpQW38RLsfxijVRzKN4mSGG8ndmwS5Vz7fUrclsOpVj41uM7MNi9uUH/58+1Aj9p5Lr3pTRU+g9B9uzE0SP5pstaZqbmqnIGsePqTxOhU4ziFUrriZD8elg/yGXSeCZa3ux9MUQOG23ZI6knpc6MPp+4K2FIxhqqPZZBclS87a982hV010Ime9djNavrd6WYdRl7SGRv6Ywx07zKGkzrypfSdQOE2XooT2PElXoUeRRLiraBPQfX/1XqfErflcCqfT2rIb0c90Y3bQ+5TPDvQi+k8lyp9BkE+PFSk1PlkbqFaT2XnmSYnx9iZuqeoZ1Ta4kTe2m7eTqXKWkx7OyawKUWFzW3bm2M739uBiZ5lWM0NvUDSY8g5BvpUIk+QcTtOrmqUnTFsi9i5Ndhjv0onCLMeu1lNvzvdrMPIS1pjQ3eMIethqX2Qz/sgl4zcGV0uSYg3ecX5RIe9T6kBoz2136fEbTmcauSTuV9pwKAVU1ODaBjtQZjHJ9QtWLBgXv2dE7Xz/Ktf/ar6C7jppj/H17/+FfUqe7KefgqHcZI8LDMqFWOo+lgGyZX1smP6s5l+d7pZh5GXTMZG9y51gdayUB0fScBtnCqJ8RYf5m04Scsn7RXoL774otEpHnayy/qZFp5pojAYJ8nDMqNSMYaqj2WQXFkvO6Y/m+l3p5t1GHnJZGzsv9MYujUtnecSt3GqJMZbfJi34SQtnwIfIhpV1p82y6ftUhiMk+RhmVGpGEPVxzJIrqyXHdOfzfS70806jLwwNtKB5UiVxHiLD/M2nKTlUwwd6Nk+08IzTRQG4yR5WGZUKsZQ9bEMkivrZcf0ZzP97nSzDiMvjI10YDlSJTHe4sO8DSdp+VS3YkXXfH19PfLTOba/g+YXzmtpWaK+moiIiIiIiIiIiIgoubQPES3Fzp07MfbTRvUqex4fvBLXbvmWekWkxzhJHpYZlYoxVH0sg+TKetkx/Uw/6y7ywxhJB5YjVRLjLT7M23BkPs3Pl7VLOlbsQLf5WPOv1F/F+7Mbr+GGknKMk+RhmVGpGEPVxzJIrqyXHdPP9JeKdVe6MUbSgeVIlcR4iw/zNpxy5RM70BPcgX7TDX+qXkX39W/+AyuhDGCcJA/LjErFGKo+lkFyZb3smH6mn3UX+WGMpAPLkSqJ8RYf5m045cqnJHWgl/0hooknC6/YibJDV/5hJ6oOXVmEnYgkXWyEnag8dHkbdqLq0pVJ2CkNdOkKO6WBLl1hpzTQpSvsRNmgK/uwE9UOXfmEnYii0sVR2In86fIs7JQluvSHnRKIHeguunINO1F26Mo/7ETVoSuLsBORpIuNsBOVhy5vw05UXboyCTulgS5dYac00KUr7JQGunSFnSgbdGUfdqLaoSufsBNRVLo4CjuRP12ehZ2yRJf+sFMSpWYIl3m8ghe/+Oc4/nIzWvofxIVvVws05vEcfji4CWewCpdtuRt/pObLWxDWXNelXkW378AYb4PJAK842Xb/dvWXiLE/zOMPf/g9fv+HP+APvxf/F9Pvfv87/O+/+RvGSRWkpcy86q6wotSTlCfz/abmltD7h/u23Y/PbLpHvTIxhkrH7diUtO3Yb/tJy34zqEyy3m5g+tOf/lLrtazzipGwqhUjuXI//w5c9fEb8GY1P6uSWo61gvEUTVrjrdzt3Pz3yVfB+yj5/pua35a5bbma+ZTYIVyaNxzE1NQUDm5oVnNqgyycF754JR4ffAD/qubFxX1WJMpE2aEr/09v3GgcAP3ud7/Db3/7W/z2N2J64zd44403jGnb1r8x3pdkldgW41qHu7zklIUyo2j84s8dP7rpr/9mG37z29/gs4NbHPOpPOx5ak3cjmtH1O0nS2XnTrucaiX9Fdm3u9Iup0qlf/7fvol/GpTpM6d/evYVc37EdJeST+60y4l1F9m54yPKRNGdffYus0744jdxVs0rB135hJ2SqhL7kFoXVzwF0cVR2KkY8iTH87b96fPTaoHi3N/WRjz86tnPGZ3Ci275Fq6NcIJXl2dhp6jc7RTndBde+Def9z3xnLlQ8WrzBElCPtUC1YHejV1TU9iGL2F0zpyTZnW4FO/fog+M+RL+UXbYy93+79Of2ojfyQOg34gDoN+IAyAx/UZMn/vf23Lvoeqw8t/9L0ll5ld3UfysePD79z8+82m88etfY8u9/9M2lzFULvY8tf/jdlz7rHJw/8vKftNKi/sf0x9v+uWB5JHhh/CqvKJRbHert3wF5x3/PxU/qLfS4v6XlvJn+6R0VnkX84/Cszp7nx4/oeaUl71cov6j5Ik7noLY4yfqv9I0423nA2cmnCcMfnV6Aq+qZUlnz6uo/6Kqe/sN+BNjH/otXNVpXsz8ts6vGK+v3WJehS9P0hyU7Znl29R89d5jm3InbqrR5rGnO+q/JHIN4dKMDQf3omOiB6t3FFcJFDOEi3W7zmud20QBbzLOfEjy7MfFTfZbCRR1W8+C6QdwcM8hNW8VFuEQzoS41UNWdOZ35m9NmBffddN1t+P61SvNNyn3b9+h/gJ+r64QMRq3b7yB7dvvV0tMjx08nIrbrmRe5PJVkBvvn1x2nvG3e5nBKo9cvqr5Ip6ssvAr4/c3mX/nNnjzpVj2FbxlQn5f4fdU89YuebuUO07cPv3pz+D3v/+dMT3wwANqrqmYOLHyBp134Nzxh3K3yL6r1Dy38tN8Kdg+X7BOuTM8gVd126Lf7/D47boDrPy2qWZImm3bGQfnYyYgnVUps1D5HzXfPobXjffb6i6fMpQc22zIejL/u7zy3L/MJa96JEo8SPn3F+bju09diWeP5V+HimufcvHe35yPv2huCYwhy1/91Ub87d/mb82XGEO29RQZQ1/9xhPcjqUo7Z0EbT/lLju7cueDFFQm9rioRuyGVRi/Qm4b9c+Df30in3eQB3TXXKpeOFVjH2zJlZPr9/mm21X3yP1X+2XQv/964HvD6oBWfL+u7qvFNoi+bvJuVy5+e2G6rO8wDtQ/fhl+aiwPV6/lPuuTb2HjS9J9Prd+Va5exwzF1A9egtK1+O36ctHVEbV2DJpLm3ot8+Pipnwet/zRQziuq0s125PRHgyIUcn9WYO1nXrEqix7P2Y6JnDeLR14ZY8Vv/bv84ghta37tV9123qS+hJClUlBHFjH62qGFLDNSYyn4HgKUo14y6VB/N6WzjM4Po7C9C0X5fevovzK2M4t3GeHKx/HfkSy5b13PW0OTVKtbVl2lMsTMo4+OFu+2+Ok4Lf/XOVjwD7Trdr5lNghXKrt1fFNeL1DninZJjYa4MyeB/B/cR4Wf/wraDHOYsmA+RauNSolEUQyOGThinmrO8T77RV3BEZAqg3WfVvBxr/aIBqzv8ev/+M/8PrZ1/Hv//5L/Psvf4n777+/4L1pYOwEJhpyZ6xkvr86bp61MpaJfJIbs7XMKBPHTkKVkZguW34Cx4edt+7oytj4blkGcgO1ylMsx8SzeEuLPAN3Aq+cVreeTH/HqHjf1nJZVcdFc5e9e3rjjV8bt9/++tdvFCwrxatiBwvREJBX+OQPcoLz/JWWfJmd2WPeBuSsiK3ylp/P3yYk5df5INq122LY35H/7V6Ngzrt9n43Gn3iYIE5xyed6lZtVzm4p/jKzPt3Rc23d6l5lqAyzNVtEetJWQ7v9s1z/9/uV49YwsSD3avje4Drxff134G3iddn9lyJH71T5qumLgkV11H2NyZ3XHhN/yH2F+55pWAMWWVi5qXfxO1YLwnbT1xlZ1eufAgqE3dcGPNcaXJPlUi/jn6/q9rZfnkgDnblwZZsE8q4v+qd33HEiJs7Te4ptvS/o8Eoa/sVWpJnuj32X0Hx7UXmk/F/V5rcU6XrLouzbvKuz2T6C+r0n88anV/2tpglbF3iJWp8Be1zwhwzhK0fysFdLpK73GvpGNQoz2H3cdo38Su1HC8/hNcvMuc76tJQ7UGPY8MyHHfqmFd6PojF71AzlOB2iymo/eoumyT2JXi3eXRx8CzerakbfTvPGU+h4ymIO4YqGW9vWdIh6srC9C266DLztRK0PzCWR2hTRSmfP7omf0W3PJkSZr9tcedXVbdllbdYfrkjTmScvcWYocrBo80TJDX5VAE11YEuN5rGJhkIl+Ldy+WMM3jdq7HkbhQ1fUxVhEWwAlKQYxG6p09t3CgatP+BX772mph+iaGdQ9r3pYGxE1A7vfwGqcrBaCg347wl59l2Csq/PYtXZEVn26jfddEq8d9D+Kl9bCyvMnaVp3ErqPgd77rsFmPn9+rxZ40K4P+eEpWr+g3VpCt/+/SGOAAyJnEw5F5WEpV/hgh5fsll9jI7gdd/Lv5n5Xnnx4zPa3f0kn2dOhHLvhgLwsSBVzrF75Pc5eCe4iwzr99Vcr4FlWEJ9aRvngf8dt96xBI1Hs7vwLvlVQZvvwznqUbv+4x89ahLQsZ1qP2N4o4Lr0k2GNzzSsIYUjHE7ThqGeQkYPuJrezsypUPQWWiiQt3mtxTRdIfRchYsLbvN192t++VYO40uae40i/rknbVISo7ZZ4evNL3oDLU/qsI7jS5p9jK36vustjrpoD6bIHRWRKyTR62LgkQNr6kUG1FP2Hrh3IoKBd9jNTMMairzpN5Io/Tch0sHvuEKO3Bgnwux3FnRGGPNzz354KufBLXl1AQn6reCIqDsBhPcrEpIJ6C6OKoYvGm6kpn+lbh3e70BO0PXPEQpk1VjvIJosuzWtyW3/LOfCxHbfOUgy79ae4/ra0O9Ah+9XO5mZWH/bvcZ0Ws6a//11bjzMlDD31eu1xOaSFv4bAeOuC4lcM4o2VWdPJM4E+PnxCVfgPeIpepq1CMs13qswW3SPmwyuDcdzgbubmd38sT+Om/vYLX5WlGq4FbRVaZ/+2OHcZ0333b8NnP/k/cveFuY748AJJXE8lbVaz3WlNJ/uh8c8cilZDnr/38Fe02tOAdcjfvYl+nTtjfEfQ9PoqNA5lO+fskK/8rXmYa1u8qNd+CyrCUetI3z0P8ds96xFJCPPgJHddFsMeEVxzJqRJXkGY1hqz85HYcj0psP7VQdkFKLhNXXEhWWpKQfikoD+qa7sZlxvatDtACHhZmpaUa6Tc6XeRVbbaDyu/5PFQrcP8VgcwnyUpLLZS/UXdZ7HVTUH1mdSy/PIvX8Rx+KvPGoy1Wal0SNb6kWj1mCMtd7tZUC8egVnm6j9PCKHp7ivG400uoGApov+rKR05J70uQ9UYpcWDHeDIWm0o8HtLFkZwqE2+qI1ymb/qb+JEsj+WXF9xpGbQ/0C13iKl8gujyTE61ti2//jNz6G1re4ra5imVLv1ySmv/aWI70Mt1QCfZv+sPoiS9pi988e+1860pDeSYS3JnZNy6YdweoxbYvDr+5zg4KG+jaUbL9eZZYIt1q6V9ssYdC8PRqFfMM4wncPyxzxlnH3NnJ6vIKvP//t/vxtmzZ/HaL1/Dq794Fdu37zDmmwdC8oFQv8m915rKrZg8lxWsbhsqpUFTatkHKSYO7Omw8r8Wysz+u0rJt6AyLLWeDMpzr98eph6JS7nj2s4eE15xJKff/f53jvfKqdyyGkNWfnI7jkcltp9aKLsg5SoTKy4kKy1JSL8UJhbkLb8yfeZtv4fwI58DNCst1Uy/cWXWLbJOEm3Zn+l/a1z7LysttVZ36XjVZ/mrBg/hp8++jNfkez3aYuWoS6LEl6UWjxnCcpe7faqVY1DdcZqfcmxPcR536pQaQ7rysaYk9yXYt9uoceCF8VQ6XRxZUyXizbwzSaRPjv8OkadtheNul7tNVc7y8aPLM2uq+LacG5rlO46TyfJkkHFiRuT9W9zDCIVo85SDLv3WlMb+00R0oGtv0VFBZN0ygun/IypC+UcRrIAU5kv4lx7mBijHozKuLlGspyq39FuVlu3BDU2Xm7coucYhC8t9W6hc9/PW7SbWbTwvnzDWH/pWzBjZy/1/bN6MV199FUPDw7l5f//lL+PR0VHs2fvV3DzrX9mEzXN11lHm6YzxhHB1a5X1+Vyeq7PxuluvFO22WGLZu2nXIQXFgU86JXsZVLTMgvK/lHwLKsNS60mvPA/12/X1SOyC8iSAZ/wJ9piQ/3RxJP+N7tlre2X+KwljKBdD9jzldhyDoN8SIOz2U7X9ZlillokmLuzpqbX0++7bPfJAdmT8k9gmpDAHv/b0VDL99t8pmbeYA4suutQnXvX7L+37334+zpX/tw5qXbEg1y/Z01MTdZeOJm7drPb6mXGzs8SzTR60DYXItyjxlVPtY4aAdOUUlIszRqL+i5vXcVpuzGpfxbUH4zzu9FViDNnLJeq/muFRb3jHgfe+X4fxVD72+In6ryxyQ14JXnf8BO0PimhTlSRkPW3Pq6j/yk12hr/POGHkPJn8q2c/Z/725bcY8ezX5oksgflUCaoDvRu7pqYwNbUXaxcCC9fuFX9P4eCG/Hg61fauNnkLwgkcH77SGMfnV9YZFVHBy1v7Dk404DI18H1U9rMz8kRIsVMamGN1mfl8cHCT2BjNfJHsy6zbZ6xbKuUtShcbD+s4hGdzy/LLgxhlIG8zscpzcA/eos4KywOW3DhlNXIrprvs/87n1hT3VC6h8/z8VTj3uDzbLh/eIc/amw8pMT7vyHPr4Rz+DzEp2BZLLHsd9zrkzjQwDnzSKbnLoWJl5pf/JeZbUBnm6rYi60mvPA/67X71SNyKjWu7whg36WIjbByVhDGUiyF3vnI7Lq+g3xJG2O2nGvvNsEotE3dcSO401Vr6tft2nzxYcNmncJ7YJmS8G7dSL9+GP7nMu2PAnaZKpd/+O+VkXb1oXbXmTjcC9l/afDKOIcyydseCXL/kTlO16y6dUPVZmM4SIXAbCpFvUeLLUu1jhqB05bjKRdKVfdgpbl7HaUFjX5fSHozruFM+TPKfxHsPDsuTQIJK0+NPPGcsLzWGdOUTdqoZXm0ejziQx+vuutHoCPXAeCofXRyFncrBnj6vq+sD9wcR21RRykcnbD2ty7OwUxysB33KuyisPHh6/ITRprn2GrO/I6jNE0VS8yludQsWLCjrT9+5cyfGftqoXiXLx5p/ha4VV6lX0Y09+TT+7MZrjLOaaSTHHHv2mDxza56xNZ5mLXcWolFrbbRxkU/jlw1oeetOmAZ0nJISJ/LMvPHE6/PvwFXqgStJp4uDMOmsRpmlJf9radurJsZQ8coVQyyD5Mp6+4rpZ/pZd1VOLbdbvMol69uIThKPO5NejmmuN9LYj8F6Iz7M23DKlU/zCepNT+wY6HFxnxWJMqWZvNXGHF9pEd5inTm1HuhQAdbtJ2HHTYybrvzDTlS8UuJAVxZhpyyrtW2vmnSxEXbKsnLGkC5vw05UXboyCTulgS5dYac00KUr7JQGunSFnSiapLZbdGUfdkqbJB936son7ETxSHM/hi6Owk7kT5dnYacs0aU/7JREdStWdM3X19cjP51j+ztofuG8lpYlVb8CPXf2VL128zr7J8+glCrNZ5q0+VqJs7bWGWJEu408LkmJk1q9iqDY7dMrDsKksxplVqv5bwlTDu1Lno192ys2HiqNMVSo0jHEMijE7ScZmH6mv1Rpq7uKUew+p5z1ZKnf5VUuWd9GdLR5HeK4s+QyKuG4M+nl6BWfUZVaBnFIYjwFYb0RX6ylLW9rPZ+SdAU6h3ApMznWUJoaLxQPxknysMyoVIyh6mMZJFfWy47pZ/pZd5Efxkg6sBypkhhv8WHehiPzKfMd6H19feoVEREREREREREREVHemTNe18bXnng60P9F34F++E9/rP5KrxWXnIcnv/eKekWkxzhJHpYZlYoxVH0sg+TKetkx/Uw/6y7ywxhJB5YjVRLjLT7M2/BkXiVFLGOg6zrQs9B5LnFDoTAYJ8nDMqNSMYaqj2WQXFkvO6af6WfdRX4YI+nAcqRKYrzFh3kbnsyrpKjIFehZ6TyXuKFQGIyT5GGZUakYQ9XHMkiurJcd08/0s+4iP4yRdGA5UiUx3uLDvA1P5lVS1Kv/xyZLnedERERERERERERElB6xdqCz85yIiIiIiIiIiIiIkiq2DnR2nteiM9j/F+/FyuVi+osvgjeUpMN37xPled8z6lXhayIiIiIiIiIiIon9RhrjfahrG8aMeulWf/vZs5BT5zo1R1r3mDHPmm7etlw7Pz89hovMdxgcnedHP2V22BrTtdj/spovvfxF3J1b9l4MH1XzJb9lilHgYtndXzuj5gCvfO3a3GdWLv8UvqvmV5UrLfbOayMNttfG748riI9+Hrt/2IO/PvZjHP77j0M70pDPb6X4WLFsn3QxXxrbCZTcVP1tJNaYj5Gzrglff/l+TtHVbVqh11MjdSGRTU1sQ1QzotVZ+f2Zrvxzbc9cG6Y293/F06XHIy/c7ToxpWm7sLZ1bdo9GLHmane42+NEQXzrLMfxr2ub81nmu3/zO6ameITIc117I6idYi1nGyUDfNqzOp6x4RmLmvaAbf/mW08VSFtbqZaEa7fF2RYxYqGcfS412L6cGW5DXd+4ehWP+off/GZ888EZNDxkdYKvQ+dDF+L5jjdDLnu440HgrkfwYdmH/uj15jzb9I9PivlPPo5Txmdd5Ibefwp9+3+Mw7LTdvgi7O62NsJnMNx9L7DhO2pZD8b7rcrAb5kivvuzMz3ovFi9NjyDbzx1DR6RnxHTX1+/F5+tdseczIPuJ9Bu5YGYHrn6CexQwfWhz4h5Xp3Zcbi4Ce9RfxYI+K0Ur6VWvKupv00tKDP7empiG0kiscPYYatrHtlwiaijQtRtvp9TtHWbjn8dWnN1IZFdTWxDVDuKq7OWXizK/5HCA43vTuxF5/U96lVefv/3HfRdnPx60dFuMLYT18GL0a67Fw3D6j1y2i+2rR2Xp6Tj5hlMPnaJKGsRBxOllWXF2+OUcH51ltiH2Y9/jW2uP3+M67XMb/8mt2XPY2qKRZg817U3gto3y9+LHRgQ+yBjBqWa37Gam09shIjFTvt+/jMfVXOLbFulrK1US4LabYlpi6S+fenNGMLlZ98cw2u4EG+TneTLL8Jb8QJePSaXCMdO4RfqzwLLt+EDK2bw/H2PqhlOr8ydAi6+Bpeer2a0rUQnTuHHstI4ehjj6MHNNy9Syz4pNtDvYW4uYJnhDPY/Ig6O1n8SC9Uc00fRbwu491xwCTDzQhWvJpGNJPE7hx9Ht5UHwnk3P44HVNqMs0xGpWSelVq/43vAY2tzZ3Dyyy3m+/SB6T6zla9YjTNO4rfgh/divVxWUBEG/1a/7zeXyR2CWfnnl9s/Y99hRH2/5Ld++T3i/V8TG7N9mWjE6M/6+n1XLTF/Z8EVKGU6M/mhjh7XNuKXL3KZu8xKKaNrcbd4rzvmTVG+pwpld/7H8YCtrjnv8muwNEzd5vc5g0i3tm7T8K0na60uJHKphW2IakhxdVbD+gF0/vAJPGffD4n9/tce60Frh3qttQiXXp2yerHtc8bB2Mkdn1f7RHNbkAdrjhPychtyvC/BZF0hjjNuXCvqgccOF6anoA1oti107Q57ezu47W2+tr63dtuQFB+fOuvlFzCLi/Be63jq/AvRoP70Xeazf/M9pqZYBOe5R3vDt50i4ubYj8Wx9QXGMkq5wD4tO+/YKH77L/V40N1WMvd9fv0Szive3f0E5FDQbnO3P7z6PALaIBHaPnbh+x3Nui+4fSk/L2MguO+orq5OTX1im7GMo6+uDcPDfc5lM8Noy72/DuYF5zMYbqtD08AkMNJlzG8btgZhMZdZ73euQ3B8n1jfaTXfgzkGevP7cK7VaX5sE37w5Ap8xBiWZTk+/PxDeOuD6/H/Wx3qNhd95i6c++QD2mXSeQsvAn44jZ+o1yaz0jArgsKroWfnzvguk175Wj92N44GXKH7DL4hgmTp1VflKo2KMxpJ4iAu1JXEi9D99+ZZalw/apzFkR3XRgen/aDg5adx5IeXoP1yq1PbIoPvciNfrLNAj2w4hc+qDUp2hMsNFBffa56FzJ2ZVAJ/q//3m76H3d2H0WosV2csl1+OufXW+4Hdg/aO32jv/+59mvU7OpLF9+2AOUTNsc/hQ7LSsZ/1PTYKqCvVgr8rC8zKD40X5raRUHncPYSF6gy4UUa5M+AhYyRXRo+LBqZ8jzPmpehlXWVz0zipDoiC6i8H2+ekcHWbKfx6aqAuJApShW2IalWUOuujaL3+ezjynXxsvPKdJ3Dy+pUB+4UzeO6pFNaLxkH1XkzKg1vP9qKQks43eaeBUYbnX4V20Yb8muMgT9cGfBqXerQ77ILa3mxDkpOrzjr/47hZXulptH9l23gtZjcMmxco+S1zs+3f/I6pKR5BeR66veFqp1B2RGrP+giz/csrmfUdlJZijgcjtpXk3Rc7LlLH53JyXphJGvZ2m1Zhn4d/GyS+tk9OpPalX99RPi3z8/PGND10HF2O8ccnMTAAjBnLd4vvHkffOuDR3PtbMbJVvr8R/UfN1+gdM5Yd7W80vmG8rwkDLea8wnXMYHidWMHQtFq+GScHRowlXuohO8nvXoHXHrxPJNV06no5NIvsRJ/A+/Egnt6k6yFfhwtWiArgcf3V54a2z5m3iuTOOAxh1vN2pUV4r5lGDdsya8N0dwBb5FkwY11rMS4CRBccFWPsMEvk2qjMA8OBwsrICOQeR76cd/NA+AOkoN8a8vs7h63OTHXGUpSB1bDQVf6h329cUXYJ+ta61u+68iz/fYL7rK91Fjbkd1XayR2Xq9iVk73Tubzy67kcR64WlatVpqHzOL8zdMRA5BjxUExZV5V5ImLphk96/B6vus31uaC6LZBrPbVUFxL5qpVtiKqqyDpLNvjzV7vIA0Q49h929v3fbq/Gf6r4ddokvPNNtRXMMjTbkCefejrfie3VBlSvfOna3tbVfyHbKJQBPnWWvA3fPAYWdQ3uxYaQy/Jc+7dIx9RUFn55Hrq9EdS+oWzx6+/y4bv9mxdh5jtTnR2UxbStSmsr+XUGUzEcfR5BbZByt310/Y6G8O1L776jwrQ09m9G7+Q+HLI9wbN3THacWzqx+2g/rM2ocdUatE6exLR6XWBmGFtHWjG0Mf8NjnXMHMK+yV5sVp3txveP9aq/9eoveszdSb4OnWfP4oLHzTHOvznWhRvOPm+OgW7zzm13o2HmQRzz6T+XjHF81AZ9+NgAGn6oFhQ4gx/bMsrJWvYS9g/KsXZ8Os7krRBWBXLBkNjw4+uIrIyP4kY5dpoxtqN5FrCzQ7Oz1naAX4CFnrcJRRT394ciz2BZOw61I1BLPGnO+pqK+K6YOcbEivGq6tx6tLdwF5MvKgbKGiO1Vz5ejDOnngdAkr5uc35ONLB96rZwD4BxrSd1dSGlVSW2IUqAYusse4NfDemRu83ZxTn2pBxDNO23F/tdRHEJFiZ4nCNHp7ZgDJPg7sT2bAMGkXc2wNn2Xm8/AE1OG4Vi5FlnmberT3aoZVc/gfW5q0L9luXp9ovhj6mpXPR5Hr69Edy+oWzx6+/yF3b7NzsobZ3YRbStim4rySE89t+LWXU1vG6YECqHgDZICW2fUP2OhlLal/a+ITMt+eFVuuB//bfsE2/Lv79pAJNqvrdJDDRZ3+9ax/TJEJ93qv/IhQ/im+/fhJ+pGe6O8Z9tWo/nZxqx6AZ7D/o6LL+rEbMP5D8XijojIocJ0d+KAjQsXOSzDJgTlUX+FhWxUxKvjbNkmlsnC8dGrTDXWZxiGemQt1OoK3y1w6wsbBJpdXtJ5FfIA6Sg31rq95dFj+2WIGsKuDVIE0emIr4rbYxx2Ny3PBeTLyoGyhojySgfOVbYZ2fuxSP2sQ596jZL4edkPnnXbZBDMOXywWywh1mPpep1IZGHSm1DHFohWaLVWfkGf25ID7XEl9HuqeRFABVga2ebYyt7pM94X5KHFDAP7HLP9ZFT9704KdJrH87Huw0Y7ENr7/Vpe7MNSU72OuuVrw1h/OJ7caN1R+3Nw8a4xzI2/ZZZdPvFAvZtnSojl+fh2huhypFSLcqxWiR+278xLK/+2Luo48GobSXZiW7sE0fRILYJx3jpVKioujygDVJC2ydUv2PJ7Ut7fJppsYZXMaejyF0Q7jbeh6aBFjWki5imh9CqFnnrzb8/N6l1NC0N8XmnenvnufSzUy8Aje/DO9RrLL8Bi8SX/+JUfhgXo5MdT+KlgKvPnZ4xHlKZvxXN1WF79PNi56MKyXOZ+XCFfKDIcbPVWTK5c3r5i7jbNvC9cXVKVQ8Q1EGd62nL8mpS3zNy7oc7qLEdPysPDrzG9bTeY0+/0UjzvhLLKeC3lvz9JdKObxlAxVH+MyIGZcOmmO+qGvNWL/NMoCBjXD4MtiwWoXu97Sr0kPlijxFHDJQSI/aYT0T5nIF84IW2YexXt3l+LqBuU+9y8FtPzdWFRG41sA1R7SixzjIb/Gvx2cfst60GMBr5lbwIIGaqfZAfKkDfrit8XwIZdcIl6FNjalqTHN8z16bxagOqV4EPUrPaIoPyFmZb2ztRbUiKjU+dVdBpZnREmJ1mfst894sOrmNqqgB7nge1N8KWI6VeiPas86GNYTi3/+/e59zHf3f0XseQYyUfDzraSlH6JeRd6OpP0iumPRbUBilT28e33zFi+zKo76iU9tT4ds0V6MdP58dQb1yFNa0j2Jp7oKhL4xK0wLZcPlC0K2AM9BvOnsXt1vSYHJH9ejX+uZo3cRfwYAfGc53l5tXn9jHTPclMtK4MWS4fkvId27hLYudju8VjZf8p0RC2boXyW+ZDFsKM+WRZOa2X42CG+VyM5MM7zbGoVFrk73rqGs9buYyDQHVFTb6TXY0PLnjfRiHHvxpFp3qyrrWeKDtu/99a+veXRq7/O2h/yhqTS02+VxaacQR5RYDx/iEs3CJ/bzHfVT0f+owt37uncbN8GGy5OHbs4fKlc3gAcypG1svx/3IxUFyMFMZ8AsrHaACJ/9uvfpOT0Ujxqb98PxeVz3pqsC4kcqiJbYhqRql1ltEIF/8PeHhoflxPMYlGvn1cxiRypKf7CbTvdz4YynyAvLz9Wr3H431JI+80gGZcTuet615tQK+2tpsaV/2H7luYk9WGpJj41VltrvGK1QPdjGc8+S3z27/5HlNTLIrNc992yjPGED6Oq9bFa98L6yjBfNqzBXxiwycWP9Th3Mc7TtwU2bbyayv59kvkxluXk0gHH+pfIKjdFiyoDVKeto/k3e8YrX3p33dkpiU/vIqYHA8RdencjbHeEXSp925dOoRetUgyx0QfQJNY1mZ0isuHi05jzb4mj3V0Yvf0EDCgljedxOaAq9rrFixYMK/+LoudO3ei4ZJV6lX2rLjkPDz5vRia0LJC6pdP4I1wQEk1K7Y4iZU8U3455tb/OJM7w2SWGdUSxlD1sQySK+tlx/Qz/ay7yA9jJB1YjlRJjLf4JDZvy9bvGL7vSOZVUtSr/1ONM6+28b+yioiIiIiIiIiIiCgK9jv6q29v/wg6Oq7ARz96Fa688r/g6qs7sWLFKnR2XoNVq67FNdd049prb0B39xrccMNN+K//9c/wsY/dgptv/nP09NyGtWvXY926T+C22/qwfv0n1ddSeT2Dycf8b6MgIiIiIiIiIiIiiob9jkE4hEuZ8TYYCoNxkjwsMyoVY6j6WAbJlfWyY/qZftZd5Icxkg4sR6okxlt8mLfhybxKilg60Ht77UO5ExERERERERERERGZZmdn1V+1L5YO9L5/6VOvnGZ6X1N/pdeF//k/4YV/+aV6RaTHOEkelhmVijFUfSyD5Mp62TH9TD/rLvLDGEkHliNVEuMtPszb8GReJUXdihVd8/X19chP59j+DppfOK+lZYm2Az0LnecSNxQKg3GSPCwzKhVjqPpYBsmV9bJj+pl+1l3khzGSDixHqiTGW3yYt+HJvEqKilyBnpXOc4kbCoXBOEkelhmVijFUfSyD5Mp62TH9TD/rLvLDGEkHliNVEuMtPszb8GReJUW9+n9sstR5TkRERERERERERETpEWsHOjvPiYiIiIiIiIiIiCipYutAZ+d5LXoRX159LhrfI6bVDyE5z7olPxP3iPK85yn1qvA1ERERERERERGRxH4jjfE+1LUNY0a9dKu//exZ3LxtuXrpdNFjZ1GwfPk23Czmyfly6lyn5ts4Os+/3W922BrT1fjyS2q+9NJDWJNbdi42f1vNl/yWKUaBi2VrvvCimgPMfuHq3Gca39OPCTW/qlxpsXdeG2mwvTZ+f1xB/O1hbD12Kx75yWuYOXgHGtRsB5/fSvGxYtk+6WK+NLYTKLmp+ttIrDEfI2ddE77+8v6cpnyC8iX0emqkLiSyqYltiGpGtDorX9aOuLFYbc9cG6Y293/F06XHIy/c7Tox2dvNSWe1n7Rp92DEmqtucLfHicLSHY86j3/9jlUj7MN89otUGqtMvOrG4DJ29XF4lj/bKZlTxHZbGG/F1g1R403XtuAxZHno8rYwHuJsi+jaPiWpwfblzHAb6vrG1at41D/v1bW+7jF85MInMetYvg6dE3cBD3bg4Te/GQ/f8SQaHnoeH9b3v5s7j1tOYvPR1zAjO233LMXWNmsjfAqb2zYBW36glt2Kr99i7Xz8liniu9efuhU3Odb9FL7wRDe+JT8jpkdu+TLWV3unJPOgbT+6rDwQ07eu2Y+NKrg67hfzvDqz47D8fVik/iwQ8FspXh+04l1NW69QC8rMvp6a2EaSSOwwNtrqmm9tuVTUUSHqNt/PmW7aYy4zpvuvVnN1/OvQmqsLiexqYhui2lFcnfXB5aL8hwoPNCYOfxk33XKrepWX3//9AJuXJ79edLQbjO1E08EjtqUl9m3i6DZg8ANVP8gpj6fw1J5LRVmLODhcWllWvD1O6eBxPLrZfvxrbHN9Je7DQhwbUxFEvr7nXGzEPWKfoGa56cpY1q1+fRxe5a+wnZIVRWy32jrFVGzdEDXe0tZWqiVB7bbEtEVS37705jGEy3J8+O4VmH3gPvxCzTGsu1YU5pP4waZj5utH78PzM414a7P50m32hZPiq7rx0QvUjCv+FDfhJF6SG/S3/wFfx634y08sVsv6xQb6HGaClhlexJeHxMHRgCg4Ncd0NbbaAm5R06XAqekqXk0id6Did+55CrdaeSA0fOIp7FNpM84yGZWSeVbqysHngD035s7g5JdbzPfpA9N9ZivfIDPOOInfgmObcKVcVlARBv9Wv+83l8nKWnyPY7n9M/bKPOr7Jb/1y+8R7/+CiAn7MtFQDXdG1v5dtcT8nY6zk7LCKtOZyY6Vt7q2Eb98kcvcZVZKGV2NNeK97pg3RfmeKpTdBXdgn62uabiqGx8MU7f5fS4q33qy1upCIpda2IaohhRXZy0ZuAc3HduPZ+zlL/b7fycOSq5eqV5rLcZHr0lZvXjFsHEw9v3BYbVPFPtR0VaWB2uOE/JyG3K8L8FkXSGOMz7xSVEP7PmHwvQUtAHNtoWu3WFvbwe3vf3aKJQd5jZWcDz60jROYykusI6nLmjCEvVn0fuwwGNjKo7Y9/zkNXGse6F67aYvY98+Dr/yp2yJvN161Cl+Yq0b3G0lc9/n1y/hvMPG3U9ADgXtNnf7w6vPI6ANEqHtYxe+39GM0+D2pfy8jIHgvqO6ujo19SF//fg4+uraMDzc51w2M4y23PvrYF5wPoPhtjo0DUwCI13G/LZh60pwc5n1fuc6BMf3ifWdVvM9aDvQ37ntEbz/hTsw/qiaobzzIrFzmfkRfq5eW956kf6UbcOFS4FjP8IZ9dpkbtDmjqfwaujTL7zou0ya/UIftl70jYArdJ/CF0SQfPCalblGSsUZO1BxEBfqSuLFuPWgeSUCbvmGcRZHdlwbHZz2g4KXDmPs2KXoukpVkjky+D5g5It1FuhbW05ivdqgZEe43EDlEDzGVQ/us4+Bv9X/+03PYWvbP+BqY7k6Y/meD2BmwHo/sLXf3vEb7f0T92jW7+hIFt83CHOImp8Mo0NWOvYzsj/5BqCuVAv+riwwKz9c1JTbRkLlcdv9aFRXVRhllLviImSM5MroKXEQId/jjHkpellX2Us/wvdVYzmo/nKwfc4iz0TrdzBO4ddTA3UhUZAqbENUq6LUWVfj6luew9jT+diYfXo/vn/LnwbsF17EM0+ksF40OnG+jKfkwa1ne1Gwd/YkmLzTwCjDC1aiS7Qh/85xkKdrAx7GRz3aHXZBbW+2IUnyPB694A78pbyLxmj/yrbxjTi9ZbfjAqWckPuwSPtFKhuvMvbr4whT/mynZEPU7Taoj6vYuqH4eIvYVpJ32AwuVcfncnJemEka9nabVmGfh38bJL62T06k9qVf31E+LfPz88Y0PXQcXY7xxycxMACMGct3o1N2qq8DHs29vxUjW+X7G9F/1HyN3jFj2dF+8zTUeF8TBlrMeYXrmMHwOrGCoWm1fDNODowYS7wUdqAv34ar7noB/3i9q/dc6xhefUH9qXPFsHkbrrHByul+nPa6PQqLccFF6s8CtmXWhul1+4k8C2as60ZRWXxDGxwVYzSKSuTaqMwDw3sKKyMjkG915EvDJ+4Jf4AU9FtDfv9Ne6zOTHXGUpSBtRPQNTZCv9+4ouxSbP6ka/2uK8/y3ye4z8haV7iF/K5K+/7gB1Tsysne6Vxe+fV8AGPXiMrVKtPQeZzfGTpiIHKMeCimrKvKPBHxwS39Hr/Hq25zf848iZbfGTp3MMFc66mlupDIV61sQ1RVRdZZssGfv9pFdr7Dsf+ws+//tno1/lPF2THnlPCrV1VbwSxDsw35/ScO5zuxvdqA6pUvXdvbutq0RtuQVGEiDvyOR+Vt+OYxsKhrsA3btfVZKfswv+NmKgu/Mg7o4/Auf7ZTss1nu/WtU4qtG4qLt9LaSn6dwVQMR59HUBuk3G0fXb+jIXz70rvvqDAtjf2b0Tu5D4dsw4j3jsmOc0sndh8VxwvqVeOqNWidPIlp9brAzDC2jrRiaGP+GxzrmDmEfZO92Kw6243vH+tVf+u5OtCX48OP3IVf3HE9Tqk5/pbjbV53PCnGOD5qo535yT1YokZ/KfQiXvJcqbXsBXy5X46149NxJm+FsCqJpvvFhp/0ndLV+IQcH88Y29E8C3jTSk3Fqu0AvxCN5bqFJ+7vD0WewbIaKnISB9lqiSfNGVlTEd8VM8eYWDFeVZ1bj/YW7mLyRcVAWWOk9srHi3Hm1PPgSNLXbUGfM3cw5k7MeTucV53mWk/q6kJKq0psQ5QAxdZZ9ga/PHCw31bv4hx7Uo5Zm/ar//wuorgUjZ4HP7XP0aktGENhuDuxPduAQeSdDXC2vQfsB6DJaaNQHF4MOB41b1d/aqWqz67Zjys1V36Wtg/zO24mnXBtaUtQGfv1cYQrf4ntlPQo6lgtJzje7IqtG8LGW9FtJTmEx9FtOK2ueNcNE0LlENAGKaHtE6rf0VBK+9LeN2SmJT+8Shf8r/+WfeJt+fc3DWBSzfc2iYEm6/td65g+GeLzTq4O9Ga8tVFsXA+dxe1n5TSB94vX5941gduf3wacegFofB/eod5t+cUpz15xJ3VGRA4Tor/1CVhy4WKfZSLDxKryt6GIhod4bZwl09w6GXpcubi4zuIUy0iHvJ1CXeGrHWblgveJtLq9IPIr5AFS0G8t9fvL4lbbLUHWFHBrkCaOTEV8V9oYY6S5b3kuJl9UDJQ1RpJRPnKssPWntuFb9vEsfeo2i+5zBYxhlcy8M4ZgyuWD2bgKsx5L1etCIg+V2oYoWaLVWfkGf25ID7XEl9HuqeRFABVga2eb4+56pM94n9/VQ7XOPLDLPddHTm2b8H2RXvtwPt5twGAdn9zm0/ZmGzLbZNvW+3h04gv34+vLt+ET1h21n9htjElsj83I7cAIbT7S07WlvfmXccFwTba6dzZE+eewnZIapR2rRYy3YuuGYuItaltJdqIbefANLBG/3zFeOhWyt9tCC2iDlND2CdfvWGr70h6DZlqs4VXM6ShyF4S7jfehaaBFDekipukhtKpF3nrz789Nah1NS0N83snVgf4oxt/8Zjycmzrw/Azw2oMdePj9m/CzRx8XG/AKXLBOvX3dZ/D+xifxUpjRXuTZ2Ftst6m5O2y/PSwqClVInsvMB33kA0WOm63OkskGyEsPYY1t4Hvj6pSqHiCogzrXk5DlGUrfM3Luh1qpsR3Xy4MDr3E9rffY02/swL2vxHIK+K0lf3+JtONbBlBxlP+MiEG5Eyrmu6rGvA3LPBMoyBgX21F5LMatA7ar0EPmiz1GHDFQSozYYz4R5fMi5AMvtAc/fnWbz+cm7nFuexOfF9u7X975rafm6kIitxrYhqh2lFhnmQ3+G7F+j/221QBGIz9FHReqfZAfDkLfrit8XwIZdcKl2KzG1LQmOb5nrk3j1QZUrwIfIGu1RfrlLcy2tnei2pAUD//j0Q53h5bREWF1aBW5D/PdL1L5BfQ5qHeZnH0cBR2atvJnOyVjQrRnzYc2+sfbmSLrhrLEm6OtFKVfQt6Frv4kvWLaY0FtkDK1fXz7HSO2L4P6jkppT41v11yBfvx0fgz1xlVY0zqCrbkHiro0LkELbMvlA0W7AsZAz11hfvYsbt4WFOWPYrzjQbzVukL9oQvxfIfPcC8yE60rQ94jH6DxA9uYlqKisN3i0XjLSdEQts4G+y3zIQvhlPlkWTldKcfBDPO5GMmzkeZ4Uyot8nc90e19u548CFRX1OQ72dX44IL3bRRyjKtv4Cb1ZF1rPQUdEz78f2vp318auf4foOsJa0wuNenOyuaYcQR59tZ4//1oHJa/t5jvqp6O+2353vYj/KV8GGy5OHa64fLlpj33YEbFyJVyrLZcDBQXI4Uxn4DyMRon4v/2q9/kZDWCvOovn891rJS3yOXnaTsWHXzWU4N1IZFDTWxDVDNKrbOMRrj4f8DDQ/PjeopJNPLt4zImkSM9bfvRddT5YCjjijjj9mv1Ho/3JY280wCacTmdt6d7tQG92tpualz1Y+5bmJPVhqQqcI+PrR7oZjzjqeh9mM9+kUrwlDHciuOKX/Ha90I3ya+Pw6f82U7JmvJst8XWDcXGm19bybdfIvcsGzmJbcrngahZFdRuCxbUBilP20fy7neM1r707zsy05IfXkVMjoeIunTuxljvCLrUe7cuHYJ9xHJzTPQBNIllbUanuHy46DTW7GvyWEcndk8PAQNqeZPYfgKuaq9bsGDBvPq7LHbu3Ikrr7lJvcqeC//zf8IL//JL9aqMZIV0i3wCLxtLaRBbnMRKnin/AGYGXsvkzjCZZUa1hDFUfSyD5Mp62TH9TD/rLvLDGEkHliNVEuMtPonN27L1O/r3Hf23T/2j8f//73MfMfIqKVxDuFCtMq+28b+yioiIiIiIiIiIiCgK9jv6q1uxomu+vr4e+ekc299B8wvntbQs4RXoZT/TJG8vuxHYk80rf9MomWckeQU6z9BTKRhD1ccySK6slx3Tz/Sz7iI/jJF0YDlSJTHe4pPMvC1nv6O+78i68tyStCvQOYRLmbESojAYJ8nDMqNSMYaqj2WQXFkvO6af6WfdRX4YI+nAcqRKYrzFh3mrxw50F9mB3ttrH8qdiIiIiIiIiIiIiMg0O5ucx7CzA73MZOE3NPBZ2uSPcZI8LDMqFWOo+lgGyZX1smP6mX7WXeSHMZIOLEeqJMZbfJi34SQtn2IZA50d6NxQyB/jJHlYZlQqxlD1sQySK+tlx/Qz/ay7yA9jJB1YjlRJjLf4MG/DSVo+8Qr0MuOGQmEwTpKHZUalYgxVH8sgubJedkw/08+6i/wwRtKB5UiVxHiLD/M2nKTlU736PxERERERERERERER2bADnYiIiIiIiIiIiIhIgx3oREREREREREREREQa9VNTU5ia2oVuNUNq3nBQzJPzzWmXfaFgLT+4oVnNISIiIiIiIiIiIiJKl/ply5Zhy5F2DFq95M0bsK1jAj1ivlzWMzqH9kGrg70bu6amsA1fgphNRERERERERERERJRaxhAup8/MAQ2LYVxPfmIHVq/egRPyb/ny8ATm0IDFxsL9uHPZMqzecdpYRkRERERERERERESUVvXyqvLb1y7E3MThXKe5w5JFWIhZvKhdSERERERERERERESUTvVTU4NoP7IFq3foesibseG2dsyNPoz9ag4RERERERERERERURYYY6D3nLmt4EGiUveuvViLUWzSdq4TEREREREREREREaWXMQa6c5xzU/euKQw2jKLHNh46EREREREREREREVFWGB3ozSs7bOOcN2PDQXaeExEREREREREREVG21U9NTWHvWmC0505znPPu27F2ofj/wrXYK5bJ5ca0Sw7w0o1dxuu9xnsWrt1rLDu4wXbpOhERERERERERERFRChhjoC9bthq5Yc733yley3mu6U7Zvb4fd2qW6R9ASkRERERERERERESUXMYQLkRERERERERERERE5MQOdCIiIiIiIiIiIiIiDXagExERERERERERERFp1K1Y0TVfX1+P/HSO7e+g+YXzWlqWYMWKFerriYiIiIiIiIiIiIiSqW7BggXz6u+y2LlzJ3p7e9Wr7JmdnUVDQ4N6RaTHOEkelhmVijFUfSyD5Mp62TH9TD/rLvLDGEkHliNVEuMtPszbcJKWTxzChYiIiIiIiIiIiIhIgx3oREREREREREREREQa7EAnIiIiIiIiIiIiItJgBzoRERERERERpcZ4Xx3q+sbVKyIiotKwA52IiIiIiIgoRWaG29A2PKNe1b7ADu/xPtS1DcNM0Tj66trgnbxxHBgBeq/rVK/9RVs3ERFlUf3U1BSmpnahW82QmjccFPPkfHPaZVvot4yIiIiIiIiyR3bY8orfWjGO7QPAmlWN6nXadGLjELDvkEeX9vgBjLQOYWO4/nOieMwMo62uDnVq8qsejfoz994+sQU7WcsLTooFrMP5vX4nnYgoSP2yZcuw5Ug7Bq2e8OYN2NYxgR4xXy7rGZ1D+6DqYPdbRkRERERERETVZXQgr0Fq+8+FxiUtmNx3SHtV+PiBEbSuWYUUJ59q3jj6mgaAoWnMz89jfqwXI11eHdjj2L5vDabl+8Q01juCrlxPuLzbog7rsBlDrWpWjv86ZOd5k+175+ePop8bBVHRjCFcTp+ZAxoWo1m+OLEDq1fvwAn5t3x5eAJzaMBiudBvGREREREREcXL84rDGQy35ec7r2JUQ14M99mW6eZJft8jFKzffH/TwCQw0mXMS9LQIWkkO5DRssTWgWyWUd+42Rlnlp27M8+73AvuLpBDmhTEl/8VtoFx5eaIM/FbT6v5ls7r0Du5D4UXocvhW1pdV9+Xed1EQeRJLPRis9Vj3bkRQ62TODltvnTqxO6j/bnttWlpK3D8tIhaSSybn8fR/ibjlYPvOsy7UIYezX8vEZWmHujG7WsXYm7icK5j3GHJIizELF7ULfRbRkRERERERGXkuuJwfgzYKsdmlh2ETRhoGVPz5zE9dBxdjo7CSQyIj44Zy3fDHN2icN54n+Z77GNPF6z/EFYdle9rBXrNzx3lZY5VNIPTx4HWpYUdbiNdW7F02izXsV5R9tttXeA+5d64ag1aRw7kYmnmtPj+1hEcsM04jl54DzkeJj7txPvX2eNsM04OjKhlliYs1XVIFlx9H8e6ifzNmBuhiFKn46cLzvi4yI7vyVB3UPiuw9gmgX3rbCeO/M9wEVGA+qmpQbQf2YLVO3S94M3YcFs75kYfxn41J89vGREREREREZWV+4pD68rFmUPYN9mLsd35HszG/s3incdh76/pHbM6zvMc82aGsXWkFUO2waON77Gu9PVav3pFtWAaJyflBeiFpdI7lh/CofO63vxVrkHl3rgELaLkzQ7zGRzaB2zeLKJLBdeMmDHZe11BbOWEjM8c9X5HnI2J3+vQiCUt7g7JGQxvdQ3fEsu6iaIy49WTcVeH7OjuwkjvWJEnIW3rmD4JUQ1gzaPmSaP56SG0jnQF3CVCRH6MMdB7ztwG94NEpe5de7EWo9ik6Vz3W0ZEREREREQx0FxxaHWWOHlcoRtoEgNNtqsWZYeOWmLQrZ9SwK/cO2H2t8se52mcbLkOnU1L5VM8Ie9+OLRvEr3q8nPtwxCjxqf2/SEYnd+u4VsqtW7KLG3MFzDvDPHUuTt/h8TSrT7f48e9jhbkzqM1rsIaY2QY3VkjIgrDGANdN5Z5964pDDaMosc25rnFbxkRERERERHFZPIkCvr9mpai4PlyxpXIrdCM5BGgVw3pYp9sD5/TrZ9SwL/c5RXrxkM7xw/guAwq2SEHeYW6jLP88C2N/Udtn1d3N0SNT+37g5lXwm92PiixQuum7NLFvHzIra6u1N0Z4mYMmeR1h4SN7zqMOA7+DiIKz+hAb17ZYRvLvBkbDnp1kPstIyIiIiIiotjIBydiBFtzT38cR58cp9q4unAEXbb782eGt7rGgg5BfU/++1281q9e5YYEoSqSV1dHvNI0qNwl9dDO7QeOq05AOVzEJE5uP4ARv+FbpKjxqYaMyf0e+VDPLvc45ObVtvkOSeeV8DmxrJsogKorc88JGN+OgdyJJjkuf11+THIZY/b4lCeC7FePe/FbhxH3k9hnPWXXWOZ+uC4RRVE/NTWFvWuB0Z47zbHMu2/H2oXi/wvXYq9YJpcb065u/2VEREREREQUo07snh4CBprUcAFbsfRROQZ5I/qPjqF3pEvNr0PTvjWYjjw+ufyeaazZZ32/mnKd5F7rl/01a9A6OYAmMb/NryOWYmaOgzwZaeyeoHKX5DAukxgZacldbS6vSh8ZGSnstC4QNT5dcdZ0EpvlGM5qqcl1Fbkau7zwp8SxbqIgZhwd7zJjrq7rOIamC59BYZCd3cdt8Wk8w9Z67zj6jPlNGJgU27WKS7OO9VuHiPtHbXHcJbZT2zMQiCi6ugULFsyrv8ti586d6O3N7kM2Zmdn0dDQoF4R6TFOkodlRqViDFUfyyC5sl52TD/Tz7qL/BTEiHwg4dalRZxASRCZxi5gTA2ZIcehbjq5GfO2h4UmDbd1qiTGW3yYt+EkLZ+MIVyIiIiIiIiIKAXUcCvW6A1pNH5gBMgNHeMxfAsREVGZsAOdiIiIiIiIKDU6sXEI+fGPU2ccB0ZaMbTR6jCXw7TMI8EXnxMRUY1jBzoRERERERFRijT2H8XR1A543Ind8xzPmYiIKqduxYqu+fr6euSnc2x/B80vnNfSsgQrVqxQX09ERERERERERERElEx8iGiZ8WEBFAbjJHlYZlQqxlD1sQySK+tlx/Qz/ay7yA9jJB1YjlRJjLf4MG/DSVo+cQgXIiIiIiIiIiIiIiINdqATEREREREREREREWmwA52IiIiIiIiIiIiISIMd6ERERERERESUGuN9dajrG1eviIiISsMOdCIiIiIiIqIUmRluQ9vwjHpV+wI7vMf7UNc2DDNF4+ira4N38sZxYATova5TvSYiIipN/dTUFKamdqFbzZCaNxwU8+R8c9plW+hc5vwcERERERERxcfoaMx1JCaX7ODlFcJxGcf2AWDNqkb1Om06sXEI2HfIYysYP4CR1iFsZP85VdPMMNrqRH2tpjDVnVG/i/fmT37NYLgt/x3GZP8iz3UEfI6IIqtftmwZthxpx6DVS968Ads6JtAj5stlPaNzaB+0Osq7cbttmeNzREREREREFKvO3fOYP9qPtHaNUhkYHchrkNr+c6FxSQsm9x3SnkgaPzCC1jWruI1QFY2jr2kAGJrG/Lyos8d6MdLld9eEMN6HruO96G1Vr216x8R3yO+R027rzFDwOvSfI6JiGEO4nD4zBzQsRrN8cWIHVq/egRPyb/ny8ATm0IDFxsL9uNO2zPE5IiIiIiIiipVzqAvzKsO+cTmkhXWloauTJvQVin3IX5+ohsgY7rMt082T/L5HKFi/+f6mgUlgpMuYl6ShRpJAdiCjZYmtAzlEnPiUY8HdAnI4lYJ4sceWTkCcuDniRvzW02q+pfM69E7uQ+FF6HL4llbb1fe1kHbKHHkSC73Y3K/isHMjhloncXLafFlIxOBW8YnNG7FUzQkUeR1EVIp646rytQsxN3E41zHusGQRFmIWLxYsDPgcERERERERxW6kayuWTptXGY71TmJgu9WbN+68QnF+DNgqh3+RHYZNGGgZy12dOD10HF2OjkHxPeKjY8by3TCvXSycN96n+R77WNUF6z+EVUfl+1rl5ZHG/KNWBxCVwQxOHwdalzap13neceJfjo2r1qB15EAuNmZOi+9vHcEB24zj6IX3kONh4s1OvH+dPW424+TAiFpmacJSXWehx9X31Us7ZdGMuRGKKHU6frrgjI9hZnidEYNeF4mPdBWe/AmzDt3niKg49VNTg2g/sgWrd+i6wZux4bZ2zI0+jP1qDrp3qfHP/T5HREREREREldA7dhS5ixCv65U9KEbnX8EViujEbjn8y8wh7JvsxZitt6axf7N453HY+3d6x6yO8zzHvJlhbB1pxZBtsGnje6wrg73Wr15RHKZxclJegF6Yy55xElSOjUvQIkrS7DSewaF9wObNIlpUsMyIGZO91xXESk7IeMtR73fEzZj4vQ6NWNLi7pA0r+LVDd9StbQTGcx41RIxuG6gxbF95DWi/6h5Ysc8uQMMNHmdeLKvI8rniCgMYwz0njO3aR8I2r1rL9ZiFJvsneT77zTGP/f7HBEREREREdUAzRWKmD6JSfVnnscVvYEmMdBkXeUopy44rhXWrZ9qkF85dsLsc5adxtM42XIdOpuWyqd4Qt7NcGjfJHrVJdjGkCe571AddlHjTfv+EIyOd/vwLWGVJ+2UTdqYL2DeGVLIvNuiRXOyUsc88WS7A8LBax1BnyOiMIwx0J3jnJu6d01hsGEUPbYxz910nyMiIiIiIqIaMXkSBX2UTUtR+Jw6eeVyKzQjfwToVUO62Kf81b7a9VMN8i9HedW28dDO8QM4LoOkcRXWQF6lLeMmP4RJY/9R2+dVp2DUeNO+P5h5NfjmfOyFVp60UzbpYl4+5FZX9xXeGSJjyD7UShPk4yEmB5pQlxsKy8YYMsjcbsKvQ7B9joiKY3SgN6/ssI1z3owNBz06z5s34OCu/PXmzs8RERERERFRzZAPWsQItuYGvx1Hn+yUkR2ArSPosj35cGZ4q3bsaF/qe/Lf7+K1fvUqN4wGlZG8sts9tEmAoHKU1EM7tx84rjro5HARkzi5/QBGgoYwiRpvatiU3O+RDxTtco+Bbl5tm+8sLPJq8LjTTtmk6r7cFd/j2zGQO9kinwlQpx5O24ndjhM305CPh2iV4/8f7cd0n3Ps8vHtA5i0thufdYz7fY6IilIvxzPfuxYY7bnTHOe8+3asXSj+v3At9hpjnatJdpyfOIyJhsHcPMfniIiIiIiIqIZ0Yrc5+K26unErlj4qxyCX4+OOoXekS82vQ9O+NZiOPD65/J5prNlnfb+acp3kXuuX/ZZr0Do5gCYxv82v85IiMsdBnow0Fk9QOUpyKJNJjIy05K64lldmj4yMhOi0jhpvrrhpOonN4rXzqnTXFexq3PSo/efxp52yyYzh49aV5V3HMTQdbpgWu87rWhzDC3UdH7JtN97r8P8cERWjbsGCBfPq77LYuXMnenvdD/jIjtnZWTQ0NKhXRHqMk+RhmVGpGEPVxzJIrqyXHdPP9LPuIj8FMTLeh7qtS9PdYSbT2AWMqSEz5DjUTSc3Y177IMZk4LZOlcR4iw/zNpyk5ZMxhAsRERERERERpYAacuRQii/sHz8wAuSGT+HDPImIKF7sQCciIiIiIiJKjU5sHAL2pbYHfRwHRloxtNHqMJfDsMwjwRefExFRjWMHOhEREREREVGKNPYfxdH+tA7g0ond80eR2uQREVHNqVuxomu+vr4e+ekc299B8wvntbQswYoVK9TXExERERERERERERElEx8iWmZ8WACFwThJHpYZlYoxVH0sg+TKetkx/Uw/6y7ywxhJB5YjVRLjLT7M23CSlk8cwoWIiIiIiIiIiIiISIMd6EREREREREREREREGuxAJyIiIiIiIiIiIiLSYAc6EREREREREREREZEGO9CJiIiIiIiIiIiIiAoA/w85/22JF0wDlAAAAABJRU5ErkJggg=="
+    }
+   },
+   "cell_type": "markdown",
+   "id": "a3bf3b74-bc71-495e-b11c-36e8a985f3e8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Previous, incorrectly calculated value for City of Commerce May 2025, pct_change_1yr = `-0.4505`\n",
+    "\n",
+    "after updating, pct_change_1yr = `-0.3106`\n",
+    "\n",
+    "Results match the manual calculation from the excel data sheet\n",
+    "![image.png](attachment:d384b318-0d97-4c6c-bf6b-775c099dbb24.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Related issue:
- #1612 

Started explore notebook to compare the percent change function in the monthly ridership data. found that `get_percent_change` was calculating equivalent to `(new-old)/new`. this is incorrect and was updated to `(new-old)/old`. updated the function, reran the report data script and confirmed the calculations are correct by comparing results to a manual calculation.  