### PR TITLE
[_shared_utils] Remove packages that image already defines

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,9 +34,9 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install share_utils dependencies
+      - name: Install shared_utils dependencies
         working-directory: _shared_utils/
-        run: pip install -r requirements.txt
+        run: pip install -r requirements_non_jupyterhub.txt
 
       - name: Run shared_utils tests
         working-directory: _shared_utils/

--- a/_shared_utils/requirements.txt
+++ b/_shared_utils/requirements.txt
@@ -1,19 +1,11 @@
 -e .
 altair-transform==0.2.0
-calitp-data-analysis==2025.12.17
 great_tables==0.16.1
-intake==0.6.4
 numba (>=0.62.1, <0.63.0)
-numpy (>=1.26.4, <2.0.0)
 omegaconf==2.3.0 # better yaml configuration
 polars==1.22.0
-pytest (>=8.4.1, <9.0.0)
-pytest-mock (>=3.15.1, <4.0.0)
-pytest-recording (>=0.13.4,<0.14.0)
-pytest-unordered (>=0.7.0,<0.8.0)
 quarto==0.1.0
 quarto-cli==1.6.40
-sqlalchemy==2.0.45
 vegafusion==2.0.2
 vl-convert-python>=1.6.0
 movingpandas==0.22.4

--- a/_shared_utils/requirements_non_jupyterhub.txt
+++ b/_shared_utils/requirements_non_jupyterhub.txt
@@ -1,0 +1,8 @@
+-r requirements.txt
+calitp-data-analysis==2025.12.17
+intake==0.6.4
+numpy (>=1.26.4, <2.0.0)
+pytest (>=8.4.1, <9.0.0)
+pytest-mock (>=3.15.1, <4.0.0)
+pytest-recording (>=0.13.4,<0.14.0)
+pytest-unordered (>=0.7.0,<0.8.0)


### PR DESCRIPTION
This PR removes packages from `requirements.txt` that the `jupyter-singleuser` image pulls in so that these don't clash with the image as we're doing packages upgrades there. It would be ideal to define all packages needed by `_shared_utils` in one place (here). Hopefully we can get to that point soon.