### PR TITLE
Use `sqlalchemy.TIMESTAMP` column type

### DIFF
--- a/_shared_utils/shared_utils/models/bridge_organization_x_headquarters_county_geography.py
+++ b/_shared_utils/shared_utils/models/bridge_organization_x_headquarters_county_geography.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, DateTime, String
+from sqlalchemy import TIMESTAMP, Boolean, Column, String
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -17,6 +17,6 @@ class BridgeOrganizationXHeadquartersCountyGeography(Base):
     county_geography_key = Column(String)
     organization_name = Column(String)
     county_geography_name = Column(String)
-    _valid_from = Column(DateTime)
-    _valid_to = Column(DateTime)
+    _valid_from = Column(TIMESTAMP)
+    _valid_to = Column(TIMESTAMP)
     _is_current = Column(Boolean)

--- a/_shared_utils/shared_utils/models/dim_county_geography.py
+++ b/_shared_utils/shared_utils/models/dim_county_geography.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, String
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -24,5 +24,5 @@ class DimCountyGeography(Base):
     organization_key = Column(String)
     service_key = Column(String)
     _is_current = Column(Boolean)
-    _valid_from = Column(DateTime)
-    _valid_to = Column(DateTime)
+    _valid_from = Column(TIMESTAMP)
+    _valid_to = Column(TIMESTAMP)

--- a/_shared_utils/shared_utils/models/dim_gtfs_dataset.py
+++ b/_shared_utils/shared_utils/models/dim_gtfs_dataset.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, Date, DateTime, String
+from sqlalchemy import TIMESTAMP, Boolean, Column, Date, String
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -34,5 +34,5 @@ class DimGtfsDataset(Base):
     private_dataset = Column(Boolean)
     analysis_name = Column(String)
     _is_current = Column(Boolean)
-    _valid_from = Column(DateTime)
-    _valid_to = Column(DateTime)
+    _valid_from = Column(TIMESTAMP)
+    _valid_to = Column(TIMESTAMP)

--- a/_shared_utils/shared_utils/models/dim_organization.py
+++ b/_shared_utils/shared_utils/models/dim_organization.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, String
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -39,5 +39,5 @@ class DimOrganization(Base):
     public_currently_operating = Column(Boolean)
     public_currently_operating_fixed_route = Column(Boolean)
     _is_current = Column(Boolean)
-    _valid_from = Column(DateTime)
-    _valid_to = Column(DateTime)
+    _valid_from = Column(TIMESTAMP)
+    _valid_to = Column(TIMESTAMP)

--- a/_shared_utils/shared_utils/models/dim_provider_gtfs_data.py
+++ b/_shared_utils/shared_utils/models/dim_provider_gtfs_data.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, String
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -40,6 +40,6 @@ class DimProviderGtfsData(Base):
     service_alerts_gtfs_dataset_key = Column(String)
     vehicle_positions_gtfs_dataset_key = Column(String)
     trip_updates_gtfs_dataset_key = Column(String)
-    _valid_from = Column(DateTime)
-    _valid_to = Column(DateTime)
+    _valid_from = Column(TIMESTAMP)
+    _valid_to = Column(TIMESTAMP)
     _is_current = Column(Boolean)

--- a/_shared_utils/shared_utils/models/dim_stop_time.py
+++ b/_shared_utils/shared_utils/models/dim_stop_time.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, Date, DateTime, Integer, Numeric, String, Time
+from sqlalchemy import TIMESTAMP, Boolean, Column, Date, Integer, Numeric, String, Time
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -37,7 +37,7 @@ class DimStopTime(Base):
     warning_duplicate_gtfs_key = Column(Boolean)
     warning_missing_foreign_key_stop_id = Column(Boolean)
     _dt = Column(Date)
-    _feed_valid_from = Column(DateTime)
+    _feed_valid_from = Column(TIMESTAMP)
     _line_number = Column(Integer)
     feed_timezone = Column(String)
     arrival_sec = Column(Integer)

--- a/_shared_utils/shared_utils/models/fct_daily_scheduled_stop.py
+++ b/_shared_utils/shared_utils/models/fct_daily_scheduled_stop.py
@@ -1,5 +1,5 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, Date, DateTime, Integer, String
+from sqlalchemy import TIMESTAMP, Boolean, Column, Date, DateTime, Integer, String
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -21,7 +21,7 @@ class FctDailyScheduledStop(Base):
     stop_event_count = Column(Integer)
     first_stop_arrival_datetime_pacific = Column(DateTime)
     last_stop_departure_datetime_pacific = Column(DateTime)
-    _feed_valid_from = Column(DateTime)
+    _feed_valid_from = Column(TIMESTAMP)
     route_type_0 = Column(Integer)
     route_type_1 = Column(Integer)
     route_type_2 = Column(Integer)

--- a/_shared_utils/shared_utils/models/fct_scheduled_trip.py
+++ b/_shared_utils/shared_utils/models/fct_scheduled_trip.py
@@ -1,5 +1,14 @@
 from shared_utils.models.base import get_table_name
-from sqlalchemy import Boolean, Column, Date, DateTime, Float, Integer, String
+from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    Integer,
+    String,
+)
 from sqlalchemy.orm import declarative_base, declared_attr
 
 Base = declarative_base()
@@ -55,8 +64,8 @@ class FctScheduledTrip(Base):
     flex_service_hours = Column(Float)
     contains_warning_duplicate_stop_times_primary_key = Column(Boolean)
     contains_warning_missing_foreign_key_stop_id = Column(Boolean)
-    trip_first_departure_ts = Column(DateTime)
-    trip_last_arrival_ts = Column(DateTime)
+    trip_first_departure_ts = Column(TIMESTAMP)
+    trip_last_arrival_ts = Column(TIMESTAMP)
     first_start_pickup_drop_off_window_sec = Column(Integer)
     last_end_pickup_drop_off_window_sec = Column(Integer)
     is_gtfs_flex_trip = Column(Boolean)
@@ -66,8 +75,8 @@ class FctScheduledTrip(Base):
     num_exact_timepoint_stop_times = Column(Integer)
     num_arrival_times_populated_stop_times = Column(Integer)
     num_departure_times_populated_stop_times = Column(Integer)
-    trip_first_start_pickup_drop_off_window_ts = Column(DateTime)
-    trip_last_end_pickup_drop_off_window_ts = Column(DateTime)
+    trip_first_start_pickup_drop_off_window_ts = Column(TIMESTAMP)
+    trip_last_end_pickup_drop_off_window_ts = Column(TIMESTAMP)
     trip_start_date_pacific = Column(Date)
     trip_first_departure_datetime_pacific = Column(DateTime)
     trip_last_arrival_datetime_pacific = Column(DateTime)


### PR DESCRIPTION
This PR uses the TIMESTAMP type instead of DateTime where appropriate. Just learned that SQLAlchemy has this type and it's a better match for the BigQuery timestamp type columns.