### PR TITLE
de-siuba monthly NTD ridership report

### DIFF
--- a/ntd/_01_ntd_ridership_utils.py
+++ b/ntd/_01_ntd_ridership_utils.py
@@ -325,139 +325,124 @@ def save_rtpa_outputs(
     return
 
 
-def produce_ntd_monthly_ridership_by_rtpa(year: int, month: int) -> pd.DataFrame:
+def produce_annual_ntd_ridership_data_by_rtpa(min_year: str, split_scag: bool) -> pd.DataFrame:
     """
-    This function works with the warehouse `dim_monthly_ntd_ridership_with_adjustments` long data format.
-    Import NTD data from warehouse, filter to CA,
-    merge in crosswalk, checks for unmerged rows, then creates new columns for full Mode and TOS name.
-
+    Function that ingest time series ridership data from `mart_ntd_funding_and_expenses.fct_service..._by_mode_upt`. 
+    Filters for CA agencies with last report year and year of data greater than min_year
+    Merges in ntd_id_to_rtpa_crosswalk function. Aggregates by agency, mode and TOS. calculates change in UPT.
     """
-
-    full_upt = (
-        tbls.mart_ntd.dim_monthly_ridership_with_adjustments()
-        >> filter(
-            _.period_year.isin(
-                ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"]
-            )
-        )
-        >>select(
-            _.ntd_id,
-            _.agency,
-            _.reporter_type,
-            _.period_year_month,
-            _.period_year,
-            _.period_month,
-            _.mode,
-            _.tos,
-            _.mode_type_of_service_status,
-            _.primary_uza_name,
-            _.upt
-            
-        )
-        >> collect()
-    ).rename(
-        columns={
-            "mode_type_of_service_status": "Status",
-            "primary_uza_name": "uza_name",
-        }
-    )
-
-    full_upt = full_upt[full_upt.agency.notna()].reset_index(drop=True)
-
-    full_upt.to_parquet(
-        f"{GCS_FILE_PATH}ntd_monthly_ridership_{year}_{month}.parquet"
-    )
-
-    ca = full_upt[
-        (full_upt["uza_name"].str.contains(", CA")) & (full_upt.agency.notna())
-    ].reset_index(drop=True)
-
-    # use new crosswalk function
-    crosswalk = ntd_id_to_rtpa_crosswalk(split_scag=True)
-
-    min_year = 2018
-
-    # get agencies with last report year and data after > 2018.
-    last_report_year = (
-        tbls.mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt()
-        >> filter(
-            _.year >= min_year,  # see if this changes anything
-            _.last_report_year >= min_year,
-            _.primary_uza_name.str.contains(", CA")
-            | _.primary_uza_name.str.contains("CA-NV")
-            | _.primary_uza_name.str.contains("California Non-UZA"),
-        )
-        >> distinct(
-            "source_agency",
-            #'agency_status',
-            #'legacy_ntd_id',
-            "last_report_year",
-            #'mode',
-            "ntd_id",
-            #'reporter_type',
-            #'reporting_module',
-            #'service',
-            #'uace_code',
-            #'primary_uza_name',
-            #'uza_population',
-            #'year',
-            #'upt',
-        )
-        >> collect()
-    )
-
-    # merge last report year to CA UPT data
-    df = pd.merge(ca, last_report_year, left_on="ntd_id", right_on="ntd_id", how="inner")
-
-    # merge crosswalk to CA last report year
-    df = pd.merge(
-        df,
-        # Merging on too many columns can create problems
-        # because csvs and dtypes aren't stable / consistent
-        # for NTD ID, Legacy NTD ID, and UZA
-        crosswalk[["ntd_id_2022", "rtpa_name"]],
-        left_on="ntd_id",
-        right_on="ntd_id_2022",
+    
+    print("ingest annual ridership data from warehouse")
+    
+    query_annual_ntd_data ="""
+    SELECT
+      source_agency,
+      agency_status,
+      mode,
+      service,
+      ntd_id,
+      reporter_type,
+      primary_uza_name,
+      year,
+      SUM(COALESCE(upt, 0)) AS upt
+    FROM
+      `cal-itp-data-infra.mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt`
+    WHERE
+      year >= 2018
+      AND last_report_year >= 2018
+      AND ( primary_uza_name LIKE "%, CA%"
+        OR primary_uza_name LIKE "%CA-NV%"
+        OR primary_uza_name LIKE "%California Non-UZA%" )
+    GROUP BY
+      source_agency,
+      agency_status,
+      ntd_id,
+      primary_uza_name,
+      reporter_type,
+      mode,
+      service,
+      year
+    ORDER BY
+      ntd_id
+    """
+    
+    ntd_service = query_sql(query_annual_ntd_data, as_df=True)
+    
+    
+    print("create crosswalk from ntd_id_to_rtpa_crosswalk function")
+    
+    # Creating crosswalk using function, enable splitting scag to indivdual CTC
+    ntd_to_rtpa_crosswalk = ntd_id_to_rtpa_crosswalk(split_scag=split_scag)
+    
+    
+    print("merge ntd data to crosswalk")
+    # merge service data to crosswalk
+    ntd_data_by_rtpa = ntd_service.merge(
+        ntd_to_rtpa_crosswalk,
         how="left",
+        left_on=[
+            "ntd_id",
+            # "agency", "reporter_type", "city" # sometime agency name, reporter type and city name change or are inconsistent, causing possible fanout
+        ],
+        right_on="ntd_id_2022",
         indicator=True,
     )
-
-    print(df._merge.value_counts())
-
-    # check for unmerged rows
-    if len(df[df._merge == "left_only"]) > 0:
+    
+    # list of ntd_id with LA County Dept of Public Works name
+    lacdpw_list = [
+        "90269",
+        "90270",
+        "90272",
+        "90273",
+        "90274",
+        "90275",
+        "90276",
+        "90277",
+        "90278",
+        "90279",
+    ]
+    
+    # replace LA County Public Works agencies with their own RTPA
+    ntd_data_by_rtpa.loc[
+        ntd_data_by_rtpa["ntd_id"].isin(lacdpw_list), ["rtpa_name", "_merge"]
+    ] = ["Los Angeles County Department of Public Works", "both"]
+    
+    print(ntd_data_by_rtpa._merge.value_counts())
+        
+    if len(ntd_data_by_rtpa[ntd_data_by_rtpa._merge=="left_only"]) > 0:
         raise ValueError("There are unmerged rows to crosswalk")
     
-    monthly_sort_cols =  [
-    "ntd_id",
-    "mode", 
-    "tos",
-    "period_month", 
-    "period_year"
-] # got the order correct with ["period_month", "period_year"]! sorted years with grouped months
+    print("add `change_column` to data")
+    
+    annual_sort_cols =  [
+        "ntd_id",
+        "year",
+        "mode", 
+        "service",
+    ] # got the order correct with ["period_month", "period_year"]! sorted years with grouped months
 
-    monthly_group_cols = [
+    annual_group_cols = [
         "ntd_id",
         "mode", 
-        "tos"
+        "service"
                   ]
 
-    monthly_change_col ="previous_y_m_upt"
+    annual_change_col ="previous_y_upt"
 
-    df = add_change_columns(
-        df,
-        sort_cols = monthly_sort_cols,
-        group_cols = monthly_group_cols,
-        change_col = monthly_change_col
-    )
-
-    
-    df = df.assign(
-        Mode_full = df["mode"].map(NTD_MODES),
-        TOS_full = df["tos"].map(NTD_TOS)
+    ntd_data_by_rtpa = add_change_columns(
+        ntd_data_by_rtpa,
+        sort_cols = annual_sort_cols,
+        group_cols = annual_group_cols,
+        change_col = annual_change_col
     )
     
-    return df
+    print("map mode and tos desc.")
+    ntd_data_by_rtpa = ntd_data_by_rtpa.assign(
+        mode_full = ntd_data_by_rtpa["mode"].map(NTD_MODES),
+        service_full = ntd_data_by_rtpa["service"].map(NTD_TOS)
+    )
+    print("complete")
+    return ntd_data_by_rtpa
 
 
 

--- a/ntd/monthly_ridership_report/explore_monthly_ridership_report.ipynb
+++ b/ntd/monthly_ridership_report/explore_monthly_ridership_report.ipynb
@@ -2,38 +2,48 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 22,
    "id": "15e15e64-5776-4b05-813d-22d1d58379d8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import sys\n",
     "\n",
     "sys.path.append(\"../bus_service_increase\")\n",
-    "sys.path.append(\"../starter_kit\")  # to test out style_df function"
+    "sys.path.append(\"../starter_kit\")  # to test out style_df function\n",
+    "sys.path.append(\"../\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 29,
    "id": "39433d1d-c54e-475c-878e-78c992d0eb58",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%capture\n",
     "import warnings\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
+    "from calitp_data_analysis.sql import query_sql, to_snakecase\n",
     "\n",
     "import altair as alt\n",
     "import calitp_data_analysis.magics\n",
     "import pandas as pd\n",
     "from shared_utils.portfolio_utils import label_visualization\n",
-    "from _starterkit_utils import style_df\n",
+    "# from _starterkit_utils import style_df\n",
     "from calitp_data_analysis import calitp_color_palette as cp\n",
     "from explore_monthly_ridership_by_rtpa import sum_by_group\n",
     "from IPython.display import HTML, Markdown, display\n",
-    "from update_vars import MONTH, PUBLIC_FILENAME, YEAR, NTD_MODES, NTD_TOS\n",
+    "from update_vars import YEAR, MONTH, PUBLIC_FILENAME, YEAR, NTD_MODES, NTD_TOS\n",
+    "from _01_ntd_ridership_utils import ntd_id_to_rtpa_crosswalk, add_change_columns, get_percent_change, sum_by_group\n",
+    "\n",
+    "# for testing\n",
+    "\n",
     "\n",
     "# from monthly_ridership_by_rtpa import get_percent_change\n",
     "# from shared_utils.rt_dates import MONTH_DICT\n",
@@ -47,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "cf5b7b68-3630-4a65-9a24-fa8ceadc48a0",
    "metadata": {
     "tags": []
@@ -60,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "798b9f83-ee62-489d-bc7c-9d1542af0a29",
    "metadata": {
     "tags": [
@@ -77,9 +87,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "f649dd2e-d38b-439c-94cd-a7480dc77511",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -104,6 +116,450 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5ccc1592-ab53-48e3-a5f1-faf5e1db3cb1",
+   "metadata": {},
+   "source": [
+    "## 09/18/2025 remove siuba from report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0628ebc-f8fb-4826-bc83-b9c0bc9da67b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def produce_ntd_monthly_ridership_by_rtpa(year: int, month: int) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    This function works with the warehouse `dim_monthly_ntd_ridership_with_adjustments` long data format.\n",
+    "    Import NTD data from warehouse, filter to CA,\n",
+    "    merge in crosswalk, checks for unmerged rows, then creates new columns for full Mode and TOS name.\n",
+    "\n",
+    "    \"\"\"\n",
+    "\n",
+    "    full_upt = (\n",
+    "        tbls.mart_ntd.dim_monthly_ridership_with_adjustments()\n",
+    "        >> filter(\n",
+    "            _.period_year.isin(\n",
+    "                [\"2018\", \"2019\", \"2020\", \"2021\", \"2022\", \"2023\", \"2024\", \"2025\"]\n",
+    "            )\n",
+    "        )\n",
+    "        >>select(\n",
+    "            _.ntd_id,\n",
+    "            _.agency,\n",
+    "            _.reporter_type,\n",
+    "            _.period_year_month,\n",
+    "            _.period_year,\n",
+    "            _.period_month,\n",
+    "            _.mode,\n",
+    "            _.tos,\n",
+    "            _.mode_type_of_service_status,\n",
+    "            _.primary_uza_name,\n",
+    "            _.upt\n",
+    "            \n",
+    "        )\n",
+    "        >> collect()\n",
+    "    ).rename(\n",
+    "        columns={\n",
+    "            \"mode_type_of_service_status\": \"Status\",\n",
+    "            \"primary_uza_name\": \"uza_name\",\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "    full_upt = full_upt[full_upt.agency.notna()].reset_index(drop=True)\n",
+    "\n",
+    "    full_upt.to_parquet(\n",
+    "        f\"{GCS_FILE_PATH}ntd_monthly_ridership_{year}_{month}.parquet\"\n",
+    "    )\n",
+    "\n",
+    "    ca = full_upt[\n",
+    "        (full_upt[\"uza_name\"].str.contains(\", CA\")) & (full_upt.agency.notna())\n",
+    "    ].reset_index(drop=True)\n",
+    "\n",
+    "    # use new crosswalk function\n",
+    "    crosswalk = ntd_id_to_rtpa_crosswalk(split_scag=True)\n",
+    "\n",
+    "    min_year = 2018\n",
+    "\n",
+    "    # get agencies with last report year and data after > 2018.\n",
+    "    last_report_year = (\n",
+    "        tbls.mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt()\n",
+    "        >> filter(\n",
+    "            _.year >= min_year,  # see if this changes anything\n",
+    "            _.last_report_year >= min_year,\n",
+    "            _.primary_uza_name.str.contains(\", CA\")\n",
+    "            | _.primary_uza_name.str.contains(\"CA-NV\")\n",
+    "            | _.primary_uza_name.str.contains(\"California Non-UZA\"),\n",
+    "        )\n",
+    "        >> distinct(\n",
+    "            \"source_agency\",\n",
+    "            \"last_report_year\",\n",
+    "            \"ntd_id\",\n",
+    "        )\n",
+    "        >> collect()\n",
+    "    )\n",
+    "\n",
+    "    # merge last report year to CA UPT data\n",
+    "    df = pd.merge(ca, last_report_year, left_on=\"ntd_id\", right_on=\"ntd_id\", how=\"inner\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f15da636-99fb-42c5-b3d3-28de5db354a8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 209340 entries, 0 to 209339\n",
+      "Data columns (total 11 columns):\n",
+      " #   Column             Non-Null Count   Dtype  \n",
+      "---  ------             --------------   -----  \n",
+      " 0   ntd_id             209340 non-null  object \n",
+      " 1   agency             209340 non-null  object \n",
+      " 2   reporter_type      209340 non-null  object \n",
+      " 3   period_year_month  209340 non-null  object \n",
+      " 4   period_year        209340 non-null  object \n",
+      " 5   period_month       209340 non-null  object \n",
+      " 6   mode               209340 non-null  object \n",
+      " 7   tos                209340 non-null  object \n",
+      " 8   Status             209340 non-null  object \n",
+      " 9   uza_name           208800 non-null  object \n",
+      " 10  upt                116688 non-null  float64\n",
+      "dtypes: float64(1), object(10)\n",
+      "memory usage: 17.6+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "full_upt = (\n",
+    "        tbls.mart_ntd.dim_monthly_ridership_with_adjustments()\n",
+    "        >> filter(\n",
+    "            _.period_year.isin(\n",
+    "                [\"2018\", \"2019\", \"2020\", \"2021\", \"2022\", \"2023\", \"2024\", \"2025\"]\n",
+    "            )\n",
+    "        )\n",
+    "        >>select(\n",
+    "            _.ntd_id,\n",
+    "            _.agency,\n",
+    "            _.reporter_type,\n",
+    "            _.period_year_month,\n",
+    "            _.period_year,\n",
+    "            _.period_month,\n",
+    "            _.mode,\n",
+    "            _.tos,\n",
+    "            _.mode_type_of_service_status,\n",
+    "            _.primary_uza_name,\n",
+    "            _.upt\n",
+    "            \n",
+    "        )\n",
+    "        >> collect()\n",
+    "    ).rename(\n",
+    "        columns={\n",
+    "            \"mode_type_of_service_status\": \"Status\",\n",
+    "            \"primary_uza_name\": \"uza_name\",\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "full_upt = full_upt[full_upt.agency.notna()].reset_index(drop=True)\n",
+    "\n",
+    "full_upt.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e34d54eb-73c2-4aeb-becd-6f62da7c4720",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 227 entries, 0 to 226\n",
+      "Data columns (total 3 columns):\n",
+      " #   Column            Non-Null Count  Dtype \n",
+      "---  ------            --------------  ----- \n",
+      " 0   source_agency     227 non-null    object\n",
+      " 1   last_report_year  227 non-null    int64 \n",
+      " 2   ntd_id            227 non-null    object\n",
+      "dtypes: int64(1), object(2)\n",
+      "memory usage: 5.4+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "min_year = 2018\n",
+    "last_report_year = (\n",
+    "        tbls.mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt()\n",
+    "        >> filter(\n",
+    "            _.year >= min_year,  # see if this changes anything\n",
+    "            _.last_report_year >= min_year,\n",
+    "            _.primary_uza_name.str.contains(\", CA\")\n",
+    "            | _.primary_uza_name.str.contains(\"CA-NV\")\n",
+    "            | _.primary_uza_name.str.contains(\"California Non-UZA\"),\n",
+    "        )\n",
+    "        >> distinct(\n",
+    "            \"source_agency\",\n",
+    "            \"last_report_year\",\n",
+    "            \"ntd_id\",\n",
+    "        )\n",
+    "        >> collect()\n",
+    "    )\n",
+    "\n",
+    "last_report_year.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e3873403-056f-483f-882c-cda97ab299e2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "monthly_query =\"\"\"\n",
+    "SELECT \n",
+    "  ntd_id,\n",
+    "  agency,\n",
+    "  reporter_type,\n",
+    "  period_year_month,\n",
+    "  period_year,\n",
+    "  period_month,\n",
+    "  mode,\n",
+    "  tos,\n",
+    "  mode_type_of_service_status AS Status,\n",
+    "  primary_uza_name as uza_name,\n",
+    "  upt\n",
+    "FROM\n",
+    "  `cal-itp-data-infra.mart_ntd.dim_monthly_ridership_with_adjustments`\n",
+    "WHERE\n",
+    "  period_year IN (\"2018\", \"2019\", \"2020\", \"2021\", \"2022\", \"2023\", \"2024\", \"2025\")\n",
+    "  AND agency IS NOT NULL\n",
+    "\"\"\"\n",
+    "\n",
+    "full_upt_test = query_sql(monthly_query, as_df=True)\n",
+    "\n",
+    "last_report_query = \"\"\"\n",
+    "SELECT DISTINCT\n",
+    "  source_agency,\n",
+    "  last_report_year,\n",
+    "  ntd_id,\n",
+    "FROM\n",
+    "  `cal-itp-data-infra.mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt`\n",
+    "WHERE\n",
+    "  year >= 2018\n",
+    "  AND last_report_year >= 2018\n",
+    "  AND (\n",
+    "    primary_uza_name LIKE \"%, CA%\"\n",
+    "    OR primary_uza_name LIKE \"%CA-NV%\"\n",
+    "    OR primary_uza_name LIKE \"%California Non-UZA%\"\n",
+    "  )\n",
+    "\"\"\"\n",
+    "\n",
+    "last_report_year_test = query_sql(last_report_query, as_df=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a4c2b54f-3627-4be2-806a-7a6d57ccefae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(\n",
+    "    full_upt.equals(full_upt_test),\n",
+    "    last_report_year.equals(last_report_year_test)\n",
+    ") # TRUE TRUE!!\n",
+    "# good to go"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "d5e011ff-754e-44b8-858a-1f3e4852a2dc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# UPDATED without siuba\n",
+    "def produce_ntd_monthly_ridership_by_rtpa(year: int, month: int) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    This function works with the warehouse `dim_monthly_ntd_ridership_with_adjustments` long data format.\n",
+    "    Import NTD data from warehouse, filter to CA,\n",
+    "    merge in crosswalk, checks for unmerged rows, then creates new columns for full Mode and TOS name.\n",
+    "\n",
+    "    \"\"\"\n",
+    "    monthly_query =\"\"\"\n",
+    "    SELECT \n",
+    "      ntd_id,\n",
+    "      agency,\n",
+    "      reporter_type,\n",
+    "      period_year_month,\n",
+    "      period_year,\n",
+    "      period_month,\n",
+    "      mode,\n",
+    "      tos,\n",
+    "      mode_type_of_service_status AS Status,\n",
+    "      primary_uza_name as uza_name,\n",
+    "      upt\n",
+    "    FROM\n",
+    "      `cal-itp-data-infra.mart_ntd.dim_monthly_ridership_with_adjustments`\n",
+    "    WHERE\n",
+    "      period_year IN (\"2018\", \"2019\", \"2020\", \"2021\", \"2022\", \"2023\", \"2024\", \"2025\")\n",
+    "      AND agency IS NOT NULL\n",
+    "    \"\"\"\n",
+    "    full_upt = query_sql(monthly_query, as_df=True)\n",
+    "\n",
+    "    full_upt.to_parquet(\n",
+    "        f\"{GCS_FILE_PATH}ntd_monthly_ridership_{year}_{month}.parquet\"\n",
+    "    )\n",
+    "\n",
+    "    ca = full_upt[\n",
+    "        (full_upt[\"uza_name\"].str.contains(\", CA\")) & (full_upt.agency.notna())\n",
+    "    ].reset_index(drop=True)\n",
+    "\n",
+    "    # use new crosswalk function\n",
+    "    crosswalk = ntd_id_to_rtpa_crosswalk(split_scag=True)\n",
+    "\n",
+    "    min_year = 2018\n",
+    "\n",
+    "    # get agencies with last report year and data after > 2018.\n",
+    "    last_report_query = \"\"\"\n",
+    "    SELECT DISTINCT\n",
+    "      source_agency,\n",
+    "      last_report_year,\n",
+    "      ntd_id,\n",
+    "    FROM\n",
+    "      `cal-itp-data-infra.mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt`\n",
+    "    WHERE\n",
+    "      year >= 2018\n",
+    "      AND last_report_year >= 2018\n",
+    "      AND (\n",
+    "        primary_uza_name LIKE \"%, CA%\"\n",
+    "        OR primary_uza_name LIKE \"%CA-NV%\"\n",
+    "        OR primary_uza_name LIKE \"%California Non-UZA%\"\n",
+    "      )\n",
+    "    \"\"\"\n",
+    "\n",
+    "    last_report_year = query_sql(last_report_query, as_df=True)\n",
+    "\n",
+    "    # merge last report year to CA UPT data\n",
+    "    df = pd.merge(ca, last_report_year, left_on=\"ntd_id\", right_on=\"ntd_id\", how=\"inner\")\n",
+    "    # merge crosswalk to CA last report year\n",
+    "    df = pd.merge(\n",
+    "        df,\n",
+    "        # Merging on too many columns can create problems\n",
+    "        # because csvs and dtypes aren't stable / consistent\n",
+    "        # for NTD ID, Legacy NTD ID, and UZA\n",
+    "        crosswalk[[\"ntd_id_2022\", \"rtpa_name\"]],\n",
+    "        left_on=\"ntd_id\",\n",
+    "        right_on=\"ntd_id_2022\",\n",
+    "        how=\"left\",\n",
+    "        indicator=True,\n",
+    "    )\n",
+    "\n",
+    "    print(df._merge.value_counts())\n",
+    "\n",
+    "    # check for unmerged rows\n",
+    "    if len(df[df._merge == \"left_only\"]) > 0:\n",
+    "        raise ValueError(\"There are unmerged rows to crosswalk\")\n",
+    "    \n",
+    "    monthly_sort_cols =  [\n",
+    "    \"ntd_id\",\n",
+    "    \"mode\", \n",
+    "    \"tos\",\n",
+    "    \"period_month\", \n",
+    "    \"period_year\"\n",
+    "] # got the order correct with [\"period_month\", \"period_year\"]! sorted years with grouped months\n",
+    "\n",
+    "    monthly_group_cols = [\n",
+    "        \"ntd_id\",\n",
+    "        \"mode\", \n",
+    "        \"tos\"\n",
+    "                  ]\n",
+    "\n",
+    "    monthly_change_col =\"previous_y_m_upt\"\n",
+    "\n",
+    "    df = add_change_columns(\n",
+    "        df,\n",
+    "        sort_cols = monthly_sort_cols,\n",
+    "        group_cols = monthly_group_cols,\n",
+    "        change_col = monthly_change_col\n",
+    "    )\n",
+    "\n",
+    "    \n",
+    "    df = df.assign(\n",
+    "        Mode_full = df[\"mode\"].map(NTD_MODES),\n",
+    "        TOS_full = df[\"tos\"].map(NTD_TOS)\n",
+    "    )\n",
+    "    \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "b34c42e2-3cb2-401f-b76a-9d5ec4d82de2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "both          29700\n",
+      "left_only         0\n",
+      "right_only        0\n",
+      "Name: _merge, dtype: int64\n",
+      "Index(['ntd_id', 'agency', 'reporter_type', 'period_year_month', 'period_year',\n",
+      "       'period_month', 'mode', 'tos', 'Status', 'uza_name', 'upt',\n",
+      "       'source_agency', 'last_report_year', 'ntd_id_2022', 'rtpa_name',\n",
+      "       '_merge', 'previous_y_m_upt', 'change_1yr', 'pct_change_1yr',\n",
+      "       'Mode_full', 'TOS_full'],\n",
+      "      dtype='object')\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = produce_ntd_monthly_ridership_by_rtpa(YEAR, MONTH)\n",
+    "print(df.columns) # good to go!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "77ec2bbf-2423-4135-9959-ecbbe2d5bd5a",
    "metadata": {},
    "source": [
@@ -112,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "3ab5ab69-fa1b-4eb5-893c-ac051206432c",
    "metadata": {
     "tags": []
@@ -137,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "8585f56c-e0ab-4c32-a4ba-99d761822df4",
    "metadata": {},
    "outputs": [],
@@ -147,7 +603,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "563ddea2-b6f3-4c7b-8ee8-9f3beb28a29f",
    "metadata": {
     "tags": []
@@ -175,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "10d22913-b801-48c6-ac1f-a1a372b3af2d",
    "metadata": {
     "tags": []
@@ -187,67 +643,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "8282a915-68da-4d1f-89a8-80a139b5c910",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_598/1389364830.py:1: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.\n",
-      "  xwalk_no_split[\"rtpa_name\"].unique() == xwalk_w_split[\"rtpa_name\"].unique()\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xwalk_no_split[\"rtpa_name\"].unique() == xwalk_w_split[\"rtpa_name\"].unique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "0400acad-375d-4ab5-8440-e4ef44d3383d",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['name',\n",
-       " 'ntd_id_2022',\n",
-       " 'rtpa_name',\n",
-       " 'mpo_name',\n",
-       " 'key',\n",
-       " 'county_geography_name',\n",
-       " 'organization_key']"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xwalk_w_split.columns.tolist()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "77f19135-2437-42e6-8a00-f6b58d4d6b8c",
    "metadata": {
     "tags": []
@@ -370,253 +790,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "1e748115-0619-4203-be1e-79c4379845d1",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name '_01_ntd_ridership_utils' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[27], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m data \u001b[38;5;241m=\u001b[39m \u001b[43m_01_ntd_ridership_utils\u001b[49m\u001b[38;5;241m.\u001b[39mproduce_ntd_monthly_ridership_by_rtpa(YEAR, MONTH)\n",
-      "\u001b[0;31mNameError\u001b[0m: name '_01_ntd_ridership_utils' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = produce_ntd_monthly_ridership_by_rtpa(YEAR, MONTH)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "cfe9d0d2-5279-4a40-9cfb-ff41b33f09c9",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "Int64Index: 28864 entries, 0 to 28863\n",
-      "Data columns (total 21 columns):\n",
-      " #   Column             Non-Null Count  Dtype   \n",
-      "---  ------             --------------  -----   \n",
-      " 0   ntd_id             28864 non-null  object  \n",
-      " 1   agency             28864 non-null  object  \n",
-      " 2   reporter_type      28864 non-null  object  \n",
-      " 3   period_year_month  28864 non-null  object  \n",
-      " 4   period_year        28864 non-null  int64   \n",
-      " 5   period_month       28864 non-null  int64   \n",
-      " 6   mode               28864 non-null  object  \n",
-      " 7   tos                28864 non-null  object  \n",
-      " 8   Status             28864 non-null  object  \n",
-      " 9   uza_name           28864 non-null  object  \n",
-      " 10  upt                18637 non-null  float64 \n",
-      " 11  source_agency      28864 non-null  object  \n",
-      " 12  last_report_year   28864 non-null  int64   \n",
-      " 13  ntd_id_2022        28864 non-null  object  \n",
-      " 14  rtpa_name          28864 non-null  object  \n",
-      " 15  _merge             28864 non-null  category\n",
-      " 16  previous_y_m_upt   18431 non-null  float64 \n",
-      " 17  change_1yr         17504 non-null  float64 \n",
-      " 18  pct_change_1yr     17489 non-null  float64 \n",
-      " 19  Mode_full          28864 non-null  object  \n",
-      " 20  TOS_full           28864 non-null  object  \n",
-      "dtypes: category(1), float64(4), int64(3), object(13)\n",
-      "memory usage: 4.7+ MB\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "None"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Metropolitan Transportation Commission                      6600\n",
-       "Los Angeles County Metropolitan Transportation Authority    6248\n",
-       "San Diego Association of Governments                        1936\n",
-       "Sacramento Area Council of Governments                      1936\n",
-       "Riverside County Transportation Commission                  1232\n",
-       "San Joaquin Council of Governments                          1144\n",
-       "Santa Barbara County Association of Governments              968\n",
-       "Orange County Transportation Authority                       968\n",
-       "Placer County Transportation Planning Agency                 880\n",
-       "Ventura County Transportation Commission                     880\n",
-       "Tulare County Association of Governments                     792\n",
-       "Stanislaus Council of Governments                            792\n",
-       "San Bernardino County Transportation Authority               704\n",
-       "Transportation Agency for Monterey County                    616\n",
-       "Tahoe Regional Planning Agency                               616\n",
-       "Santa Cruz County Regional Transportation Commission         440\n",
-       "Kings County Association of Governments                      440\n",
-       "Kern Council of Governments                                  352\n",
-       "El Dorado County Transportation Commission                   264\n",
-       "Shasta Regional Transportation Agency                        264\n",
-       "Merced County Association of Governments                     264\n",
-       "Fresno Council of Governments                                176\n",
-       "Butte County Association of Governments                      176\n",
-       "Imperial County Transportation Commission                    176\n",
-       "Name: rtpa_name, dtype: int64"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>period_year</th>\n",
-       "      <th>period_month</th>\n",
-       "      <th>upt</th>\n",
-       "      <th>last_report_year</th>\n",
-       "      <th>previous_y_m_upt</th>\n",
-       "      <th>change_1yr</th>\n",
-       "      <th>pct_change_1yr</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>count</th>\n",
-       "      <td>28864.000000</td>\n",
-       "      <td>28864.000000</td>\n",
-       "      <td>1.863700e+04</td>\n",
-       "      <td>28864.000000</td>\n",
-       "      <td>1.843100e+04</td>\n",
-       "      <td>1.750400e+04</td>\n",
-       "      <td>17489.0000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>mean</th>\n",
-       "      <td>2021.181818</td>\n",
-       "      <td>6.318182</td>\n",
-       "      <td>3.534826e+05</td>\n",
-       "      <td>2022.926829</td>\n",
-       "      <td>3.532932e+05</td>\n",
-       "      <td>-1.746176e+03</td>\n",
-       "      <td>-inf</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>std</th>\n",
-       "      <td>2.124277</td>\n",
-       "      <td>3.482306</td>\n",
-       "      <td>1.470315e+06</td>\n",
-       "      <td>0.435631</td>\n",
-       "      <td>1.470108e+06</td>\n",
-       "      <td>5.259563e+05</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>min</th>\n",
-       "      <td>2018.000000</td>\n",
-       "      <td>1.000000</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>2019.000000</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>-1.516618e+07</td>\n",
-       "      <td>-inf</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25%</th>\n",
-       "      <td>2019.000000</td>\n",
-       "      <td>3.000000</td>\n",
-       "      <td>4.059000e+03</td>\n",
-       "      <td>2023.000000</td>\n",
-       "      <td>4.049000e+03</td>\n",
-       "      <td>-1.398500e+03</td>\n",
-       "      <td>-0.1090</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50%</th>\n",
-       "      <td>2021.000000</td>\n",
-       "      <td>6.000000</td>\n",
-       "      <td>2.258700e+04</td>\n",
-       "      <td>2023.000000</td>\n",
-       "      <td>2.250900e+04</td>\n",
-       "      <td>6.715000e+02</td>\n",
-       "      <td>0.0726</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>75%</th>\n",
-       "      <td>2023.000000</td>\n",
-       "      <td>9.000000</td>\n",
-       "      <td>1.411850e+05</td>\n",
-       "      <td>2023.000000</td>\n",
-       "      <td>1.410980e+05</td>\n",
-       "      <td>1.158700e+04</td>\n",
-       "      <td>0.2388</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>max</th>\n",
-       "      <td>2025.000000</td>\n",
-       "      <td>12.000000</td>\n",
-       "      <td>2.425492e+07</td>\n",
-       "      <td>2023.000000</td>\n",
-       "      <td>2.425492e+07</td>\n",
-       "      <td>6.711318e+06</td>\n",
-       "      <td>1.0000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        period_year  period_month           upt  last_report_year  \\\n",
-       "count  28864.000000  28864.000000  1.863700e+04      28864.000000   \n",
-       "mean    2021.181818      6.318182  3.534826e+05       2022.926829   \n",
-       "std        2.124277      3.482306  1.470315e+06          0.435631   \n",
-       "min     2018.000000      1.000000  0.000000e+00       2019.000000   \n",
-       "25%     2019.000000      3.000000  4.059000e+03       2023.000000   \n",
-       "50%     2021.000000      6.000000  2.258700e+04       2023.000000   \n",
-       "75%     2023.000000      9.000000  1.411850e+05       2023.000000   \n",
-       "max     2025.000000     12.000000  2.425492e+07       2023.000000   \n",
-       "\n",
-       "       previous_y_m_upt    change_1yr  pct_change_1yr  \n",
-       "count      1.843100e+04  1.750400e+04      17489.0000  \n",
-       "mean       3.532932e+05 -1.746176e+03            -inf  \n",
-       "std        1.470108e+06  5.259563e+05             NaN  \n",
-       "min        0.000000e+00 -1.516618e+07            -inf  \n",
-       "25%        4.049000e+03 -1.398500e+03         -0.1090  \n",
-       "50%        2.250900e+04  6.715000e+02          0.0726  \n",
-       "75%        1.410980e+05  1.158700e+04          0.2388  \n",
-       "max        2.425492e+07  6.711318e+06          1.0000  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "display(\n",
     "    data.info(),\n",
@@ -627,7 +818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "8dcbd833-9751-41d5-94b7-ec7f88a307c2",
    "metadata": {
     "tags": []
@@ -641,46 +832,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "ffd5153f-7ce0-4006-9aaf-3e017f0052fc",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array(['Butte County Association of Governments',\n",
-       "       'El Dorado County Transportation Commission',\n",
-       "       'Fresno Council of Governments',\n",
-       "       'Imperial County Transportation Commission',\n",
-       "       'Kern Council of Governments',\n",
-       "       'Kings County Association of Governments',\n",
-       "       'Los Angeles County Metropolitan Transportation Authority',\n",
-       "       'Merced County Association of Governments',\n",
-       "       'Metropolitan Transportation Commission',\n",
-       "       'Orange County Transportation Authority',\n",
-       "       'Placer County Transportation Planning Agency',\n",
-       "       'Riverside County Transportation Commission',\n",
-       "       'Sacramento Area Council of Governments',\n",
-       "       'San Bernardino County Transportation Authority',\n",
-       "       'San Diego Association of Governments',\n",
-       "       'San Joaquin Council of Governments',\n",
-       "       'Santa Barbara County Association of Governments',\n",
-       "       'Santa Cruz County Regional Transportation Commission',\n",
-       "       'Shasta Regional Transportation Agency',\n",
-       "       'Stanislaus Council of Governments',\n",
-       "       'Tahoe Regional Planning Agency',\n",
-       "       'Transportation Agency for Monterey County',\n",
-       "       'Tulare County Association of Governments',\n",
-       "       'Ventura County Transportation Commission'], dtype=object)"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_check[\"rtpa_name\"].sort_values().unique()\n",
     "# wher is SLOCOG??!?!\n",
@@ -689,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "3ca344b4-a186-4126-ad8b-94ab016942c5",
    "metadata": {
     "tags": []
@@ -729,179 +886,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "id": "d002304f-f6f3-47bf-b6f9-420d1ef69dea",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>ntd_id_2022</th>\n",
-       "      <th>rtpa_name</th>\n",
-       "      <th>mpo_name</th>\n",
-       "      <th>key</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>70</th>\n",
-       "      <td>San Luis Obispo Council of Governments</td>\n",
-       "      <td>90297</td>\n",
-       "      <td>San Luis Obispo Council of Governments</td>\n",
-       "      <td>None</td>\n",
-       "      <td>6f5660575e79129ff67bc2c54a2f6c1b</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>149</th>\n",
-       "      <td>City of San Luis Obispo</td>\n",
-       "      <td>90156</td>\n",
-       "      <td>San Diego Association of Governments</td>\n",
-       "      <td>San Diego Association of Governments</td>\n",
-       "      <td>113c74aa8cbc098bdd25c8275823f04f</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>216</th>\n",
-       "      <td>San Luis Obispo Regional Transit Authority</td>\n",
-       "      <td>90206</td>\n",
-       "      <td>San Diego Association of Governments</td>\n",
-       "      <td>San Diego Association of Governments</td>\n",
-       "      <td>64a73df3f0231d86d20dca85c271c312</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                           name ntd_id_2022  \\\n",
-       "70       San Luis Obispo Council of Governments       90297   \n",
-       "149                     City of San Luis Obispo       90156   \n",
-       "216  San Luis Obispo Regional Transit Authority       90206   \n",
-       "\n",
-       "                                  rtpa_name  \\\n",
-       "70   San Luis Obispo Council of Governments   \n",
-       "149    San Diego Association of Governments   \n",
-       "216    San Diego Association of Governments   \n",
-       "\n",
-       "                                 mpo_name                               key  \n",
-       "70                                   None  6f5660575e79129ff67bc2c54a2f6c1b  \n",
-       "149  San Diego Association of Governments  113c74aa8cbc098bdd25c8275823f04f  \n",
-       "216  San Diego Association of Governments  64a73df3f0231d86d20dca85c271c312  "
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ntd_rtpa_orgs[ntd_rtpa_orgs[\"name\"].str.contains(\"San Luis\")]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "574f74f4-69e3-4eb6-9767-680996f5a579",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Los Angeles        185\n",
-       "San Diego           80\n",
-       "Orange              68\n",
-       "Riverside           59\n",
-       "Alameda             54\n",
-       "San Bernardino      53\n",
-       "Santa Clara         46\n",
-       "San Francisco       43\n",
-       "San Mateo           38\n",
-       "Contra Costa        36\n",
-       "Fresno              33\n",
-       "Sacramento          32\n",
-       "Santa Barbara       26\n",
-       "Kern                26\n",
-       "Ventura             25\n",
-       "Monterey            25\n",
-       "Sonoma              24\n",
-       "San Joaquin         24\n",
-       "Humboldt            24\n",
-       "Mendocino           23\n",
-       "Marin               21\n",
-       "Stanislaus          19\n",
-       "San Luis Obispo     18\n",
-       "Tulare              17\n",
-       "Solano              16\n",
-       "Placer              14\n",
-       "Butte               14\n",
-       "Siskiyou            13\n",
-       "Merced              13\n",
-       "Imperial            13\n",
-       "Lake                12\n",
-       "Santa Cruz          12\n",
-       "Amador              12\n",
-       "Yolo                12\n",
-       "Inyo                11\n",
-       "El Dorado           11\n",
-       "Shasta              11\n",
-       "Del Norte           11\n",
-       "Kings               11\n",
-       "Lassen               9\n",
-       "Napa                 8\n",
-       "Tuolumne             8\n",
-       "Tehama               7\n",
-       "Modoc                7\n",
-       "Colusa               7\n",
-       "Madera               7\n",
-       "Plumas               6\n",
-       "Nevada               6\n",
-       "Mono                 6\n",
-       "San Benito           6\n",
-       "Sutter               5\n",
-       "Yuba                 5\n",
-       "Sierra               5\n",
-       "Calaveras            5\n",
-       "Glenn                5\n",
-       "Mariposa             3\n",
-       "Alpine               2\n",
-       "Trinity              2\n",
-       "Name: county_geography_name, dtype: int64"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bridge_counties[\"county_geography_name\"].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "a541efd3-a3b2-46bb-ac69-efc347c37f1e",
    "metadata": {
     "tags": []
@@ -918,76 +927,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "52043d7c-4751-475b-b231-50a467a4f57e",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>ntd_id_2022</th>\n",
-       "      <th>rtpa_name</th>\n",
-       "      <th>mpo_name</th>\n",
-       "      <th>key</th>\n",
-       "      <th>county_geography_name</th>\n",
-       "      <th>organization_key</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>70</th>\n",
-       "      <td>San Luis Obispo Council of Governments</td>\n",
-       "      <td>90297</td>\n",
-       "      <td>San Luis Obispo Council of Governments</td>\n",
-       "      <td>None</td>\n",
-       "      <td>6f5660575e79129ff67bc2c54a2f6c1b</td>\n",
-       "      <td>San Luis Obispo</td>\n",
-       "      <td>6f5660575e79129ff67bc2c54a2f6c1b</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                      name ntd_id_2022  \\\n",
-       "70  San Luis Obispo Council of Governments       90297   \n",
-       "\n",
-       "                                 rtpa_name mpo_name  \\\n",
-       "70  San Luis Obispo Council of Governments     None   \n",
-       "\n",
-       "                                 key county_geography_name  \\\n",
-       "70  6f5660575e79129ff67bc2c54a2f6c1b       San Luis Obispo   \n",
-       "\n",
-       "                    organization_key  \n",
-       "70  6f5660575e79129ff67bc2c54a2f6c1b  "
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ntd_to_rtpa_crosswalk[ntd_to_rtpa_crosswalk[\"rtpa_name\"].str.contains(\"San Luis\")]"
    ]

--- a/ntd/monthly_ridership_report/monthly_ridership_by_rtpa.py
+++ b/ntd/monthly_ridership_report/monthly_ridership_by_rtpa.py
@@ -14,7 +14,6 @@ import sys
 
 sys.path.append("../")  # up one level
 
-from calitp_data_analysis.tables import tbls
 from calitp_data_analysis.sql import to_snakecase
 from segment_speed_utils.project_vars import PUBLIC_GCS
 from update_vars import GCS_FILE_PATH, NTD_MODES, NTD_TOS, MONTH, YEAR


### PR DESCRIPTION
issue:
- #1657 
- 
removed siuba from `produce_ntd_monthly_ridership_by_rtpa` function. tested and confirm `query_sql` produces equivalent results and `monthly_ridership_by_rtpa.py` still runs.

