### PR TITLE
potential detours (scheduled stops + vp path) MVP data product

### DIFF
--- a/rt_predictions/README_detour_stops.md
+++ b/rt_predictions/README_detour_stops.md
@@ -1,0 +1,16 @@
+# README
+
+Use GTFS Real-Time vehicle positions to find where the positions we're capturing did not get near a scheduled stop.
+
+To start, we calculate is which and how many vehicle positions got within 10 meters, 25 meters, 50 meters, and 100 meters of a stop for that trip.
+
+
+Starting heuristics:
+To get at whether real-time stops were serviced, we need to know whether we captured vehicle positions near the scheduled stop for that trip.
+
+For stops that are eventually detoured or out of service, vehicle positions would likely get near enough (serving surrounding stops) while skipping the stop in question. Also, real-time vehicle positions information must be available enough that day for that stop (out of all the scheduled trips for that stop, from `stop_times`, how many of these trips had vehicle positions data? Let's assume at least 20% of the trips had real-time information.
+
+All the following conditions must be met.
+* zero vehicle positions within 10 meters, 25 meters, and 50 meters of a stop
+* some threshold (50? 100? distinct vehicle positions) were captured within 100 meters of the stop
+* at least 20% of the scheduled trips had vehicle positions

--- a/rt_predictions/detour_stops.ipynb
+++ b/rt_predictions/detour_stops.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e53cbaa4-a146-498f-a240-f9800219e4a1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import pandas as pd\n",
+    "import calitp_data_analysis.magics\n",
+    "import prep_vp_detour_stops as prep_vp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ca2eebf-74b9-4bc5-af57-c1e2ed2bc307",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Comment out, this is `parameters` tagged cell\n",
+    "#name = \"Montebello Vehicle Positions\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "679cd4a0-e0ed-450d-bb2d-04c4299100d1",
+   "metadata": {},
+   "source": [
+    "# {name} \n",
+    "\n",
+    "## Potential detour stops \n",
+    "1. Stop has at least 20% of its scheduled trips served by vehicle positions.\n",
+    "2. There are zero vehicle positions within 10, 25, and 50 meters.\n",
+    "3. There are at least 10 distinct vehicle positions within 100 meters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16964774-44ad-4fbd-a889-a9e44ff04e73",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "stop_gdf = prep_vp.prep_fct_vp_stop_metrics(\n",
+    "    filters = [[(\"vp_name\", \"==\", name)]]\n",
+    ")\n",
+    "vp_path = prep_vp.prep_vp_path(\n",
+    "    filters = [[(\"gtfs_dataset_name\", \"==\", name)]]\n",
+    ") \n",
+    "\n",
+    "intermediate_df = prep_vp.prep_intermediate_vp_stops_trip_crosswalk(\n",
+    "    filters = [[(\"feed_key\", \"==\", stop_gdf.feed_key.iloc[0])]]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "969eb111-e6ab-4257-8610-921bb38a8e43",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# 10 vp near 100m, this is capturing a lot of rows now\n",
+    "gdf = prep_vp.filter_to_potential_detour_stops(\n",
+    "    stop_gdf,\n",
+    "    intermediate_df,\n",
+    "    vp_path,\n",
+    "    [10, 0, 0, 0, 0.2]\n",
+    ")\n",
+    "\n",
+    "print(\"trip_instance_keys with potential detour stops\")\n",
+    "gdf.trip_instance_key.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10a590c6-347c-4eef-a338-7d099a7c4963",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "stop_summary = (\n",
+    "    gdf\n",
+    "    .groupby([\"stop_id\", \"n_vp_near_100m\", \"pct_vp_trips\"])\n",
+    "    .agg({\"trip_instance_key\": lambda x: list(x)})\n",
+    "    .reset_index()\n",
+    ")\n",
+    "\n",
+    "stop_summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e06047e8-4f7b-4aa8-ac2e-4a4158b9217a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "prep_vp.plot_stops_and_exploded_vp(\n",
+    "    gdf\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa98ace3-d7f0-4b77-9519-c4beacafcd7b",
+   "metadata": {},
+   "source": [
+    "### Robustness and Sensitivity of Cutoffs\n",
+    "\n",
+    "More sensitive to what n_vp_cutoff is, rather than pct_vp_trips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "896b8716-36d6-4486-87a1-7b5cec17eca9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def adjust_filters(n_vp_cutoff, pct_vp):\n",
+    "    test = prep_vp.filter_to_potential_detour_stops(\n",
+    "        stop_gdf,\n",
+    "        intermediate_df,\n",
+    "        vp_path,\n",
+    "        [n_vp_cutoff, 0, 0, 0, pct_vp]\n",
+    "    )\n",
+    "\n",
+    "    results = len(test)\n",
+    "    \n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c7af90d-2b21-406a-a9c4-a963cd2c4ee3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vp_series = []\n",
+    "pct_series = []\n",
+    "n_trips_series = []\n",
+    "for vp in [50, 25, 10]:\n",
+    "    for pct in [0.1, 0.15, 0.2, 0.25, 0.3, 0.35]:\n",
+    "            \n",
+    "        results = adjust_filters(vp, pct)\n",
+    "        vp_series.append(vp)\n",
+    "        pct_series.append(pct)\n",
+    "        n_trips_series.append(results)\n",
+    "\n",
+    "\n",
+    "results_df = pd.DataFrame()\n",
+    "results_df = results_df.assign(\n",
+    "    at_least_vp = vp_series,\n",
+    "    pct_vp = pct_series,\n",
+    "    n_trips = n_trips_series\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b532360-091e-4ab9-a734-b56d99c5b6e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16ed6787-cc15-476e-932d-9a5c1ed12514",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rt_predictions/prep_vp_detour_stops.py
+++ b/rt_predictions/prep_vp_detour_stops.py
@@ -1,0 +1,201 @@
+"""
+# Plot vp path for stops that have low percent of vp trips
+
+1. `fct_vp_stop_metrics`
+
+* no configs yet, it's a table for now with no partitioning or clustering
+* partitioned by
+* clustered by
+* grain: `service_date-feed_key-stop_id`
+
+Daily counts for a of how many `n_(vp)_trips` and `n_vp` showed up within 10m, 25m, 50m, and 100m of a stop.
+
+2. `fct_vp_path`
+
+* partitioned by `service_date`
+* clustered by `(vp)_base64_url`, `schedule_base64_url`
+* grain: `service_date-trip_instance_key`
+Daily vp paths so we can use for a map. For the stops that had very few vp getting near it, here's where we want to see if the vp_path is detouring around it.
+
+3. `int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping`
+
+* partitioned by `dt`
+* clustered by `dt`, `vp_base64_url`, `feed_key`
+`service_date-trip_instance_key-vp_base64_url-feed_key-stop_id`
+"""
+
+import folium
+import geopandas as gpd
+import google.auth
+import pandas as pd
+import warehouse_utils
+from rt_msa_utils import RT_MSA_DICT, VP_GCS
+from shared_utils import catalog_utils, rt_dates
+
+credentials, project = google.auth.default()
+GTFS_DATA_DICT = catalog_utils.get_catalog("gtfs_analytics_data")
+
+
+def prep_fct_vp_stop_metrics(
+    file_name: str = RT_MSA_DICT.rt_vehicle_position_models.daily_stop_grain, **kwargs
+) -> gpd.GeoDataFrame:
+    """
+    Any data wrangling related to fct_vp_stop_metrics.
+    Take a pass through to see what can be worked into
+    earlier download step or into warehouse.
+    """
+    stop_gdf = gpd.read_parquet(f"{VP_GCS}{file_name}.parquet", storage_options={"token": credentials.token}, **kwargs)
+
+    # We want to capture stops that had "enough" vp trips serving the stop
+    # Compare trips with vp passing through stop vs scheduled trips
+    # Do not use stops that had extra low pct_vp_trips for potential detours
+    stop_gdf = stop_gdf.assign(pct_vp_trips=stop_gdf.n_vp_trips.divide(stop_gdf.n_trips).round(3))
+
+    return stop_gdf
+
+
+def prep_vp_path(file_name: str = GTFS_DATA_DICT.speeds_tables.vp_path, **kwargs) -> pd.DataFrame:
+    """
+    Any data wrangling related to vp path.
+    Take a pass through to see what can be worked into
+    earlier download step or into warehouse.
+    """
+    SEGMENT_GCS = GTFS_DATA_DICT.speeds_tables.dir
+    analysis_date = rt_dates.DATES["oct2025"]
+
+    vp_path = pd.read_parquet(
+        f"{SEGMENT_GCS}{file_name}_{analysis_date}.parquet",
+        **kwargs,
+        columns=["gtfs_dataset_name", "base64_url", "service_date", "trip_instance_key", "trip_id", "pt_array"],
+    )
+
+    # this needs to be handled at download
+    vp_path = vp_path.assign(service_date=pd.to_datetime(vp_path.service_date))
+
+    return vp_path
+
+
+def prep_intermediate_vp_stops_trip_crosswalk(
+    file_name: str = "int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping", **kwargs
+) -> pd.DataFrame:
+    """
+    This intermediate table acts like a bridge.
+    For the stops that we want to plot all the vp paths, we need to know which
+    trip_instance_keys to pull from vp_path.
+    """
+    analysis_date = rt_dates.DATES["oct2025"]
+
+    vp_stops_to_trips = pd.read_parquet(
+        f"{VP_GCS}{file_name}_{analysis_date}_{analysis_date}.parquet",
+        columns=["service_date", "base64_url", "feed_key", "trip_instance_key", "stop_id"],
+        **kwargs,
+    ).rename(columns={"base64_url": "vp_base64_url"})
+
+    return vp_stops_to_trips
+
+
+def plot_stops_and_exploded_vp(gdf: gpd.GeoDataFrame):
+    """
+    Plot stops that potentially could have detours,
+    and also the exploded vp points
+    """
+    keep_cols = [
+        "vp_name",
+        "stop_id",
+        "stop_name",
+        "pct_vp_trips",
+        "n_vp_near_10m",
+        "n_vp_near_25m",
+        "n_vp_near_50m",
+        "n_vp_near_100m",
+        "geometry",
+    ]
+
+    # Change marker size, even change according to value in column
+    # https://stackoverflow.com/questions/73884448/geopandas-explore-marker-size-according-to-score
+    # style_kwds={"style_function":lambda x: {"radius":x["properties"]["Score"]}}
+    m = gdf[keep_cols].explore(
+        "stop_id",
+        legend=False,
+        tiles="CartoDB Positron",
+        name="vp within 10m of stop",
+        marker_kwds={
+            "radius": 5,
+        },
+    )
+
+    vp_gdf = (
+        gdf[["trip_instance_key", "pt_array"]]
+        .explode("pt_array")
+        .pipe(warehouse_utils.convert_to_gdf, geom_col="pt_array", geom_type="point")
+    )
+
+    # https://github.com/posit-dev/great-tables/blob/main/great_tables/_data_color/constants.py
+    # quickly grab color palette we want to iterate through so each vp path is distinguishable
+    viridis_color_palette = [
+        # "#440154",
+        # "#482878",
+        "#3E4989",
+        # "#31688E",
+        "#26828E",
+        # "#1F9E89",
+        "#35B779",
+        # "#6DCD59",
+        "#B4DD2C",
+        "#FDE725",
+    ]
+
+    # How should multiple trips be plotted?
+    # Would like to select trips to display/turn off on map, but only if
+    # this can get crazy when there are a lot of trips being displayed in the legend
+    m = vp_gdf.explore("trip_instance_key", m=m, cmap=viridis_color_palette, name="vp path", legend=False)
+
+    folium.LayerControl().add_to(m)
+
+    return m
+
+
+def filter_to_potential_detour_stops(
+    stop_gdf: gpd.GeoDataFrame, intermediate_crosswalk: pd.DataFrame, vp_path: gpd.GeoDataFrame, cutoffs: list
+) -> gpd.GeoDataFrame:
+    """
+    Filter to stops that potentially are detours,
+    merge in crosswalk to get vp path for these stops
+    """
+
+    gdf = (
+        stop_gdf[
+            (stop_gdf.n_vp_near_100m > cutoffs[0])
+            & (stop_gdf.n_vp_near_50m == cutoffs[1])
+            & (stop_gdf.n_vp_near_25m == cutoffs[2])
+            & (stop_gdf.n_vp_near_10m == cutoffs[3])
+            & (stop_gdf.pct_vp_trips >= cutoffs[4])
+        ]
+        .merge(intermediate_crosswalk, on=["service_date", "feed_key", "vp_base64_url", "stop_id"], how="inner")
+        .merge(
+            vp_path.rename(
+                columns={
+                    "gtfs_dataset_name": "vp_name",
+                    "base64_url": "vp_base64_url",
+                }
+            ),
+            on=["service_date", "vp_base64_url", "vp_name", "trip_instance_key"],
+            how="inner",
+        )
+    )
+
+    return gdf
+
+
+"""
+# try 50, 100, 10, 75
+gdf = filter_to_potential_detour_stops(
+    stop_gdf,
+    intermediate_df,
+    vp_path,
+    [50, 0, 0, 0, 0.2]
+)
+
+gdf.shape
+display(gdf.vp_name.value_counts())
+"""


### PR DESCRIPTION
* One way to find potential detour stops is to compare scheduled stops with vehicle positions.
   * vehicle positions need to serve stops along that trip more generally, but may not get near a particular stop
* Only a couple of operators met the filters (had zero vehicle positions get near 10m, 25m, 50m of a stop, but had vehicle positions get near 100m of a stop). 
* Visualize trips for 1 day as an MVP to see what we're getting
   * Only found 1 operator where this actually does look like a detour, the other ones seem to be traveling along the desired path
   * But why wouldn't we be getting vehicle positions near those stops? Presumably bus/train is stopping near the stop and idling
* vp path is challenging to visualize, we want to know the points to see where we're capturing it, but that means we're plotting a lot of points close together 
* https://github.com/cal-itp/data-infra/issues/4034