### PR TITLE
Add End of Year Calculations to Holiday Service Mismatch Query

### DIFF
--- a/holiday_service_research/holiday_service_mismatch.sql
+++ b/holiday_service_research/holiday_service_mismatch.sql
@@ -3,6 +3,12 @@
  * and the actual service data in their GTFS feeds for specific holidays in late 2025 and early 2026.
  * It combines data from a GTFS staging table, an external Airtable with holiday schedules, and GTFS trip data.
  * This serves as a baseline for further analysis on holiday service discrepancies.
+ *
+ * Key definitions:
+ * reduced_reference_holiday_name: reduced service (weekend) reference counts for the corresponding holiday
+ * regular_reference_holiday_name: regular service reference counts for the corresponding holiday
+ * red_ratio_holiday_name: referenced ratio of reduced service (weekend) trips to regular weekday trips for the corresponding holiday
+ * holiday_name_ratio: actual ratio of holiday service to regular weekday service reference for the corresponding holiday
  */
 WITH
   the_bridge AS (


### PR DESCRIPTION
This PR adds End of Year analysis to the holiday service mismatch query. Same logic as Thanksgiving analysis.

For End of Year analysis, 12/17 (Wednesday) is picked as regular service reference, and the 12/13 weekend is picked as reduced service reference.