### PR TITLE
Fix `filter_dim_county_geography` dup columns issue

### DIFF
--- a/_shared_utils/shared_utils/schedule_rt_utils.py
+++ b/_shared_utils/shared_utils/schedule_rt_utils.py
@@ -256,7 +256,7 @@ def filter_dim_county_geography(
 
     df = pd.read_sql(statement, session.bind)
 
-    return df[["organization_name", "caltrans_district"] + keep_cols].drop_duplicates().reset_index(drop=True)
+    return df[set(["organization_name", "caltrans_district"] + keep_cols)].drop_duplicates().reset_index(drop=True)
 
 
 def filter_dim_organizations(

--- a/_shared_utils/tests/shared_utils/test_schedule_rt_utils.py
+++ b/_shared_utils/tests/shared_utils/test_schedule_rt_utils.py
@@ -181,6 +181,8 @@ class TestScheduleRtUtils:
             ]
         )
 
+        assert result.columns.is_unique == True
+
     @pytest.mark.vcr
     def test_filter_dim_organizations(self, project: str, dataset: str):
         result = filter_dim_organizations(project=project, dataset=dataset)


### PR DESCRIPTION
Fix `shared_utils.schedule_rt_utils.filter_dim_county_geography` where duplicate columns were return from a dataframe.

Resolves https://github.com/cal-itp/data-analyses/issues/1772