### PR TITLE
Stop using Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-portfolio/**/*.ipynb filter=lfs diff=lfs merge=lfs -text
-portfolio/**/**/*.ipynb filter=lfs diff=lfs merge=lfs -text
-“portfolio/**/**/*.ipynb” filter=lfs diff=lfs merge=lfs -text
-“portfolio/**/*.ipynb” filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
To better describe how to remove Git LFS (issue https://github.com/cal-itp/data-analyses/issues/1875) from `data-analyses` repo I created this PR.

This PR deletes `.gitattributes` file that was used to set which files were using Git LFS.
All the lfs files on the repo were already deleted (see PR https://github.com/cal-itp/data-analyses/pull/1918).

I researched [how to remove git-lfs](https://github.com/git-lfs/git-lfs/issues/3026#issuecomment-696697599) and followed [these steps](https://gist.github.com/everttrollip/198ed9a09bba45d2663ccac99e662201) and [also these Linux / macOS / Unix solution](https://stackoverflow.com/questions/48699293/how-do-i-disable-git-lfs/78494978#78494978), but there are no more existing LFS files (run `git lfs ls-files`). 
However, If you run ` git lfs ls-files --all` it will list all the deleted files I mentioned above. As @vevetron mentioned on https://github.com/cal-itp/data-analyses/issues/1484, looks like we can't remove the history.
I tried to recreate those deleted files as empty files to see if it could remove them from the --all list, but still showing.
We can test in the new image to see if these removed files would affect anything.

For now we would merge the PR and then:
* Remove `git-lfs` from `jupyter-singleuser` image, I created this PR https://github.com/cal-itp/data-infra/pull/4887 on `data-infra`
* Add this new image as a prototype to be tested (like [this example](https://github.com/cal-itp/data-infra/pull/4766/changes))