### PR TITLE
[_shared_utils] Upgrade to SQLAlchemy 2.0, remove siuba package dependency

### DIFF
--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 altair-transform==0.2.0
-calitp-data-analysis==2025.8.10
+calitp-data-analysis==2025.12.17
 great_tables==0.16.1
 intake==0.6.4
 numba (>=0.62.1, <0.63.0)
@@ -13,7 +13,7 @@ pytest-recording (>=0.13.4,<0.14.0)
 pytest-unordered (>=0.7.0,<0.8.0)
 quarto==0.1.0
 quarto-cli==1.6.40
-sqlalchemy==1.4.46
+sqlalchemy==2.0.45
 vegafusion==2.0.2
 vl-convert-python>=1.6.0
 movingpandas==0.22.4

--- a/_shared_utils/shared_utils/gtfs_utils_v2.py
+++ b/_shared_utils/shared_utils/gtfs_utils_v2.py
@@ -215,7 +215,7 @@ def schedule_daily_feed_to_gtfs_dataset_name(
         for column in keep_cols:
             new_column = DimGtfsDataset.name if column == "name" else getattr(FctDailyScheduleFeed, column)
             columns.append(new_column)
-        statement = statement.with_only_columns(columns)
+        statement = statement.with_only_columns(*columns)
 
     if get_df:
         with DBSession() as session:


### PR DESCRIPTION
This PR upgrades SQLAlchemy to 2.0 and calitp-data-analysis package to a new version without siuba. 

Relates to https://github.com/cal-itp/data-infra/issues/3739