### PR TITLE
Fix issue with pre-commit hook and pushes to `main`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,10 +9,24 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - id: changed-files
-      uses: tj-actions/changed-files@v47
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v47
+
+    - name: List changed files
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        for file in ${ALL_CHANGED_FILES}; do
+          echo "$file was changed"
+        done
+
     - uses: actions/setup-python@v3
+
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Pushes to `main`, including PR merges, have been failing the pre-commit GH Action. Following guidance from [`tj-action/changed-files`](https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F) to hopefully resolve this issue.

Resolves https://github.com/cal-itp/data-analyses/issues/1767