### PR TITLE
Allow setting different test dataset for models in `shared_utils`

### DIFF
--- a/_shared_utils/shared_utils/models/base.py
+++ b/_shared_utils/shared_utils/models/base.py
@@ -1,8 +1,13 @@
+import os
 import sys
 
 
 def get_table_name(dataset, table):
     if hasattr(sys, "_called_from_test"):
-        return f"test_shared_utils.{table}"
+        if "TEST_DATASET" in os.environ:
+            return f"{os.environ['TEST_DATASET']}.{table}"
+        else:
+            raise KeyError("You must set TEST_DATASET in your conftest.py to use these models in tests.")
+
     else:
         return f"{dataset}.{table}"

--- a/_shared_utils/tests/conftest.py
+++ b/_shared_utils/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 
 import pytest
@@ -7,10 +8,12 @@ from vcr.request import Request
 
 def pytest_configure(config):
     sys._called_from_test = True
+    os.environ["TEST_DATASET"] = "test_shared_utils"
 
 
 def pytest_unconfigure(config):
     del sys._called_from_test
+    del os.environ["TEST_DATASET"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR allows setting a different test dataset than `cal-itp-data-infra-staging.test_shared_utils` for models in `shared_utils`. This will be useful for any testing that happens outside of the `shared_utils` module where the test writer wants an different dataset, but still wants to use SQLAlchemy models defined in `shared_utils`.