### PR TITLE
Analysis name patch

### DIFF
--- a/_shared_utils/shared_utils/export_portfolio_display_yml_airtable.ipynb
+++ b/_shared_utils/shared_utils/export_portfolio_display_yml_airtable.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0e2482bf-ab64-4435-b183-ec1ac4d2f293",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23b8a6ad-77ad-433f-bf3c-f639aff95fd9",
+   "metadata": {},
+   "source": [
+    "# Exporting Analysis Names to Airtable\n",
+    "\n",
+    "## Interim Documentation\n",
+    "\n",
+    "- `gtfs_funnel/crosswalk_gtfs_dataset_key_to_organization.py` is a dependency\n",
+    "    - part of the usual GTFS Funnel workflow and Makefile\n",
+    "- Run `../_shared_utils/shared_utils/create_portfolio_display_yaml.py`\n",
+    "- Download csv from Airtable of Schedule view of GTFS Datasets\n",
+    "- Very simple update script… (read csv -> lookup -> write csv)\n",
+    "- Open csv in Excel to copy column\n",
+    "- Csv must have a value in top cell even if no Analysis Name to paste properly\n",
+    "    - Script will add a placeholder if na\n",
+    "- Paste back into same Airtable view and check alignment\n",
+    "    - Delete top cell placeholder value if present"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cb1875ac-ca8c-48e8-bb58-56f5faa1ea00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airtable_gtfs_datasets_schedule = pd.read_csv('./gtfs datasets-Schedule.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "789444d5-9661-4f3b-9af2-5d91ad0faa67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airtable_gtfs_datasets_schedule = airtable_gtfs_datasets_schedule[['Name', 'Analysis Name']]\n",
+    "airtable_gtfs_datasets_schedule.Name = airtable_gtfs_datasets_schedule.Name.str.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "fa1bfc97-0d9e-45df-9e75-20ca60ad0481",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "airtable_gtfs_datasets_schedule = airtable_gtfs_datasets_schedule.assign(airtable_ix = range(1, airtable_gtfs_datasets_schedule.shape[0]+1))\n",
+    "airtable_gtfs_datasets_schedule = airtable_gtfs_datasets_schedule.set_index('airtable_ix')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "397ef259-49a6-4b46-ab2f-b5674f8d9c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('../_shared_utils/shared_utils/portfolio_organization_name.yml') as f:\n",
+    "    portfolio_organization_name = yaml.safe_load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "b2ab9059-a10a-4e7e-b9e8-eac92b2298f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# portfolio_organization_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "012ecace-b387-44f3-8dd0-c5f30e5795ad",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "airtable_ix\n",
+       "1                     AC Transit Alerts\n",
+       "2                   AC Transit Schedule\n",
+       "3                AC Transit TripUpdates\n",
+       "4           AC Transit VehiclePositions\n",
+       "5                          ACE Schedule\n",
+       "                     ...               \n",
+       "803           Yolobus Vehicle Positions\n",
+       "804    Yosemite Valley Shuttle Schedule\n",
+       "805                Yuba-Sutter Schedule\n",
+       "806                       Yuma Schedule\n",
+       "807                      Yurok Schedule\n",
+       "Name: Name, Length: 807, dtype: object"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "airtable_gtfs_datasets_schedule.Name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "8ea8918b-d7e7-4154-bb16-518ca3942b0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airtable_gtfs_datasets_schedule['Analysis Name'] = airtable_gtfs_datasets_schedule.Name.map(\n",
+    "    lambda x: portfolio_organization_name[x] if x in portfolio_organization_name.keys() else None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "4808e774-36bd-4e5e-8a68-1d2d3ccef0d8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if not airtable_gtfs_datasets_schedule.iloc[0,1]:\n",
+    "    airtable_gtfs_datasets_schedule.iloc[0,1] = '_placeholder, delete after pasting to Airtable'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "3158b4de-03fc-401c-8925-df6602f6e70e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'_placeholder, delete after pasting to Airtable'"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "airtable_gtfs_datasets_schedule.iloc[0,1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "cabedaec-4709-48b2-b4e0-5c4afb56e20a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Analysis Name</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>airtable_ix</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AC Transit Alerts</td>\n",
+       "      <td>_placeholder, delete after pasting to Airtable</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AC Transit Schedule</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AC Transit TripUpdates</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AC Transit VehiclePositions</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>ACE Schedule</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>803</th>\n",
+       "      <td>Yolobus Vehicle Positions</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>804</th>\n",
+       "      <td>Yosemite Valley Shuttle Schedule</td>\n",
+       "      <td>Yosemite National Park</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>805</th>\n",
+       "      <td>Yuba-Sutter Schedule</td>\n",
+       "      <td>Yuba-Sutter Transit Authority</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>806</th>\n",
+       "      <td>Yuma Schedule</td>\n",
+       "      <td>Yuma County Intergovernmental Public Transport...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>807</th>\n",
+       "      <td>Yurok Schedule</td>\n",
+       "      <td>Yurok Tribe</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>807 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                         Name  \\\n",
+       "airtable_ix                                     \n",
+       "1                           AC Transit Alerts   \n",
+       "2                         AC Transit Schedule   \n",
+       "3                      AC Transit TripUpdates   \n",
+       "4                 AC Transit VehiclePositions   \n",
+       "5                                ACE Schedule   \n",
+       "...                                       ...   \n",
+       "803                 Yolobus Vehicle Positions   \n",
+       "804          Yosemite Valley Shuttle Schedule   \n",
+       "805                      Yuba-Sutter Schedule   \n",
+       "806                             Yuma Schedule   \n",
+       "807                            Yurok Schedule   \n",
+       "\n",
+       "                                                 Analysis Name  \n",
+       "airtable_ix                                                     \n",
+       "1               _placeholder, delete after pasting to Airtable  \n",
+       "2                                                         None  \n",
+       "3                                                         None  \n",
+       "4                                                         None  \n",
+       "5                                                         None  \n",
+       "...                                                        ...  \n",
+       "803                                                       None  \n",
+       "804                                     Yosemite National Park  \n",
+       "805                              Yuba-Sutter Transit Authority  \n",
+       "806          Yuma County Intergovernmental Public Transport...  \n",
+       "807                                                Yurok Tribe  \n",
+       "\n",
+       "[807 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "airtable_gtfs_datasets_schedule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "898102fd-2a95-4c17-9174-5ae5dbdf11b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airtable_gtfs_datasets_schedule.to_csv('output.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/portfolio/portfolio_name_testing.ipynb
+++ b/portfolio/portfolio_name_testing.ipynb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c2783d31394e7d71c8715152115c4c7dcd225f9cfeeeff609f4e3818f81fc89
-size 10664

--- a/portfolio/portfolio_name_testing.ipynb
+++ b/portfolio/portfolio_name_testing.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c38bdabc6588e1363d6dea1c08872ebb241b38fd071890b1e745e6e41bc37b2
-size 8849
+oid sha256:3c2783d31394e7d71c8715152115c4c7dcd225f9cfeeeff609f4e3818f81fc89
+size 10664


### PR DESCRIPTION
- move Airtable comparison and export notebook for portfolio display names (analysis name) into shared_utils alongside yml export script
- match Airtable index numbers for easier comparison
- strip spaces from Airtable csv