### PR TITLE
Fix failure in pre-commit hook by updating flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: ["--ignore=E501,W503,F403,F405,E711,E712,E231,E702,E203"] 


### PR DESCRIPTION
Flake8 was failing with `"pyflakes[F]" failed during execution due to AttributeError("module 'ast' has no attribute 'Str'")`. Updating flake8 from 6.0.0 to 7.3.0 fixes this issue.