### PR TITLE
get paths to each RTPAs page in ridership reports

### DIFF
--- a/ntd/ridership_site_scraper.ipynb
+++ b/ntd/ridership_site_scraper.ipynb
@@ -1,0 +1,580 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "a9fab2a1-9b3c-4ce6-aed8-f4d6881861df",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from bs4 import BeautifulSoup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e39af74e-48e6-4fb0-a32b-26913efa9b2c",
+   "metadata": {},
+   "source": [
+    "## Monthly NTD Ridership: extract URLs\n",
+    "Notebook to grab all the links/urls from the riderships sites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "625688fb-6795-433f-8168-1ed2b0dc156f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "monthly_url = \"https://analysis.dds.dot.ca.gov/ntd_monthly_ridership/README.html\"\n",
+    "annual_url = \"https://analysis.dds.dot.ca.gov/ntd_annual_ridership_report/README.html\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "4550187f-6bb9-46c7-b02c-334175292f81",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response_m = requests.get(monthly_url)\n",
+    "response_m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "2c3dd894-6171-4d98-bf0f-234a8305b1af",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response_a = requests.get(annual_url)\n",
+    "response_a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "4d7aa994-1fd5-41a9-8d60-1f8ec419adfa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bs4.BeautifulSoup"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "monthly_soup = BeautifulSoup(response_m.content,\"html.parser\")\n",
+    "type(monthly_soup)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "b536ad59-5671-4d02-942c-a7d2b7d1506d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bs4.BeautifulSoup"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "annual_soup = BeautifulSoup(response_a.content,\"html.parser\")\n",
+    "type(annual_soup)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "d2fbaf31-bf36-47ff-8166-40009a1142d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#main-content\n",
+      "#\n",
+      "#\n",
+      "rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html\n",
+      "rtpa_el-dorado-county-transportation-commission/00__monthly_ridership_report__rtpa_el-dorado-county-transportation-commission.html\n",
+      "rtpa_fresno-council-of-governments/00__monthly_ridership_report__rtpa_fresno-council-of-governments.html\n",
+      "rtpa_imperial-county-transportation-commission/00__monthly_ridership_report__rtpa_imperial-county-transportation-commission.html\n",
+      "rtpa_kern-council-of-governments/00__monthly_ridership_report__rtpa_kern-council-of-governments.html\n",
+      "rtpa_kings-county-association-of-governments/00__monthly_ridership_report__rtpa_kings-county-association-of-governments.html\n",
+      "rtpa_los-angeles-county-metropolitan-transportation-authority/00__monthly_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html\n",
+      "rtpa_merced-county-association-of-governments/00__monthly_ridership_report__rtpa_merced-county-association-of-governments.html\n",
+      "rtpa_metropolitan-transportation-commission/00__monthly_ridership_report__rtpa_metropolitan-transportation-commission.html\n",
+      "rtpa_orange-county-transportation-authority/00__monthly_ridership_report__rtpa_orange-county-transportation-authority.html\n",
+      "rtpa_placer-county-transportation-planning-agency/00__monthly_ridership_report__rtpa_placer-county-transportation-planning-agency.html\n",
+      "rtpa_riverside-county-transportation-commission/00__monthly_ridership_report__rtpa_riverside-county-transportation-commission.html\n",
+      "rtpa_sacramento-area-council-of-governments/00__monthly_ridership_report__rtpa_sacramento-area-council-of-governments.html\n",
+      "rtpa_san-bernardino-county-transportation-authority/00__monthly_ridership_report__rtpa_san-bernardino-county-transportation-authority.html\n",
+      "rtpa_san-diego-association-of-governments/00__monthly_ridership_report__rtpa_san-diego-association-of-governments.html\n",
+      "rtpa_san-joaquin-council-of-governments/00__monthly_ridership_report__rtpa_san-joaquin-council-of-governments.html\n",
+      "rtpa_san-luis-obispo-council-of-governments/00__monthly_ridership_report__rtpa_san-luis-obispo-council-of-governments.html\n",
+      "rtpa_santa-barbara-county-association-of-governments/00__monthly_ridership_report__rtpa_santa-barbara-county-association-of-governments.html\n",
+      "rtpa_santa-cruz-county-regional-transportation-commission/00__monthly_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html\n",
+      "rtpa_shasta-regional-transportation-agency/00__monthly_ridership_report__rtpa_shasta-regional-transportation-agency.html\n",
+      "rtpa_stanislaus-council-of-governments/00__monthly_ridership_report__rtpa_stanislaus-council-of-governments.html\n",
+      "rtpa_tahoe-regional-planning-agency/00__monthly_ridership_report__rtpa_tahoe-regional-planning-agency.html\n",
+      "rtpa_transportation-agency-for-monterey-county/00__monthly_ridership_report__rtpa_transportation-agency-for-monterey-county.html\n",
+      "rtpa_tulare-county-association-of-governments/00__monthly_ridership_report__rtpa_tulare-county-association-of-governments.html\n",
+      "rtpa_ventura-county-transportation-commission/00__monthly_ridership_report__rtpa_ventura-county-transportation-commission.html\n",
+      "https://github.com/cal-itp/data-analyses\n",
+      "https://github.com/cal-itp/data-analyses/edit/main/ntd/monthly_ridership_report/README.md\n",
+      "https://github.com/cal-itp/data-analyses/issues/new?title=Issue%20on%20page%20%2FREADME.html&body=Your%20issue%20content%20here.\n",
+      "_sources/README.md\n",
+      "#definitions\n",
+      "#methodology\n",
+      "#frequently-asked-questions\n",
+      "#datasets-data-sources\n",
+      "#who-we-are\n",
+      "#monthly-ntd-ridership-by-rtpa\n",
+      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
+      "https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release\n",
+      "#definitions\n",
+      "#methodology\n",
+      "#frequently-asked-questions\n",
+      "https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release\n",
+      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
+      "#datasets-data-sources\n",
+      "https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release\n",
+      "https://gis.data.ca.gov/datasets/CAEnergy::regional-transportation-planning-agencies/explore?appid=cf412a17daaa47bca93c6d6b7e77aff0&amp;edit=true\n",
+      "https://console.cloud.google.com/storage/browser/calitp-publish-data-analysis\n",
+      "#who-we-are\n",
+      "https://dot.ca.gov/\n",
+      "https://analysis.calitp.org/\n",
+      "rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html\n",
+      "#definitions\n",
+      "#methodology\n",
+      "#frequently-asked-questions\n",
+      "#datasets-data-sources\n",
+      "#who-we-are\n"
+     ]
+    }
+   ],
+   "source": [
+    "# just to see all <a> tags with href attributes\n",
+    "for link in monthly_soup.find_all(\"a\"):\n",
+    "    print(link.get(\"href\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "62d4949c-32eb-4d92-9e7e-1d51c84eccfd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#main-content\n",
+      "#\n",
+      "#\n",
+      "rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html\n",
+      "rtpa_amador-county-transportation-commission/00__annual_ridership_report__rtpa_amador-county-transportation-commission.html\n",
+      "rtpa_butte-county-association-of-governments/00__annual_ridership_report__rtpa_butte-county-association-of-governments.html\n",
+      "rtpa_calaveras-council-of-governments/00__annual_ridership_report__rtpa_calaveras-council-of-governments.html\n",
+      "rtpa_colusa-county-transportation-commission/00__annual_ridership_report__rtpa_colusa-county-transportation-commission.html\n",
+      "rtpa_council-of-san-benito-county-governments/00__annual_ridership_report__rtpa_council-of-san-benito-county-governments.html\n",
+      "rtpa_del-norte-local-transportation-commission/00__annual_ridership_report__rtpa_del-norte-local-transportation-commission.html\n",
+      "rtpa_el-dorado-county-transportation-commission/00__annual_ridership_report__rtpa_el-dorado-county-transportation-commission.html\n",
+      "rtpa_fresno-council-of-governments/00__annual_ridership_report__rtpa_fresno-council-of-governments.html\n",
+      "rtpa_glenn-county-transportation-commission/00__annual_ridership_report__rtpa_glenn-county-transportation-commission.html\n",
+      "rtpa_humboldt-county-association-of-governments/00__annual_ridership_report__rtpa_humboldt-county-association-of-governments.html\n",
+      "rtpa_imperial-county-transportation-commission/00__annual_ridership_report__rtpa_imperial-county-transportation-commission.html\n",
+      "rtpa_inyo-county-local-transportation-commission/00__annual_ridership_report__rtpa_inyo-county-local-transportation-commission.html\n",
+      "rtpa_kern-council-of-governments/00__annual_ridership_report__rtpa_kern-council-of-governments.html\n",
+      "rtpa_kings-county-association-of-governments/00__annual_ridership_report__rtpa_kings-county-association-of-governments.html\n",
+      "rtpa_lake-county-city-area-planning-council/00__annual_ridership_report__rtpa_lake-county-city-area-planning-council.html\n",
+      "rtpa_lassen-county-transportation-commission/00__annual_ridership_report__rtpa_lassen-county-transportation-commission.html\n",
+      "rtpa_los-angeles-county-department-of-public-works/00__annual_ridership_report__rtpa_los-angeles-county-department-of-public-works.html\n",
+      "rtpa_los-angeles-county-metropolitan-transportation-authority/00__annual_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html\n",
+      "rtpa_madera-county-transportation-commission/00__annual_ridership_report__rtpa_madera-county-transportation-commission.html\n",
+      "rtpa_mariposa-county-local-transportation-commission/00__annual_ridership_report__rtpa_mariposa-county-local-transportation-commission.html\n",
+      "rtpa_mendocino-council-of-governments/00__annual_ridership_report__rtpa_mendocino-council-of-governments.html\n",
+      "rtpa_merced-county-association-of-governments/00__annual_ridership_report__rtpa_merced-county-association-of-governments.html\n",
+      "rtpa_metropolitan-transportation-commission/00__annual_ridership_report__rtpa_metropolitan-transportation-commission.html\n",
+      "rtpa_modoc-county-transportation-commission/00__annual_ridership_report__rtpa_modoc-county-transportation-commission.html\n",
+      "rtpa_nevada-county-transportation-commission/00__annual_ridership_report__rtpa_nevada-county-transportation-commission.html\n",
+      "rtpa_orange-county-transportation-authority/00__annual_ridership_report__rtpa_orange-county-transportation-authority.html\n",
+      "rtpa_placer-county-transportation-planning-agency/00__annual_ridership_report__rtpa_placer-county-transportation-planning-agency.html\n",
+      "rtpa_plumas-county-transportation-commission/00__annual_ridership_report__rtpa_plumas-county-transportation-commission.html\n",
+      "rtpa_riverside-county-transportation-commission/00__annual_ridership_report__rtpa_riverside-county-transportation-commission.html\n",
+      "rtpa_sacramento-area-council-of-governments/00__annual_ridership_report__rtpa_sacramento-area-council-of-governments.html\n",
+      "rtpa_san-bernardino-county-transportation-authority/00__annual_ridership_report__rtpa_san-bernardino-county-transportation-authority.html\n",
+      "rtpa_san-diego-association-of-governments/00__annual_ridership_report__rtpa_san-diego-association-of-governments.html\n",
+      "rtpa_san-joaquin-council-of-governments/00__annual_ridership_report__rtpa_san-joaquin-council-of-governments.html\n",
+      "rtpa_san-luis-obispo-council-of-governments/00__annual_ridership_report__rtpa_san-luis-obispo-council-of-governments.html\n",
+      "rtpa_santa-barbara-county-association-of-governments/00__annual_ridership_report__rtpa_santa-barbara-county-association-of-governments.html\n",
+      "rtpa_santa-cruz-county-regional-transportation-commission/00__annual_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html\n",
+      "rtpa_shasta-regional-transportation-agency/00__annual_ridership_report__rtpa_shasta-regional-transportation-agency.html\n",
+      "rtpa_sierra-county-transportation-commission/00__annual_ridership_report__rtpa_sierra-county-transportation-commission.html\n",
+      "rtpa_siskiyou-county-local-transportation-commission/00__annual_ridership_report__rtpa_siskiyou-county-local-transportation-commission.html\n",
+      "rtpa_stanislaus-council-of-governments/00__annual_ridership_report__rtpa_stanislaus-council-of-governments.html\n",
+      "rtpa_tahoe-regional-planning-agency/00__annual_ridership_report__rtpa_tahoe-regional-planning-agency.html\n",
+      "rtpa_tehama-county-transportation-commission/00__annual_ridership_report__rtpa_tehama-county-transportation-commission.html\n",
+      "rtpa_transportation-agency-for-monterey-county/00__annual_ridership_report__rtpa_transportation-agency-for-monterey-county.html\n",
+      "rtpa_trinity-county-transportation-commission/00__annual_ridership_report__rtpa_trinity-county-transportation-commission.html\n",
+      "rtpa_tulare-county-association-of-governments/00__annual_ridership_report__rtpa_tulare-county-association-of-governments.html\n",
+      "rtpa_tuolumne-county-transportation-council/00__annual_ridership_report__rtpa_tuolumne-county-transportation-council.html\n",
+      "rtpa_ventura-county-transportation-commission/00__annual_ridership_report__rtpa_ventura-county-transportation-commission.html\n",
+      "https://github.com/cal-itp/data-analyses\n",
+      "https://github.com/cal-itp/data-analyses/edit/main/ntd/annual_ridership_report/README.md\n",
+      "https://github.com/cal-itp/data-analyses/issues/new?title=Issue%20on%20page%20%2FREADME.html&body=Your%20issue%20content%20here.\n",
+      "_sources/README.md\n",
+      "#definitions\n",
+      "#methodology\n",
+      "#frequently-asked-questions\n",
+      "#datasets-data-sources\n",
+      "#who-we-are\n",
+      "#ntd-annual-ridership-by-rtpa\n",
+      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
+      "#definitions\n",
+      "#methodology\n",
+      "https://www.transit.dot.gov/ntd/ntd-data?field_data_categories_target_id%5B2551%5D=2551&amp;field_product_type_target_id=1016&amp;year=all&amp;combine=\n",
+      "#frequently-asked-questions\n",
+      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
+      "#datasets-data-sources\n",
+      "https://www.transit.dot.gov/ntd/data-product/2022-annual-database-service\n",
+      "https://gis.data.ca.gov/datasets/CAEnergy::regional-transportation-planning-agencies/explore?appid=cf412a17daaa47bca93c6d6b7e77aff0&amp;edit=true\n",
+      "https://console.cloud.google.com/storage/browser/calitp-publish-data-analysis\n",
+      "#who-we-are\n",
+      "https://dot.ca.gov/\n",
+      "https://analysis.calitp.org/\n",
+      "rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html\n",
+      "#definitions\n",
+      "#methodology\n",
+      "#frequently-asked-questions\n",
+      "#datasets-data-sources\n",
+      "#who-we-are\n"
+     ]
+    }
+   ],
+   "source": [
+    "for link in annual_soup.find_all(\"a\"):\n",
+    "    print(link.get(\"href\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "289f7e2d-8b66-46f7-ad58-a490a17616c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bs4.element.ResultSet"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# look for all <a> tags, with class_\"reference internal\", with a href attribute\n",
+    "links_m = monthly_soup.find_all(\"a\", class_=\"reference internal\", href=True)\n",
+    "type(links_m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "314795c5-78d1-4367-9dfa-39a7ff9e255e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bs4.element.ResultSet"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "links_a = annual_soup.find_all(\"a\", class_=\"reference internal\", href=True)\n",
+    "type(links_a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "13079d83-8efa-42cc-abe9-3d2b21dc8235",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# list comprehension\n",
+    "monthly_link_list = [link[\"href\"] for link in links_m]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "7f456fef-8fe4-42c4-ba26-23c1dc713108",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "annual_link_list = [link[\"href\"] for link in links_a]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "53649493-2cbc-4e88-9c69-c67387cb7aad",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'len of monthly links: 26'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'len of annual links: 49'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(\n",
+    "    monthly_link_list == annual_link_list,\n",
+    "    f\"len of monthly links: {len(monthly_link_list)}\",\n",
+    "    f\"len of annual links: {len(annual_link_list)}\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "e2ad9296-d48a-41ee-9f20-afb864ef8609",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['#',\n",
+       " 'rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html',\n",
+       " 'rtpa_amador-county-transportation-commission/00__annual_ridership_report__rtpa_amador-county-transportation-commission.html',\n",
+       " 'rtpa_butte-county-association-of-governments/00__annual_ridership_report__rtpa_butte-county-association-of-governments.html',\n",
+       " 'rtpa_calaveras-council-of-governments/00__annual_ridership_report__rtpa_calaveras-council-of-governments.html',\n",
+       " 'rtpa_colusa-county-transportation-commission/00__annual_ridership_report__rtpa_colusa-county-transportation-commission.html',\n",
+       " 'rtpa_council-of-san-benito-county-governments/00__annual_ridership_report__rtpa_council-of-san-benito-county-governments.html',\n",
+       " 'rtpa_del-norte-local-transportation-commission/00__annual_ridership_report__rtpa_del-norte-local-transportation-commission.html',\n",
+       " 'rtpa_el-dorado-county-transportation-commission/00__annual_ridership_report__rtpa_el-dorado-county-transportation-commission.html',\n",
+       " 'rtpa_fresno-council-of-governments/00__annual_ridership_report__rtpa_fresno-council-of-governments.html',\n",
+       " 'rtpa_glenn-county-transportation-commission/00__annual_ridership_report__rtpa_glenn-county-transportation-commission.html',\n",
+       " 'rtpa_humboldt-county-association-of-governments/00__annual_ridership_report__rtpa_humboldt-county-association-of-governments.html',\n",
+       " 'rtpa_imperial-county-transportation-commission/00__annual_ridership_report__rtpa_imperial-county-transportation-commission.html',\n",
+       " 'rtpa_inyo-county-local-transportation-commission/00__annual_ridership_report__rtpa_inyo-county-local-transportation-commission.html',\n",
+       " 'rtpa_kern-council-of-governments/00__annual_ridership_report__rtpa_kern-council-of-governments.html',\n",
+       " 'rtpa_kings-county-association-of-governments/00__annual_ridership_report__rtpa_kings-county-association-of-governments.html',\n",
+       " 'rtpa_lake-county-city-area-planning-council/00__annual_ridership_report__rtpa_lake-county-city-area-planning-council.html',\n",
+       " 'rtpa_lassen-county-transportation-commission/00__annual_ridership_report__rtpa_lassen-county-transportation-commission.html',\n",
+       " 'rtpa_los-angeles-county-department-of-public-works/00__annual_ridership_report__rtpa_los-angeles-county-department-of-public-works.html',\n",
+       " 'rtpa_los-angeles-county-metropolitan-transportation-authority/00__annual_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html',\n",
+       " 'rtpa_madera-county-transportation-commission/00__annual_ridership_report__rtpa_madera-county-transportation-commission.html',\n",
+       " 'rtpa_mariposa-county-local-transportation-commission/00__annual_ridership_report__rtpa_mariposa-county-local-transportation-commission.html',\n",
+       " 'rtpa_mendocino-council-of-governments/00__annual_ridership_report__rtpa_mendocino-council-of-governments.html',\n",
+       " 'rtpa_merced-county-association-of-governments/00__annual_ridership_report__rtpa_merced-county-association-of-governments.html',\n",
+       " 'rtpa_metropolitan-transportation-commission/00__annual_ridership_report__rtpa_metropolitan-transportation-commission.html',\n",
+       " 'rtpa_modoc-county-transportation-commission/00__annual_ridership_report__rtpa_modoc-county-transportation-commission.html',\n",
+       " 'rtpa_nevada-county-transportation-commission/00__annual_ridership_report__rtpa_nevada-county-transportation-commission.html',\n",
+       " 'rtpa_orange-county-transportation-authority/00__annual_ridership_report__rtpa_orange-county-transportation-authority.html',\n",
+       " 'rtpa_placer-county-transportation-planning-agency/00__annual_ridership_report__rtpa_placer-county-transportation-planning-agency.html',\n",
+       " 'rtpa_plumas-county-transportation-commission/00__annual_ridership_report__rtpa_plumas-county-transportation-commission.html',\n",
+       " 'rtpa_riverside-county-transportation-commission/00__annual_ridership_report__rtpa_riverside-county-transportation-commission.html',\n",
+       " 'rtpa_sacramento-area-council-of-governments/00__annual_ridership_report__rtpa_sacramento-area-council-of-governments.html',\n",
+       " 'rtpa_san-bernardino-county-transportation-authority/00__annual_ridership_report__rtpa_san-bernardino-county-transportation-authority.html',\n",
+       " 'rtpa_san-diego-association-of-governments/00__annual_ridership_report__rtpa_san-diego-association-of-governments.html',\n",
+       " 'rtpa_san-joaquin-council-of-governments/00__annual_ridership_report__rtpa_san-joaquin-council-of-governments.html',\n",
+       " 'rtpa_san-luis-obispo-council-of-governments/00__annual_ridership_report__rtpa_san-luis-obispo-council-of-governments.html',\n",
+       " 'rtpa_santa-barbara-county-association-of-governments/00__annual_ridership_report__rtpa_santa-barbara-county-association-of-governments.html',\n",
+       " 'rtpa_santa-cruz-county-regional-transportation-commission/00__annual_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html',\n",
+       " 'rtpa_shasta-regional-transportation-agency/00__annual_ridership_report__rtpa_shasta-regional-transportation-agency.html',\n",
+       " 'rtpa_sierra-county-transportation-commission/00__annual_ridership_report__rtpa_sierra-county-transportation-commission.html',\n",
+       " 'rtpa_siskiyou-county-local-transportation-commission/00__annual_ridership_report__rtpa_siskiyou-county-local-transportation-commission.html',\n",
+       " 'rtpa_stanislaus-council-of-governments/00__annual_ridership_report__rtpa_stanislaus-council-of-governments.html',\n",
+       " 'rtpa_tahoe-regional-planning-agency/00__annual_ridership_report__rtpa_tahoe-regional-planning-agency.html',\n",
+       " 'rtpa_tehama-county-transportation-commission/00__annual_ridership_report__rtpa_tehama-county-transportation-commission.html',\n",
+       " 'rtpa_transportation-agency-for-monterey-county/00__annual_ridership_report__rtpa_transportation-agency-for-monterey-county.html',\n",
+       " 'rtpa_trinity-county-transportation-commission/00__annual_ridership_report__rtpa_trinity-county-transportation-commission.html',\n",
+       " 'rtpa_tulare-county-association-of-governments/00__annual_ridership_report__rtpa_tulare-county-association-of-governments.html',\n",
+       " 'rtpa_tuolumne-county-transportation-council/00__annual_ridership_report__rtpa_tuolumne-county-transportation-council.html',\n",
+       " 'rtpa_ventura-county-transportation-commission/00__annual_ridership_report__rtpa_ventura-county-transportation-commission.html']"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "annual_link_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "77e8a184-b42f-4309-be50-859e31641d8a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['#',\n",
+       " 'rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html',\n",
+       " 'rtpa_el-dorado-county-transportation-commission/00__monthly_ridership_report__rtpa_el-dorado-county-transportation-commission.html',\n",
+       " 'rtpa_fresno-council-of-governments/00__monthly_ridership_report__rtpa_fresno-council-of-governments.html',\n",
+       " 'rtpa_imperial-county-transportation-commission/00__monthly_ridership_report__rtpa_imperial-county-transportation-commission.html',\n",
+       " 'rtpa_kern-council-of-governments/00__monthly_ridership_report__rtpa_kern-council-of-governments.html',\n",
+       " 'rtpa_kings-county-association-of-governments/00__monthly_ridership_report__rtpa_kings-county-association-of-governments.html',\n",
+       " 'rtpa_los-angeles-county-metropolitan-transportation-authority/00__monthly_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html',\n",
+       " 'rtpa_merced-county-association-of-governments/00__monthly_ridership_report__rtpa_merced-county-association-of-governments.html',\n",
+       " 'rtpa_metropolitan-transportation-commission/00__monthly_ridership_report__rtpa_metropolitan-transportation-commission.html',\n",
+       " 'rtpa_orange-county-transportation-authority/00__monthly_ridership_report__rtpa_orange-county-transportation-authority.html',\n",
+       " 'rtpa_placer-county-transportation-planning-agency/00__monthly_ridership_report__rtpa_placer-county-transportation-planning-agency.html',\n",
+       " 'rtpa_riverside-county-transportation-commission/00__monthly_ridership_report__rtpa_riverside-county-transportation-commission.html',\n",
+       " 'rtpa_sacramento-area-council-of-governments/00__monthly_ridership_report__rtpa_sacramento-area-council-of-governments.html',\n",
+       " 'rtpa_san-bernardino-county-transportation-authority/00__monthly_ridership_report__rtpa_san-bernardino-county-transportation-authority.html',\n",
+       " 'rtpa_san-diego-association-of-governments/00__monthly_ridership_report__rtpa_san-diego-association-of-governments.html',\n",
+       " 'rtpa_san-joaquin-council-of-governments/00__monthly_ridership_report__rtpa_san-joaquin-council-of-governments.html',\n",
+       " 'rtpa_san-luis-obispo-council-of-governments/00__monthly_ridership_report__rtpa_san-luis-obispo-council-of-governments.html',\n",
+       " 'rtpa_santa-barbara-county-association-of-governments/00__monthly_ridership_report__rtpa_santa-barbara-county-association-of-governments.html',\n",
+       " 'rtpa_santa-cruz-county-regional-transportation-commission/00__monthly_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html',\n",
+       " 'rtpa_shasta-regional-transportation-agency/00__monthly_ridership_report__rtpa_shasta-regional-transportation-agency.html',\n",
+       " 'rtpa_stanislaus-council-of-governments/00__monthly_ridership_report__rtpa_stanislaus-council-of-governments.html',\n",
+       " 'rtpa_tahoe-regional-planning-agency/00__monthly_ridership_report__rtpa_tahoe-regional-planning-agency.html',\n",
+       " 'rtpa_transportation-agency-for-monterey-county/00__monthly_ridership_report__rtpa_transportation-agency-for-monterey-county.html',\n",
+       " 'rtpa_tulare-county-association-of-governments/00__monthly_ridership_report__rtpa_tulare-county-association-of-governments.html',\n",
+       " 'rtpa_ventura-county-transportation-commission/00__monthly_ridership_report__rtpa_ventura-county-transportation-commission.html']"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "monthly_link_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bad4456-b5c8-4d74-b6d0-46777f92bce0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ntd/ridership_site_scraper.ipynb
+++ b/ntd/ridership_site_scraper.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 1,
    "id": "a9fab2a1-9b3c-4ce6-aed8-f4d6881861df",
    "metadata": {
     "tags": []
@@ -18,542 +18,105 @@
    "id": "e39af74e-48e6-4fb0-a32b-26913efa9b2c",
    "metadata": {},
    "source": [
-    "## Monthly NTD Ridership: extract URLs\n",
+    "## NTD Ridership Sites: extract URLs\n",
     "Notebook to grab all the links/urls from the riderships sites"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
-   "id": "625688fb-6795-433f-8168-1ed2b0dc156f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "monthly_url = \"https://analysis.dds.dot.ca.gov/ntd_monthly_ridership/README.html\"\n",
-    "annual_url = \"https://analysis.dds.dot.ca.gov/ntd_annual_ridership_report/README.html\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "id": "4550187f-6bb9-46c7-b02c-334175292f81",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response_m = requests.get(monthly_url)\n",
-    "response_m"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "id": "2c3dd894-6171-4d98-bf0f-234a8305b1af",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response_a = requests.get(annual_url)\n",
-    "response_a"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "id": "4d7aa994-1fd5-41a9-8d60-1f8ec419adfa",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bs4.BeautifulSoup"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "monthly_soup = BeautifulSoup(response_m.content,\"html.parser\")\n",
-    "type(monthly_soup)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "id": "b536ad59-5671-4d02-942c-a7d2b7d1506d",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bs4.BeautifulSoup"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "annual_soup = BeautifulSoup(response_a.content,\"html.parser\")\n",
-    "type(annual_soup)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "id": "d2fbaf31-bf36-47ff-8166-40009a1142d4",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#main-content\n",
-      "#\n",
-      "#\n",
-      "rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html\n",
-      "rtpa_el-dorado-county-transportation-commission/00__monthly_ridership_report__rtpa_el-dorado-county-transportation-commission.html\n",
-      "rtpa_fresno-council-of-governments/00__monthly_ridership_report__rtpa_fresno-council-of-governments.html\n",
-      "rtpa_imperial-county-transportation-commission/00__monthly_ridership_report__rtpa_imperial-county-transportation-commission.html\n",
-      "rtpa_kern-council-of-governments/00__monthly_ridership_report__rtpa_kern-council-of-governments.html\n",
-      "rtpa_kings-county-association-of-governments/00__monthly_ridership_report__rtpa_kings-county-association-of-governments.html\n",
-      "rtpa_los-angeles-county-metropolitan-transportation-authority/00__monthly_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html\n",
-      "rtpa_merced-county-association-of-governments/00__monthly_ridership_report__rtpa_merced-county-association-of-governments.html\n",
-      "rtpa_metropolitan-transportation-commission/00__monthly_ridership_report__rtpa_metropolitan-transportation-commission.html\n",
-      "rtpa_orange-county-transportation-authority/00__monthly_ridership_report__rtpa_orange-county-transportation-authority.html\n",
-      "rtpa_placer-county-transportation-planning-agency/00__monthly_ridership_report__rtpa_placer-county-transportation-planning-agency.html\n",
-      "rtpa_riverside-county-transportation-commission/00__monthly_ridership_report__rtpa_riverside-county-transportation-commission.html\n",
-      "rtpa_sacramento-area-council-of-governments/00__monthly_ridership_report__rtpa_sacramento-area-council-of-governments.html\n",
-      "rtpa_san-bernardino-county-transportation-authority/00__monthly_ridership_report__rtpa_san-bernardino-county-transportation-authority.html\n",
-      "rtpa_san-diego-association-of-governments/00__monthly_ridership_report__rtpa_san-diego-association-of-governments.html\n",
-      "rtpa_san-joaquin-council-of-governments/00__monthly_ridership_report__rtpa_san-joaquin-council-of-governments.html\n",
-      "rtpa_san-luis-obispo-council-of-governments/00__monthly_ridership_report__rtpa_san-luis-obispo-council-of-governments.html\n",
-      "rtpa_santa-barbara-county-association-of-governments/00__monthly_ridership_report__rtpa_santa-barbara-county-association-of-governments.html\n",
-      "rtpa_santa-cruz-county-regional-transportation-commission/00__monthly_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html\n",
-      "rtpa_shasta-regional-transportation-agency/00__monthly_ridership_report__rtpa_shasta-regional-transportation-agency.html\n",
-      "rtpa_stanislaus-council-of-governments/00__monthly_ridership_report__rtpa_stanislaus-council-of-governments.html\n",
-      "rtpa_tahoe-regional-planning-agency/00__monthly_ridership_report__rtpa_tahoe-regional-planning-agency.html\n",
-      "rtpa_transportation-agency-for-monterey-county/00__monthly_ridership_report__rtpa_transportation-agency-for-monterey-county.html\n",
-      "rtpa_tulare-county-association-of-governments/00__monthly_ridership_report__rtpa_tulare-county-association-of-governments.html\n",
-      "rtpa_ventura-county-transportation-commission/00__monthly_ridership_report__rtpa_ventura-county-transportation-commission.html\n",
-      "https://github.com/cal-itp/data-analyses\n",
-      "https://github.com/cal-itp/data-analyses/edit/main/ntd/monthly_ridership_report/README.md\n",
-      "https://github.com/cal-itp/data-analyses/issues/new?title=Issue%20on%20page%20%2FREADME.html&body=Your%20issue%20content%20here.\n",
-      "_sources/README.md\n",
-      "#definitions\n",
-      "#methodology\n",
-      "#frequently-asked-questions\n",
-      "#datasets-data-sources\n",
-      "#who-we-are\n",
-      "#monthly-ntd-ridership-by-rtpa\n",
-      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
-      "https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release\n",
-      "#definitions\n",
-      "#methodology\n",
-      "#frequently-asked-questions\n",
-      "https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release\n",
-      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
-      "#datasets-data-sources\n",
-      "https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release\n",
-      "https://gis.data.ca.gov/datasets/CAEnergy::regional-transportation-planning-agencies/explore?appid=cf412a17daaa47bca93c6d6b7e77aff0&amp;edit=true\n",
-      "https://console.cloud.google.com/storage/browser/calitp-publish-data-analysis\n",
-      "#who-we-are\n",
-      "https://dot.ca.gov/\n",
-      "https://analysis.calitp.org/\n",
-      "rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html\n",
-      "#definitions\n",
-      "#methodology\n",
-      "#frequently-asked-questions\n",
-      "#datasets-data-sources\n",
-      "#who-we-are\n"
-     ]
-    }
-   ],
-   "source": [
-    "# just to see all <a> tags with href attributes\n",
-    "for link in monthly_soup.find_all(\"a\"):\n",
-    "    print(link.get(\"href\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
-   "id": "62d4949c-32eb-4d92-9e7e-1d51c84eccfd",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#main-content\n",
-      "#\n",
-      "#\n",
-      "rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html\n",
-      "rtpa_amador-county-transportation-commission/00__annual_ridership_report__rtpa_amador-county-transportation-commission.html\n",
-      "rtpa_butte-county-association-of-governments/00__annual_ridership_report__rtpa_butte-county-association-of-governments.html\n",
-      "rtpa_calaveras-council-of-governments/00__annual_ridership_report__rtpa_calaveras-council-of-governments.html\n",
-      "rtpa_colusa-county-transportation-commission/00__annual_ridership_report__rtpa_colusa-county-transportation-commission.html\n",
-      "rtpa_council-of-san-benito-county-governments/00__annual_ridership_report__rtpa_council-of-san-benito-county-governments.html\n",
-      "rtpa_del-norte-local-transportation-commission/00__annual_ridership_report__rtpa_del-norte-local-transportation-commission.html\n",
-      "rtpa_el-dorado-county-transportation-commission/00__annual_ridership_report__rtpa_el-dorado-county-transportation-commission.html\n",
-      "rtpa_fresno-council-of-governments/00__annual_ridership_report__rtpa_fresno-council-of-governments.html\n",
-      "rtpa_glenn-county-transportation-commission/00__annual_ridership_report__rtpa_glenn-county-transportation-commission.html\n",
-      "rtpa_humboldt-county-association-of-governments/00__annual_ridership_report__rtpa_humboldt-county-association-of-governments.html\n",
-      "rtpa_imperial-county-transportation-commission/00__annual_ridership_report__rtpa_imperial-county-transportation-commission.html\n",
-      "rtpa_inyo-county-local-transportation-commission/00__annual_ridership_report__rtpa_inyo-county-local-transportation-commission.html\n",
-      "rtpa_kern-council-of-governments/00__annual_ridership_report__rtpa_kern-council-of-governments.html\n",
-      "rtpa_kings-county-association-of-governments/00__annual_ridership_report__rtpa_kings-county-association-of-governments.html\n",
-      "rtpa_lake-county-city-area-planning-council/00__annual_ridership_report__rtpa_lake-county-city-area-planning-council.html\n",
-      "rtpa_lassen-county-transportation-commission/00__annual_ridership_report__rtpa_lassen-county-transportation-commission.html\n",
-      "rtpa_los-angeles-county-department-of-public-works/00__annual_ridership_report__rtpa_los-angeles-county-department-of-public-works.html\n",
-      "rtpa_los-angeles-county-metropolitan-transportation-authority/00__annual_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html\n",
-      "rtpa_madera-county-transportation-commission/00__annual_ridership_report__rtpa_madera-county-transportation-commission.html\n",
-      "rtpa_mariposa-county-local-transportation-commission/00__annual_ridership_report__rtpa_mariposa-county-local-transportation-commission.html\n",
-      "rtpa_mendocino-council-of-governments/00__annual_ridership_report__rtpa_mendocino-council-of-governments.html\n",
-      "rtpa_merced-county-association-of-governments/00__annual_ridership_report__rtpa_merced-county-association-of-governments.html\n",
-      "rtpa_metropolitan-transportation-commission/00__annual_ridership_report__rtpa_metropolitan-transportation-commission.html\n",
-      "rtpa_modoc-county-transportation-commission/00__annual_ridership_report__rtpa_modoc-county-transportation-commission.html\n",
-      "rtpa_nevada-county-transportation-commission/00__annual_ridership_report__rtpa_nevada-county-transportation-commission.html\n",
-      "rtpa_orange-county-transportation-authority/00__annual_ridership_report__rtpa_orange-county-transportation-authority.html\n",
-      "rtpa_placer-county-transportation-planning-agency/00__annual_ridership_report__rtpa_placer-county-transportation-planning-agency.html\n",
-      "rtpa_plumas-county-transportation-commission/00__annual_ridership_report__rtpa_plumas-county-transportation-commission.html\n",
-      "rtpa_riverside-county-transportation-commission/00__annual_ridership_report__rtpa_riverside-county-transportation-commission.html\n",
-      "rtpa_sacramento-area-council-of-governments/00__annual_ridership_report__rtpa_sacramento-area-council-of-governments.html\n",
-      "rtpa_san-bernardino-county-transportation-authority/00__annual_ridership_report__rtpa_san-bernardino-county-transportation-authority.html\n",
-      "rtpa_san-diego-association-of-governments/00__annual_ridership_report__rtpa_san-diego-association-of-governments.html\n",
-      "rtpa_san-joaquin-council-of-governments/00__annual_ridership_report__rtpa_san-joaquin-council-of-governments.html\n",
-      "rtpa_san-luis-obispo-council-of-governments/00__annual_ridership_report__rtpa_san-luis-obispo-council-of-governments.html\n",
-      "rtpa_santa-barbara-county-association-of-governments/00__annual_ridership_report__rtpa_santa-barbara-county-association-of-governments.html\n",
-      "rtpa_santa-cruz-county-regional-transportation-commission/00__annual_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html\n",
-      "rtpa_shasta-regional-transportation-agency/00__annual_ridership_report__rtpa_shasta-regional-transportation-agency.html\n",
-      "rtpa_sierra-county-transportation-commission/00__annual_ridership_report__rtpa_sierra-county-transportation-commission.html\n",
-      "rtpa_siskiyou-county-local-transportation-commission/00__annual_ridership_report__rtpa_siskiyou-county-local-transportation-commission.html\n",
-      "rtpa_stanislaus-council-of-governments/00__annual_ridership_report__rtpa_stanislaus-council-of-governments.html\n",
-      "rtpa_tahoe-regional-planning-agency/00__annual_ridership_report__rtpa_tahoe-regional-planning-agency.html\n",
-      "rtpa_tehama-county-transportation-commission/00__annual_ridership_report__rtpa_tehama-county-transportation-commission.html\n",
-      "rtpa_transportation-agency-for-monterey-county/00__annual_ridership_report__rtpa_transportation-agency-for-monterey-county.html\n",
-      "rtpa_trinity-county-transportation-commission/00__annual_ridership_report__rtpa_trinity-county-transportation-commission.html\n",
-      "rtpa_tulare-county-association-of-governments/00__annual_ridership_report__rtpa_tulare-county-association-of-governments.html\n",
-      "rtpa_tuolumne-county-transportation-council/00__annual_ridership_report__rtpa_tuolumne-county-transportation-council.html\n",
-      "rtpa_ventura-county-transportation-commission/00__annual_ridership_report__rtpa_ventura-county-transportation-commission.html\n",
-      "https://github.com/cal-itp/data-analyses\n",
-      "https://github.com/cal-itp/data-analyses/edit/main/ntd/annual_ridership_report/README.md\n",
-      "https://github.com/cal-itp/data-analyses/issues/new?title=Issue%20on%20page%20%2FREADME.html&body=Your%20issue%20content%20here.\n",
-      "_sources/README.md\n",
-      "#definitions\n",
-      "#methodology\n",
-      "#frequently-asked-questions\n",
-      "#datasets-data-sources\n",
-      "#who-we-are\n",
-      "#ntd-annual-ridership-by-rtpa\n",
-      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
-      "#definitions\n",
-      "#methodology\n",
-      "https://www.transit.dot.gov/ntd/ntd-data?field_data_categories_target_id%5B2551%5D=2551&amp;field_product_type_target_id=1016&amp;year=all&amp;combine=\n",
-      "#frequently-asked-questions\n",
-      "https://calsta.ca.gov/-/media/calsta-media/documents/sb125-final-guidelines-a11y.pdf\n",
-      "#datasets-data-sources\n",
-      "https://www.transit.dot.gov/ntd/data-product/2022-annual-database-service\n",
-      "https://gis.data.ca.gov/datasets/CAEnergy::regional-transportation-planning-agencies/explore?appid=cf412a17daaa47bca93c6d6b7e77aff0&amp;edit=true\n",
-      "https://console.cloud.google.com/storage/browser/calitp-publish-data-analysis\n",
-      "#who-we-are\n",
-      "https://dot.ca.gov/\n",
-      "https://analysis.calitp.org/\n",
-      "rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html\n",
-      "#definitions\n",
-      "#methodology\n",
-      "#frequently-asked-questions\n",
-      "#datasets-data-sources\n",
-      "#who-we-are\n"
-     ]
-    }
-   ],
-   "source": [
-    "for link in annual_soup.find_all(\"a\"):\n",
-    "    print(link.get(\"href\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "id": "289f7e2d-8b66-46f7-ad58-a490a17616c1",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bs4.element.ResultSet"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# look for all <a> tags, with class_\"reference internal\", with a href attribute\n",
-    "links_m = monthly_soup.find_all(\"a\", class_=\"reference internal\", href=True)\n",
-    "type(links_m)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "id": "314795c5-78d1-4367-9dfa-39a7ff9e255e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bs4.element.ResultSet"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "links_a = annual_soup.find_all(\"a\", class_=\"reference internal\", href=True)\n",
-    "type(links_a)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "id": "13079d83-8efa-42cc-abe9-3d2b21dc8235",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# list comprehension\n",
-    "monthly_link_list = [link[\"href\"] for link in links_m]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "id": "7f456fef-8fe4-42c4-ba26-23c1dc713108",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "annual_link_list = [link[\"href\"] for link in links_a]"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 53,
-   "id": "53649493-2cbc-4e88-9c69-c67387cb7aad",
+   "id": "7330a069-2b37-44cb-a8ab-e2c78ba6aced",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def scrape_ridership_sites(monthly:str, annual:str):\n",
+    "    \"\"\"\n",
+    "    Function to list URLs from the monthly and annual ridership sites. The URL list will be used for email campaigns.\n",
+    "    \"\"\"\n",
+    "    monthly_url = monthly\n",
+    "    annual_url = annual\n",
+    "\n",
+    "    # checking status codes for each site\n",
+    "    response_m = requests.get(monthly_url)\n",
+    "    \n",
+    "    response_a = requests.get(annual_url)\n",
+    "    \n",
+    "    print(\n",
+    "        f\"\"\"Monthly report status code: {response_m},\n",
+    "        \\nAnnual report status code: {response_a}\"\"\"\n",
+    "    )\n",
+    "    \n",
+    "    # create bs4 soup of both sites\n",
+    "    monthly_soup = BeautifulSoup(response_m.content,\"html.parser\")\n",
+    "    annual_soup = BeautifulSoup(response_a.content,\"html.parser\")\n",
+    "    \n",
+    "    # look for all <a> tags, with class_\"reference internal\", with a href attribute\n",
+    "    links_m = monthly_soup.find_all(\"a\", class_=\"reference internal\", href=True)\n",
+    "    links_a = annual_soup.find_all(\"a\", class_=\"reference internal\", href=True)\n",
+    "    \n",
+    "    # list comprehension. Make a list of just the href lines\n",
+    "    monthly_link_list = [link[\"href\"] for link in links_m]\n",
+    "    annual_link_list = [link[\"href\"] for link in links_a]\n",
+    "     \n",
+    "    print(\n",
+    "        f\"\"\"\n",
+    "        len of monthly links: {len(monthly_link_list)}\n",
+    "        len of annual links: {len(annual_link_list)}\n",
+    "        \\nRTPA path's from Monthly Report:\n",
+    "        \\n{monthly_link_list},\n",
+    "        \\nRTPA path's from Annual Report:\n",
+    "        \\n{annual_link_list}\n",
+    "        \"\"\"\n",
+    "        )\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "590adead-6d94-47f0-98ed-27b6e443f980",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'len of monthly links: 26'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'len of annual links: 49'"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monthly report status code: <Response [200]>,\n",
+      "        \n",
+      "Annual report status code: <Response [200]>\n",
+      "\n",
+      "        len of monthly links: 26\n",
+      "        len of annual links: 49\n",
+      "        \n",
+      "RTPA path's from Monthly Report:\n",
+      "        \n",
+      "['#', 'rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html', 'rtpa_el-dorado-county-transportation-commission/00__monthly_ridership_report__rtpa_el-dorado-county-transportation-commission.html', 'rtpa_fresno-council-of-governments/00__monthly_ridership_report__rtpa_fresno-council-of-governments.html', 'rtpa_imperial-county-transportation-commission/00__monthly_ridership_report__rtpa_imperial-county-transportation-commission.html', 'rtpa_kern-council-of-governments/00__monthly_ridership_report__rtpa_kern-council-of-governments.html', 'rtpa_kings-county-association-of-governments/00__monthly_ridership_report__rtpa_kings-county-association-of-governments.html', 'rtpa_los-angeles-county-metropolitan-transportation-authority/00__monthly_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html', 'rtpa_merced-county-association-of-governments/00__monthly_ridership_report__rtpa_merced-county-association-of-governments.html', 'rtpa_metropolitan-transportation-commission/00__monthly_ridership_report__rtpa_metropolitan-transportation-commission.html', 'rtpa_orange-county-transportation-authority/00__monthly_ridership_report__rtpa_orange-county-transportation-authority.html', 'rtpa_placer-county-transportation-planning-agency/00__monthly_ridership_report__rtpa_placer-county-transportation-planning-agency.html', 'rtpa_riverside-county-transportation-commission/00__monthly_ridership_report__rtpa_riverside-county-transportation-commission.html', 'rtpa_sacramento-area-council-of-governments/00__monthly_ridership_report__rtpa_sacramento-area-council-of-governments.html', 'rtpa_san-bernardino-county-transportation-authority/00__monthly_ridership_report__rtpa_san-bernardino-county-transportation-authority.html', 'rtpa_san-diego-association-of-governments/00__monthly_ridership_report__rtpa_san-diego-association-of-governments.html', 'rtpa_san-joaquin-council-of-governments/00__monthly_ridership_report__rtpa_san-joaquin-council-of-governments.html', 'rtpa_san-luis-obispo-council-of-governments/00__monthly_ridership_report__rtpa_san-luis-obispo-council-of-governments.html', 'rtpa_santa-barbara-county-association-of-governments/00__monthly_ridership_report__rtpa_santa-barbara-county-association-of-governments.html', 'rtpa_santa-cruz-county-regional-transportation-commission/00__monthly_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html', 'rtpa_shasta-regional-transportation-agency/00__monthly_ridership_report__rtpa_shasta-regional-transportation-agency.html', 'rtpa_stanislaus-council-of-governments/00__monthly_ridership_report__rtpa_stanislaus-council-of-governments.html', 'rtpa_tahoe-regional-planning-agency/00__monthly_ridership_report__rtpa_tahoe-regional-planning-agency.html', 'rtpa_transportation-agency-for-monterey-county/00__monthly_ridership_report__rtpa_transportation-agency-for-monterey-county.html', 'rtpa_tulare-county-association-of-governments/00__monthly_ridership_report__rtpa_tulare-county-association-of-governments.html', 'rtpa_ventura-county-transportation-commission/00__monthly_ridership_report__rtpa_ventura-county-transportation-commission.html'],\n",
+      "        \n",
+      "RTPA path's from Annual Report:\n",
+      "        \n",
+      "['#', 'rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html', 'rtpa_amador-county-transportation-commission/00__annual_ridership_report__rtpa_amador-county-transportation-commission.html', 'rtpa_butte-county-association-of-governments/00__annual_ridership_report__rtpa_butte-county-association-of-governments.html', 'rtpa_calaveras-council-of-governments/00__annual_ridership_report__rtpa_calaveras-council-of-governments.html', 'rtpa_colusa-county-transportation-commission/00__annual_ridership_report__rtpa_colusa-county-transportation-commission.html', 'rtpa_council-of-san-benito-county-governments/00__annual_ridership_report__rtpa_council-of-san-benito-county-governments.html', 'rtpa_del-norte-local-transportation-commission/00__annual_ridership_report__rtpa_del-norte-local-transportation-commission.html', 'rtpa_el-dorado-county-transportation-commission/00__annual_ridership_report__rtpa_el-dorado-county-transportation-commission.html', 'rtpa_fresno-council-of-governments/00__annual_ridership_report__rtpa_fresno-council-of-governments.html', 'rtpa_glenn-county-transportation-commission/00__annual_ridership_report__rtpa_glenn-county-transportation-commission.html', 'rtpa_humboldt-county-association-of-governments/00__annual_ridership_report__rtpa_humboldt-county-association-of-governments.html', 'rtpa_imperial-county-transportation-commission/00__annual_ridership_report__rtpa_imperial-county-transportation-commission.html', 'rtpa_inyo-county-local-transportation-commission/00__annual_ridership_report__rtpa_inyo-county-local-transportation-commission.html', 'rtpa_kern-council-of-governments/00__annual_ridership_report__rtpa_kern-council-of-governments.html', 'rtpa_kings-county-association-of-governments/00__annual_ridership_report__rtpa_kings-county-association-of-governments.html', 'rtpa_lake-county-city-area-planning-council/00__annual_ridership_report__rtpa_lake-county-city-area-planning-council.html', 'rtpa_lassen-county-transportation-commission/00__annual_ridership_report__rtpa_lassen-county-transportation-commission.html', 'rtpa_los-angeles-county-department-of-public-works/00__annual_ridership_report__rtpa_los-angeles-county-department-of-public-works.html', 'rtpa_los-angeles-county-metropolitan-transportation-authority/00__annual_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html', 'rtpa_madera-county-transportation-commission/00__annual_ridership_report__rtpa_madera-county-transportation-commission.html', 'rtpa_mariposa-county-local-transportation-commission/00__annual_ridership_report__rtpa_mariposa-county-local-transportation-commission.html', 'rtpa_mendocino-council-of-governments/00__annual_ridership_report__rtpa_mendocino-council-of-governments.html', 'rtpa_merced-county-association-of-governments/00__annual_ridership_report__rtpa_merced-county-association-of-governments.html', 'rtpa_metropolitan-transportation-commission/00__annual_ridership_report__rtpa_metropolitan-transportation-commission.html', 'rtpa_modoc-county-transportation-commission/00__annual_ridership_report__rtpa_modoc-county-transportation-commission.html', 'rtpa_nevada-county-transportation-commission/00__annual_ridership_report__rtpa_nevada-county-transportation-commission.html', 'rtpa_orange-county-transportation-authority/00__annual_ridership_report__rtpa_orange-county-transportation-authority.html', 'rtpa_placer-county-transportation-planning-agency/00__annual_ridership_report__rtpa_placer-county-transportation-planning-agency.html', 'rtpa_plumas-county-transportation-commission/00__annual_ridership_report__rtpa_plumas-county-transportation-commission.html', 'rtpa_riverside-county-transportation-commission/00__annual_ridership_report__rtpa_riverside-county-transportation-commission.html', 'rtpa_sacramento-area-council-of-governments/00__annual_ridership_report__rtpa_sacramento-area-council-of-governments.html', 'rtpa_san-bernardino-county-transportation-authority/00__annual_ridership_report__rtpa_san-bernardino-county-transportation-authority.html', 'rtpa_san-diego-association-of-governments/00__annual_ridership_report__rtpa_san-diego-association-of-governments.html', 'rtpa_san-joaquin-council-of-governments/00__annual_ridership_report__rtpa_san-joaquin-council-of-governments.html', 'rtpa_san-luis-obispo-council-of-governments/00__annual_ridership_report__rtpa_san-luis-obispo-council-of-governments.html', 'rtpa_santa-barbara-county-association-of-governments/00__annual_ridership_report__rtpa_santa-barbara-county-association-of-governments.html', 'rtpa_santa-cruz-county-regional-transportation-commission/00__annual_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html', 'rtpa_shasta-regional-transportation-agency/00__annual_ridership_report__rtpa_shasta-regional-transportation-agency.html', 'rtpa_sierra-county-transportation-commission/00__annual_ridership_report__rtpa_sierra-county-transportation-commission.html', 'rtpa_siskiyou-county-local-transportation-commission/00__annual_ridership_report__rtpa_siskiyou-county-local-transportation-commission.html', 'rtpa_stanislaus-council-of-governments/00__annual_ridership_report__rtpa_stanislaus-council-of-governments.html', 'rtpa_tahoe-regional-planning-agency/00__annual_ridership_report__rtpa_tahoe-regional-planning-agency.html', 'rtpa_tehama-county-transportation-commission/00__annual_ridership_report__rtpa_tehama-county-transportation-commission.html', 'rtpa_transportation-agency-for-monterey-county/00__annual_ridership_report__rtpa_transportation-agency-for-monterey-county.html', 'rtpa_trinity-county-transportation-commission/00__annual_ridership_report__rtpa_trinity-county-transportation-commission.html', 'rtpa_tulare-county-association-of-governments/00__annual_ridership_report__rtpa_tulare-county-association-of-governments.html', 'rtpa_tuolumne-county-transportation-council/00__annual_ridership_report__rtpa_tuolumne-county-transportation-council.html', 'rtpa_ventura-county-transportation-commission/00__annual_ridership_report__rtpa_ventura-county-transportation-commission.html']\n",
+      "        \n"
+     ]
     }
    ],
    "source": [
-    "display(\n",
-    "    monthly_link_list == annual_link_list,\n",
-    "    f\"len of monthly links: {len(monthly_link_list)}\",\n",
-    "    f\"len of annual links: {len(annual_link_list)}\",\n",
+    "scrape_ridership_sites(\n",
+    "    monthly = \"https://analysis.dds.dot.ca.gov/ntd_monthly_ridership/README.html\",\n",
+    "    annual = \"https://analysis.dds.dot.ca.gov/ntd_annual_ridership_report/README.html\"\n",
     ")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 64,
-   "id": "e2ad9296-d48a-41ee-9f20-afb864ef8609",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['#',\n",
-       " 'rtpa_alpine-county-local-transportation-commission/00__annual_ridership_report__rtpa_alpine-county-local-transportation-commission.html',\n",
-       " 'rtpa_amador-county-transportation-commission/00__annual_ridership_report__rtpa_amador-county-transportation-commission.html',\n",
-       " 'rtpa_butte-county-association-of-governments/00__annual_ridership_report__rtpa_butte-county-association-of-governments.html',\n",
-       " 'rtpa_calaveras-council-of-governments/00__annual_ridership_report__rtpa_calaveras-council-of-governments.html',\n",
-       " 'rtpa_colusa-county-transportation-commission/00__annual_ridership_report__rtpa_colusa-county-transportation-commission.html',\n",
-       " 'rtpa_council-of-san-benito-county-governments/00__annual_ridership_report__rtpa_council-of-san-benito-county-governments.html',\n",
-       " 'rtpa_del-norte-local-transportation-commission/00__annual_ridership_report__rtpa_del-norte-local-transportation-commission.html',\n",
-       " 'rtpa_el-dorado-county-transportation-commission/00__annual_ridership_report__rtpa_el-dorado-county-transportation-commission.html',\n",
-       " 'rtpa_fresno-council-of-governments/00__annual_ridership_report__rtpa_fresno-council-of-governments.html',\n",
-       " 'rtpa_glenn-county-transportation-commission/00__annual_ridership_report__rtpa_glenn-county-transportation-commission.html',\n",
-       " 'rtpa_humboldt-county-association-of-governments/00__annual_ridership_report__rtpa_humboldt-county-association-of-governments.html',\n",
-       " 'rtpa_imperial-county-transportation-commission/00__annual_ridership_report__rtpa_imperial-county-transportation-commission.html',\n",
-       " 'rtpa_inyo-county-local-transportation-commission/00__annual_ridership_report__rtpa_inyo-county-local-transportation-commission.html',\n",
-       " 'rtpa_kern-council-of-governments/00__annual_ridership_report__rtpa_kern-council-of-governments.html',\n",
-       " 'rtpa_kings-county-association-of-governments/00__annual_ridership_report__rtpa_kings-county-association-of-governments.html',\n",
-       " 'rtpa_lake-county-city-area-planning-council/00__annual_ridership_report__rtpa_lake-county-city-area-planning-council.html',\n",
-       " 'rtpa_lassen-county-transportation-commission/00__annual_ridership_report__rtpa_lassen-county-transportation-commission.html',\n",
-       " 'rtpa_los-angeles-county-department-of-public-works/00__annual_ridership_report__rtpa_los-angeles-county-department-of-public-works.html',\n",
-       " 'rtpa_los-angeles-county-metropolitan-transportation-authority/00__annual_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html',\n",
-       " 'rtpa_madera-county-transportation-commission/00__annual_ridership_report__rtpa_madera-county-transportation-commission.html',\n",
-       " 'rtpa_mariposa-county-local-transportation-commission/00__annual_ridership_report__rtpa_mariposa-county-local-transportation-commission.html',\n",
-       " 'rtpa_mendocino-council-of-governments/00__annual_ridership_report__rtpa_mendocino-council-of-governments.html',\n",
-       " 'rtpa_merced-county-association-of-governments/00__annual_ridership_report__rtpa_merced-county-association-of-governments.html',\n",
-       " 'rtpa_metropolitan-transportation-commission/00__annual_ridership_report__rtpa_metropolitan-transportation-commission.html',\n",
-       " 'rtpa_modoc-county-transportation-commission/00__annual_ridership_report__rtpa_modoc-county-transportation-commission.html',\n",
-       " 'rtpa_nevada-county-transportation-commission/00__annual_ridership_report__rtpa_nevada-county-transportation-commission.html',\n",
-       " 'rtpa_orange-county-transportation-authority/00__annual_ridership_report__rtpa_orange-county-transportation-authority.html',\n",
-       " 'rtpa_placer-county-transportation-planning-agency/00__annual_ridership_report__rtpa_placer-county-transportation-planning-agency.html',\n",
-       " 'rtpa_plumas-county-transportation-commission/00__annual_ridership_report__rtpa_plumas-county-transportation-commission.html',\n",
-       " 'rtpa_riverside-county-transportation-commission/00__annual_ridership_report__rtpa_riverside-county-transportation-commission.html',\n",
-       " 'rtpa_sacramento-area-council-of-governments/00__annual_ridership_report__rtpa_sacramento-area-council-of-governments.html',\n",
-       " 'rtpa_san-bernardino-county-transportation-authority/00__annual_ridership_report__rtpa_san-bernardino-county-transportation-authority.html',\n",
-       " 'rtpa_san-diego-association-of-governments/00__annual_ridership_report__rtpa_san-diego-association-of-governments.html',\n",
-       " 'rtpa_san-joaquin-council-of-governments/00__annual_ridership_report__rtpa_san-joaquin-council-of-governments.html',\n",
-       " 'rtpa_san-luis-obispo-council-of-governments/00__annual_ridership_report__rtpa_san-luis-obispo-council-of-governments.html',\n",
-       " 'rtpa_santa-barbara-county-association-of-governments/00__annual_ridership_report__rtpa_santa-barbara-county-association-of-governments.html',\n",
-       " 'rtpa_santa-cruz-county-regional-transportation-commission/00__annual_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html',\n",
-       " 'rtpa_shasta-regional-transportation-agency/00__annual_ridership_report__rtpa_shasta-regional-transportation-agency.html',\n",
-       " 'rtpa_sierra-county-transportation-commission/00__annual_ridership_report__rtpa_sierra-county-transportation-commission.html',\n",
-       " 'rtpa_siskiyou-county-local-transportation-commission/00__annual_ridership_report__rtpa_siskiyou-county-local-transportation-commission.html',\n",
-       " 'rtpa_stanislaus-council-of-governments/00__annual_ridership_report__rtpa_stanislaus-council-of-governments.html',\n",
-       " 'rtpa_tahoe-regional-planning-agency/00__annual_ridership_report__rtpa_tahoe-regional-planning-agency.html',\n",
-       " 'rtpa_tehama-county-transportation-commission/00__annual_ridership_report__rtpa_tehama-county-transportation-commission.html',\n",
-       " 'rtpa_transportation-agency-for-monterey-county/00__annual_ridership_report__rtpa_transportation-agency-for-monterey-county.html',\n",
-       " 'rtpa_trinity-county-transportation-commission/00__annual_ridership_report__rtpa_trinity-county-transportation-commission.html',\n",
-       " 'rtpa_tulare-county-association-of-governments/00__annual_ridership_report__rtpa_tulare-county-association-of-governments.html',\n",
-       " 'rtpa_tuolumne-county-transportation-council/00__annual_ridership_report__rtpa_tuolumne-county-transportation-council.html',\n",
-       " 'rtpa_ventura-county-transportation-commission/00__annual_ridership_report__rtpa_ventura-county-transportation-commission.html']"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "annual_link_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 65,
-   "id": "77e8a184-b42f-4309-be50-859e31641d8a",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['#',\n",
-       " 'rtpa_butte-county-association-of-governments/00__monthly_ridership_report__rtpa_butte-county-association-of-governments.html',\n",
-       " 'rtpa_el-dorado-county-transportation-commission/00__monthly_ridership_report__rtpa_el-dorado-county-transportation-commission.html',\n",
-       " 'rtpa_fresno-council-of-governments/00__monthly_ridership_report__rtpa_fresno-council-of-governments.html',\n",
-       " 'rtpa_imperial-county-transportation-commission/00__monthly_ridership_report__rtpa_imperial-county-transportation-commission.html',\n",
-       " 'rtpa_kern-council-of-governments/00__monthly_ridership_report__rtpa_kern-council-of-governments.html',\n",
-       " 'rtpa_kings-county-association-of-governments/00__monthly_ridership_report__rtpa_kings-county-association-of-governments.html',\n",
-       " 'rtpa_los-angeles-county-metropolitan-transportation-authority/00__monthly_ridership_report__rtpa_los-angeles-county-metropolitan-transportation-authority.html',\n",
-       " 'rtpa_merced-county-association-of-governments/00__monthly_ridership_report__rtpa_merced-county-association-of-governments.html',\n",
-       " 'rtpa_metropolitan-transportation-commission/00__monthly_ridership_report__rtpa_metropolitan-transportation-commission.html',\n",
-       " 'rtpa_orange-county-transportation-authority/00__monthly_ridership_report__rtpa_orange-county-transportation-authority.html',\n",
-       " 'rtpa_placer-county-transportation-planning-agency/00__monthly_ridership_report__rtpa_placer-county-transportation-planning-agency.html',\n",
-       " 'rtpa_riverside-county-transportation-commission/00__monthly_ridership_report__rtpa_riverside-county-transportation-commission.html',\n",
-       " 'rtpa_sacramento-area-council-of-governments/00__monthly_ridership_report__rtpa_sacramento-area-council-of-governments.html',\n",
-       " 'rtpa_san-bernardino-county-transportation-authority/00__monthly_ridership_report__rtpa_san-bernardino-county-transportation-authority.html',\n",
-       " 'rtpa_san-diego-association-of-governments/00__monthly_ridership_report__rtpa_san-diego-association-of-governments.html',\n",
-       " 'rtpa_san-joaquin-council-of-governments/00__monthly_ridership_report__rtpa_san-joaquin-council-of-governments.html',\n",
-       " 'rtpa_san-luis-obispo-council-of-governments/00__monthly_ridership_report__rtpa_san-luis-obispo-council-of-governments.html',\n",
-       " 'rtpa_santa-barbara-county-association-of-governments/00__monthly_ridership_report__rtpa_santa-barbara-county-association-of-governments.html',\n",
-       " 'rtpa_santa-cruz-county-regional-transportation-commission/00__monthly_ridership_report__rtpa_santa-cruz-county-regional-transportation-commission.html',\n",
-       " 'rtpa_shasta-regional-transportation-agency/00__monthly_ridership_report__rtpa_shasta-regional-transportation-agency.html',\n",
-       " 'rtpa_stanislaus-council-of-governments/00__monthly_ridership_report__rtpa_stanislaus-council-of-governments.html',\n",
-       " 'rtpa_tahoe-regional-planning-agency/00__monthly_ridership_report__rtpa_tahoe-regional-planning-agency.html',\n",
-       " 'rtpa_transportation-agency-for-monterey-county/00__monthly_ridership_report__rtpa_transportation-agency-for-monterey-county.html',\n",
-       " 'rtpa_tulare-county-association-of-governments/00__monthly_ridership_report__rtpa_tulare-county-association-of-governments.html',\n",
-       " 'rtpa_ventura-county-transportation-commission/00__monthly_ridership_report__rtpa_ventura-county-transportation-commission.html']"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "monthly_link_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2bad4456-b5c8-4d74-b6d0-46777f92bce0",
+   "cell_type": "markdown",
+   "id": "eb31cdfd-21f6-4d69-9da5-952406763980",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "---"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Quick notebook/function to scrape the unique URL paths for each RTPA in the monthly and annual ridership report. Used in RTPA contact list for email campaigns.
