### PR TITLE
Enable shared memory for portfolio accessibility checks

### DIFF
--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -522,6 +522,9 @@ def check_accessibility(site: SiteChoices):
     opts.headless = True
     opts.add_argument("--headless")
     opts.add_argument("--no-sandbox")
+    # The /dev/shm partition is too small in certain VM environments, causing Chrome to fail or crash (see http://crbug.com/715363).
+    # Use this flag to work-around this issue (a temporary directory will always be used to create anonymous shared memory files).
+    opts.add_argument("--disable-dev-shm-usage")
     driver = webdriver.Chrome(options=opts)
     axe = Axe(driver)
 
@@ -559,14 +562,9 @@ def check_accessibility(site: SiteChoices):
                 print(f"- {impact}  {violation['help']} ({violation['helpUrl']}):")
                 print(f"  {find_key_recursive(violation, 'failureSummary')}")
                 print(f"  {find_key_recursive(violation, 'html')}")
-                # print("-----")
-                # print(violation)
-                # print("-----")
                 print("\n")
         else:
             print(f"✅ {file_path}.\n")
-        # print("Press Enter to continue...")
-        # input()
 
     driver.quit()
     return serious_count


### PR DESCRIPTION
We were seeing chrome tabs crash when running portfolio site accessibility checks. See below for sample stack trace. After some investigation, I found that selenium uses `/dev/shm` for any shared memory needed to run these checks. This directory is too small in certain VM environments (including ours) and is not possible to change. Passing the flag `--disable-dev-shm-usage` allows selenium to use a tmp directory instead and the checks run smoothly after that.

```
Traceback (most recent call last):
 
  File "/home/jovyan/data-analyses/portfolio/portfolio.py", line 576, in <module>
    app()
 
  File "/home/jovyan/data-analyses/portfolio/portfolio.py", line 454, in build
    accessibilty_errors = check_accessibility(site)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
  File "/home/jovyan/data-analyses/portfolio/portfolio.py", line 548, in check_accessibility
    driver.get(f"file:///{file_path}")
 
  File "/opt/conda/lib/python3.11/site-packages/selenium/webdriver/remote/webdriver.py", line 452, in get
    self.execute(Command.GET, {"url": url})
 
  File "/opt/conda/lib/python3.11/site-packages/selenium/webdriver/remote/webdriver.py", line 432, in execute
    self.error_handler.check_response(response)
 
  File "/opt/conda/lib/python3.11/site-packages/selenium/webdriver/remote/errorhandler.py", line 232, in check_response
    raise exception_class(message, screen, stacktrace)
 
selenium.common.exceptions.WebDriverException: Message: tab crashed
  (Session info: chrome=143.0.7499.109)
```

Related to https://github.com/cal-itp/data-analyses/issues/1802 and https://github.com/cal-itp/data-analyses/issues/1854