### PR TITLE
additonal analysis for 1943 Data for GTFS-RT Implementation

### DIFF
--- a/ntd/1943_revenue_vehicle_count.ipynb
+++ b/ntd/1943_revenue_vehicle_count.ipynb
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "53019442-8679-4f9c-9a2f-c90dbf6e7c5b",
    "metadata": {
     "scrolled": true
@@ -200,12 +200,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "dda723ab-ddf2-47a7-94cf-c31a93722916",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 35218 entries, 0 to 35217\n",
+      "Data columns (total 41 columns):\n",
+      " #   Column                                        Non-Null Count  Dtype  \n",
+      "---  ------                                        --------------  -----  \n",
+      " 0   state/parent_ntd_id                           13899 non-null  object \n",
+      " 1   ntd_id                                        35218 non-null  object \n",
+      " 2   agency_name                                   35218 non-null  object \n",
+      " 3   reporter_type                                 35218 non-null  object \n",
+      " 4   reporting_module                              35218 non-null  object \n",
+      " 5   group_plan_sponsor_ntdid                      18739 non-null  object \n",
+      " 6   group_plan_sponsor_name                       18739 non-null  object \n",
+      " 7   modes                                         35218 non-null  object \n",
+      " 8   revenue_vehicle_inventory_id                  35218 non-null  int64  \n",
+      " 9   agency_fleet_id                               35218 non-null  object \n",
+      " 10  modetos_vehicles_operated_in_maximum_service  32583 non-null  float64\n",
+      " 11  total_fleet_vehicles                          35218 non-null  int64  \n",
+      " 12  dedicated_fleet                               35218 non-null  object \n",
+      " 13  vehicle_type                                  35218 non-null  object \n",
+      " 14  ownership_type                                35218 non-null  object \n",
+      " 15  funding_source                                35218 non-null  object \n",
+      " 16  manufacture_year                              33589 non-null  float64\n",
+      " 17  rebuild_year                                  1651 non-null   float64\n",
+      " 18  type_of_last_renewal                          1754 non-null   object \n",
+      " 19  useful_life_benchmark                         31097 non-null  float64\n",
+      " 20  manufacturer                                  18955 non-null  object \n",
+      " 21  other_manufacturer_description                360 non-null    object \n",
+      " 22  model                                         18934 non-null  object \n",
+      " 23  active_fleet_vehicles                         35218 non-null  int64  \n",
+      " 24  ada_fleet_vehicles                            30198 non-null  float64\n",
+      " 25  emergency_contingency_vehicles                6967 non-null   float64\n",
+      " 26  fuel_type                                     34135 non-null  object \n",
+      " 27  other_fuel_description                        55 non-null     object \n",
+      " 28  vehicle_length                                33589 non-null  float64\n",
+      " 29  seating_capacity                              35218 non-null  int64  \n",
+      " 30  standing_capacity                             18939 non-null  float64\n",
+      " 31  total_miles_on_active_vehicles_during_period  18552 non-null  float64\n",
+      " 32  average_lifetime_miles_per_active_vehicles    18552 non-null  float64\n",
+      " 33  no_capital_replacement_flag                   2492 non-null   object \n",
+      " 34  separate_asset_flag                           35218 non-null  object \n",
+      " 35  event_data_recorders                          2287 non-null   float64\n",
+      " 36  emergency_lighting_system_design              2287 non-null   float64\n",
+      " 37  emergency_signage                             2287 non-null   float64\n",
+      " 38  emergency_path_marking                        2287 non-null   float64\n",
+      " 39  automated_vehicles_flag                       55 non-null     object \n",
+      " 40  notes                                         9119 non-null   object \n",
+      "dtypes: float64(14), int64(4), object(23)\n",
+      "memory usage: 11.0+ MB\n"
+     ]
+    }
+   ],
    "source": [
     "rev_veh_inv_link = f\"{this_gcs_path}2024 Revenue Vehicle Inventory_250820.xlsx\"\n",
     "\n",
@@ -218,17 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9b75abc8-a7b2-4bf0-a1f7-e1d72f86638c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rev_veh.head(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "6d88cd1f-f355-48d1-ab15-08d6b10be270",
    "metadata": {},
    "outputs": [],
@@ -242,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "989719de-2471-4aa9-a4fc-928222af13e1",
    "metadata": {
     "scrolled": true
@@ -272,27 +317,99 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b5b819ad-5872-4e7c-9b8d-2437d0e3a87d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ntd_id</th>\n",
+       "      <th>agency_name</th>\n",
+       "      <th>total_fleet_vehicles</th>\n",
+       "      <th>active_fleet_vehicles</th>\n",
+       "      <th>modetos_vehicles_operated_in_maximum_service</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>90003</td>\n",
+       "      <td>San Francisco Bay Area Rapid Transit District</td>\n",
+       "      <td>785</td>\n",
+       "      <td>776</td>\n",
+       "      <td>566.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>90004</td>\n",
+       "      <td>Golden Empire Transit District</td>\n",
+       "      <td>160</td>\n",
+       "      <td>160</td>\n",
+       "      <td>51.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>90006</td>\n",
+       "      <td>Santa Cruz Metropolitan Transit District</td>\n",
+       "      <td>147</td>\n",
+       "      <td>147</td>\n",
+       "      <td>58.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ntd_id                                    agency_name  total_fleet_vehicles  \\\n",
+       "0  90003  San Francisco Bay Area Rapid Transit District                   785   \n",
+       "1  90004                 Golden Empire Transit District                   160   \n",
+       "2  90006       Santa Cruz Metropolitan Transit District                   147   \n",
+       "\n",
+       "   active_fleet_vehicles  modetos_vehicles_operated_in_maximum_service  \n",
+       "0                    776                                         566.0  \n",
+       "1                    160                                          51.0  \n",
+       "2                    147                                          58.0  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "ca_rev_veh.head()"
+    "ca_rev_veh.head(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "1906b9b3-b731-4d96-a5a4-b7c8ad8f9f87",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## difference between VOMs and Rev Vehicle Inv."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "af546470-b091-4187-a64f-2a46c02132d5",
    "metadata": {},
    "outputs": [],
@@ -309,20 +426,118 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "2403e7dd-6cbf-47da-9cf3-847108e731b7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ntd_id</th>\n",
+       "      <th>agency_name</th>\n",
+       "      <th>total_fleet_vehicles</th>\n",
+       "      <th>active_fleet_vehicles</th>\n",
+       "      <th>modetos_vehicles_operated_in_maximum_service</th>\n",
+       "      <th>ntd_id_mart</th>\n",
+       "      <th>agency_mart</th>\n",
+       "      <th>agency_voms_mart</th>\n",
+       "      <th>report_year_mart</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>90003</td>\n",
+       "      <td>San Francisco Bay Area Rapid Transit District</td>\n",
+       "      <td>785</td>\n",
+       "      <td>776</td>\n",
+       "      <td>566.0</td>\n",
+       "      <td>90003</td>\n",
+       "      <td>San Francisco Bay Area Rapid Transit District,...</td>\n",
+       "      <td>582.0</td>\n",
+       "      <td>2024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>90004</td>\n",
+       "      <td>Golden Empire Transit District</td>\n",
+       "      <td>160</td>\n",
+       "      <td>160</td>\n",
+       "      <td>51.0</td>\n",
+       "      <td>90004</td>\n",
+       "      <td>Golden Empire Transit District</td>\n",
+       "      <td>93.0</td>\n",
+       "      <td>2024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>90006</td>\n",
+       "      <td>Santa Cruz Metropolitan Transit District</td>\n",
+       "      <td>147</td>\n",
+       "      <td>147</td>\n",
+       "      <td>58.0</td>\n",
+       "      <td>90006</td>\n",
+       "      <td>Santa Cruz Metropolitan Transit District</td>\n",
+       "      <td>97.0</td>\n",
+       "      <td>2024</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ntd_id                                    agency_name  total_fleet_vehicles  \\\n",
+       "0  90003  San Francisco Bay Area Rapid Transit District                   785   \n",
+       "1  90004                 Golden Empire Transit District                   160   \n",
+       "2  90006       Santa Cruz Metropolitan Transit District                   147   \n",
+       "\n",
+       "   active_fleet_vehicles  modetos_vehicles_operated_in_maximum_service  \\\n",
+       "0                    776                                         566.0   \n",
+       "1                    160                                          51.0   \n",
+       "2                    147                                          58.0   \n",
+       "\n",
+       "  ntd_id_mart                                        agency_mart  \\\n",
+       "0       90003  San Francisco Bay Area Rapid Transit District,...   \n",
+       "1       90004                     Golden Empire Transit District   \n",
+       "2       90006           Santa Cruz Metropolitan Transit District   \n",
+       "\n",
+       "   agency_voms_mart  report_year_mart  \n",
+       "0             582.0              2024  \n",
+       "1              93.0              2024  \n",
+       "2              97.0              2024  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "diff_voms_ref_veh.head()"
+    "diff_voms_ref_veh.head(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b084f861-b850-4876-8a15-0a8e54f6b6d5",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Calculate the differencs in VOMS values between the revenue vehicle inventory and the warehouse\n",
     "Note, the warehouse table pull from a NTD excel file as well, so VOMS should be the same..."
@@ -330,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "f732a8a3-beef-4949-97cc-2dcb08e89435",
    "metadata": {
     "scrolled": true
@@ -345,7 +560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "c297f793-c6c2-4524-bd3d-a90c6b7da5d8",
    "metadata": {},
    "outputs": [],
@@ -358,12 +573,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "464bf7c1-d39d-4218-a239-8e42649f375a",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "210"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "diff_voms_ref_veh[\"ntd_id\"].nunique()"
    ]
@@ -371,21 +597,19 @@
   {
    "cell_type": "markdown",
    "id": "7545e6b3-1482-457b-ae07-804d8d2cf938",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## save data to GCS"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "5727de43-f695-4b9b-96a5-0435e7bb4942",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# diff_voms_ref_veh.to_csv(f\"{this_gcs_path}1943_total_revenue_vehicles.csv\")"
+    "diff_voms_ref_veh.to_csv(f\"{this_gcs_path}1943_total_revenue_vehicles.csv\")"
    ]
   },
   {
@@ -398,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "id": "a3eff858-c248-4d41-ad24-ff4f4ae7194a",
    "metadata": {},
    "outputs": [],
@@ -413,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 16,
    "id": "f3f262e6-7c58-4213-9270-042166e1a875",
    "metadata": {},
    "outputs": [
@@ -422,23 +646,24 @@
      "output_type": "stream",
      "text": [
       "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 209 entries, 0 to 208\n",
-      "Data columns (total 11 columns):\n",
+      "RangeIndex: 210 entries, 0 to 209\n",
+      "Data columns (total 12 columns):\n",
       " #   Column                                        Non-Null Count  Dtype  \n",
       "---  ------                                        --------------  -----  \n",
-      " 0   Unnamed: 0                                    209 non-null    int64  \n",
-      " 1   ntd_id                                        209 non-null    object \n",
-      " 2   agency_name                                   209 non-null    object \n",
-      " 3   total_fleet_vehicles                          209 non-null    int64  \n",
-      " 4   active_fleet_vehicles                         209 non-null    int64  \n",
-      " 5   modetos_vehicles_operated_in_maximum_service  209 non-null    float64\n",
-      " 6   ntd_id_mart                                   209 non-null    object \n",
-      " 7   agency_mart                                   209 non-null    object \n",
-      " 8   agency_voms_mart                              209 non-null    float64\n",
-      " 9   voms_diff                                     209 non-null    float64\n",
-      " 10  total_fleet_veh_voms_diff                     209 non-null    float64\n",
-      "dtypes: float64(4), int64(3), object(4)\n",
-      "memory usage: 18.1+ KB\n"
+      " 0   Unnamed: 0                                    210 non-null    int64  \n",
+      " 1   ntd_id                                        210 non-null    object \n",
+      " 2   agency_name                                   210 non-null    object \n",
+      " 3   total_fleet_vehicles                          210 non-null    int64  \n",
+      " 4   active_fleet_vehicles                         210 non-null    int64  \n",
+      " 5   modetos_vehicles_operated_in_maximum_service  210 non-null    float64\n",
+      " 6   ntd_id_mart                                   210 non-null    object \n",
+      " 7   agency_mart                                   210 non-null    object \n",
+      " 8   agency_voms_mart                              210 non-null    float64\n",
+      " 9   report_year_mart                              210 non-null    int64  \n",
+      " 10  voms_diff                                     210 non-null    float64\n",
+      " 11  total_fleet_veh_voms_diff                     210 non-null    float64\n",
+      "dtypes: float64(4), int64(4), object(4)\n",
+      "memory usage: 19.8+ KB\n"
      ]
     },
     {
@@ -480,6 +705,7 @@
        "      <th>ntd_id_mart</th>\n",
        "      <th>agency_mart</th>\n",
        "      <th>agency_voms_mart</th>\n",
+       "      <th>report_year_mart</th>\n",
        "      <th>voms_diff</th>\n",
        "      <th>total_fleet_veh_voms_diff</th>\n",
        "    </tr>\n",
@@ -496,6 +722,7 @@
        "      <td>90003</td>\n",
        "      <td>San Francisco Bay Area Rapid Transit District,...</td>\n",
        "      <td>582.0</td>\n",
+       "      <td>2024</td>\n",
        "      <td>16.0</td>\n",
        "      <td>219.0</td>\n",
        "    </tr>\n",
@@ -510,6 +737,7 @@
        "      <td>90004</td>\n",
        "      <td>Golden Empire Transit District</td>\n",
        "      <td>93.0</td>\n",
+       "      <td>2024</td>\n",
        "      <td>42.0</td>\n",
        "      <td>109.0</td>\n",
        "    </tr>\n",
@@ -524,6 +752,7 @@
        "      <td>90006</td>\n",
        "      <td>Santa Cruz Metropolitan Transit District</td>\n",
        "      <td>97.0</td>\n",
+       "      <td>2024</td>\n",
        "      <td>39.0</td>\n",
        "      <td>89.0</td>\n",
        "    </tr>\n",
@@ -552,10 +781,10 @@
        "1                     Golden Empire Transit District              93.0   \n",
        "2           Santa Cruz Metropolitan Transit District              97.0   \n",
        "\n",
-       "   voms_diff  total_fleet_veh_voms_diff  \n",
-       "0       16.0                      219.0  \n",
-       "1       42.0                      109.0  \n",
-       "2       39.0                       89.0  "
+       "   report_year_mart  voms_diff  total_fleet_veh_voms_diff  \n",
+       "0              2024       16.0                      219.0  \n",
+       "1              2024       42.0                      109.0  \n",
+       "2              2024       39.0                       89.0  "
       ]
      },
      "metadata": {},
@@ -564,66 +793,6 @@
    ],
    "source": [
     "display(diff_voms_ref_veh.info(), diff_voms_ref_veh.head(3))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "d9284259-8b74-4177-bb7e-fe50b6882ac7",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Unnamed: 0</th>\n",
-       "      <th>ntd_id</th>\n",
-       "      <th>agency_name</th>\n",
-       "      <th>total_fleet_vehicles</th>\n",
-       "      <th>active_fleet_vehicles</th>\n",
-       "      <th>modetos_vehicles_operated_in_maximum_service</th>\n",
-       "      <th>ntd_id_mart</th>\n",
-       "      <th>agency_mart</th>\n",
-       "      <th>agency_voms_mart</th>\n",
-       "      <th>voms_diff</th>\n",
-       "      <th>total_fleet_veh_voms_diff</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: [Unnamed: 0, ntd_id, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, ntd_id_mart, agency_mart, agency_voms_mart, voms_diff, total_fleet_veh_voms_diff]\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "diff_voms_ref_veh[diff_voms_ref_veh[\"agency_name\"].str.contains(\"Yuma\")]"
    ]
   },
   {
@@ -644,7 +813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "942fe047-9522-46a0-bbce-1c00bdfa9928",
    "metadata": {},
    "outputs": [],
@@ -660,7 +829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "id": "31ac5028-c30b-44de-b969-2ace5cf4f307",
    "metadata": {},
    "outputs": [
@@ -720,78 +889,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "5035494d-2e7d-40eb-aff3-700ca0b3bf90",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>schedule_gtfs_dataset_name</th>\n",
-       "      <th>analysis_name</th>\n",
-       "      <th>ntd_id_2022</th>\n",
-       "      <th>schedule_name</th>\n",
-       "      <th>n_routes</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>191</th>\n",
-       "      <td>Yuma Schedule</td>\n",
-       "      <td>Yuma County Intergovernmental Public Transport...</td>\n",
-       "      <td>90233</td>\n",
-       "      <td>Yuma Schedule</td>\n",
-       "      <td>9</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    schedule_gtfs_dataset_name  \\\n",
-       "191              Yuma Schedule   \n",
-       "\n",
-       "                                         analysis_name ntd_id_2022  \\\n",
-       "191  Yuma County Intergovernmental Public Transport...       90233   \n",
-       "\n",
-       "     schedule_name  n_routes  \n",
-       "191  Yuma Schedule         9  "
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "agency = \"Yuma\"\n",
-    "rollup_route_bridge[\n",
-    "    (rollup_route_bridge[\"schedule_gtfs_dataset_name\"].str.contains(agency))\n",
-    "    | (rollup_route_bridge[\"analysis_name\"].str.contains(agency))\n",
-    "    | (rollup_route_bridge[\"schedule_name\"].str.contains(agency))\n",
-    "]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "697ada90-d82f-4ee2-b9fa-a1e1e957b82c",
    "metadata": {},
@@ -802,12 +899,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 19,
    "id": "fac1af3c-50be-4961-ace7-6ad69178c940",
    "metadata": {
     "scrolled": true
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Index: 54 entries, 0 to 53\n",
+      "Data columns (total 9 columns):\n",
+      " #   Column                                            Non-Null Count  Dtype  \n",
+      "---  ------                                            --------------  -----  \n",
+      " 0   organization_name                                 54 non-null     object \n",
+      " 1   ntd_id                                            54 non-null     object \n",
+      " 2   service_name                                      54 non-null     object \n",
+      " 3   total_2023_voms                                   54 non-null     float64\n",
+      " 4   is_the_agency_pursuing_rt_(via_the_msas_or_not)?  10 non-null     object \n",
+      " 5   notes                                             10 non-null     object \n",
+      " 6   passiogo                                          3 non-null      object \n",
+      " 7   gtfs_rt                                           50 non-null     object \n",
+      " 8   if_gtfs-rt_data_-_add_the_link                    2 non-null      object \n",
+      "dtypes: float64(1), object(8)\n",
+      "memory usage: 4.2+ KB\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "None"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/html": [
@@ -830,6 +958,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>organization_name</th>\n",
+       "      <th>ntd_id</th>\n",
        "      <th>service_name</th>\n",
        "      <th>total_2023_voms</th>\n",
        "      <th>is_the_agency_pursuing_rt_(via_the_msas_or_not)?</th>\n",
@@ -841,34 +970,34 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>Plumas County Transportation Commission</td>\n",
-       "      <td>Plumas Transit Systems</td>\n",
-       "      <td>6.0</td>\n",
+       "      <th>30</th>\n",
+       "      <td>City of Baldwin Park</td>\n",
+       "      <td>90251</td>\n",
+       "      <td>Baldwin Park Express</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>No</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>yes</td>\n",
+       "      <td>Public Transit | Baldwin Park, CA</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                          organization_name            service_name  \\\n",
-       "35  Plumas County Transportation Commission  Plumas Transit Systems   \n",
+       "       organization_name ntd_id          service_name  total_2023_voms  \\\n",
+       "30  City of Baldwin Park  90251  Baldwin Park Express              8.0   \n",
        "\n",
-       "    total_2023_voms is_the_agency_pursuing_rt_(via_the_msas_or_not)? notes  \\\n",
-       "35              6.0                                              NaN   NaN   \n",
+       "   is_the_agency_pursuing_rt_(via_the_msas_or_not)? notes passiogo gtfs_rt  \\\n",
+       "30                                              NaN   NaN      NaN     yes   \n",
        "\n",
-       "   passiogo gtfs_rt if_gtfs-rt_data_-_add_the_link  \n",
-       "35      NaN     No                             NaN  "
+       "       if_gtfs-rt_data_-_add_the_link  \n",
+       "30  Public Transit | Baldwin Park, CA  "
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -877,70 +1006,19 @@
     ")\n",
     "\n",
     "no_rt.columns = no_rt.columns.str.lower().str.strip().str.replace(\" \", \"_\")\n",
-    "\n",
     "no_rt = no_rt[\n",
-    "    (no_rt[\"organization_name\"].notna()) & (no_rt[\"gtfs_rt\"].str.contains(\"No\"))\n",
+    "    no_rt[\"organization_name\"].notna()\n",
     "]\n",
+    "no_rt[\"ntd_id\"] = no_rt[\"ntd_id\"].astype(\"int64\").astype(\"str\")\n",
+    "\n",
     "\n",
     "# update Plumas County to Plumas County Transportation Commission\n",
     "no_rt.loc[no_rt[\"organization_name\"]==\"Plumas County\",\"organization_name\"] = \"Plumas County Transportation Commission\"\n",
     "\n",
-    "no_rt[no_rt[\"organization_name\"].str.contains('Plumas')]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45b954c0-74c1-4112-bf90-e1be5415607c",
-   "metadata": {},
-   "source": [
-    "## Can i fill the no_rt list with NTD ID? \n",
-    "and fill in the unmerged one manually?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1de376fc-d571-450a-8a86-6754c3794809",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "no_rt_ntd = no_rt.merge(\n",
-    "    ca_agencies,\n",
-    "    left_on = \"organization_name\",\n",
-    "    right_on = \"agency_mart\",\n",
-    "    how = \"left\",\n",
-    "    indicator = True\n",
-    ")\n",
-    "no_rt_ntd[\"_merge\"].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8856f569-310a-49f6-ae66-abe0a7bd5d7b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "no_rt_ntd.head(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d01f4da4-d0fa-45fd-aeda-ea2d2c393b79",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# what didnt merge, manually get the ntd_ids for those?\n",
-    "no_rt_ntd[no_rt_ntd[\"_merge\"]==\"left_only\"][\"organization_name\"].tolist()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3e26d686-c2dd-4ff1-9deb-6bd751501906",
-   "metadata": {},
-   "source": [
-    "having copilot give this a shot"
+    "display(\n",
+    "    no_rt.info(),\n",
+    "    no_rt[no_rt[\"organization_name\"].str.contains('Baldwin')]\n",
+    ")"
    ]
   },
   {
@@ -967,31 +1045,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "1e34014a-8ff8-4c4c-9e6c-60de7aaa8552",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "no_rt_keep_cols = [\n",
-    "    \"organization_name\",\n",
-    "    \"service_name\",\n",
-    "    # 'total_2023_voms',\n",
-    "    \"is_the_agency_pursuing_rt_(via_the_msas_or_not)?\",\n",
-    "    # 'notes',\n",
-    "    # 'passiogo',\n",
-    "    \"gtfs_rt\",\n",
-    "    # 'if_gtfs-rt_data_-_add_the_link'\n",
-    "]\n",
-    "no_rt_rev_veh_inv = diff_voms_ref_veh.merge(\n",
-    "    no_rt[no_rt_keep_cols],\n",
-    "    left_on=\"agency_name\",\n",
-    "    right_on=\"organization_name\",\n",
-    "    how=\"inner\",\n",
-    ")\n",
+    "# no_rt_keep_cols = [\n",
+    "#     \"organization_name\",\n",
+    "#     \"service_name\",\n",
+    "#     # 'total_2023_voms',\n",
+    "#     \"is_the_agency_pursuing_rt_(via_the_msas_or_not)?\",\n",
+    "#     # 'notes',\n",
+    "#     # 'passiogo',\n",
+    "#     \"gtfs_rt\",\n",
+    "#     # 'if_gtfs-rt_data_-_add_the_link'\n",
+    "# ]\n",
+    "# no_rt_rev_veh_inv = diff_voms_ref_veh.merge(\n",
+    "#     no_rt[no_rt_keep_cols],\n",
+    "#     left_on=\"agency_name\",\n",
+    "#     right_on=\"organization_name\",\n",
+    "#     how=\"inner\",\n",
+    "# )\n",
     "\n",
-    "no_rt_rev_veh_inv"
+    "# no_rt_rev_veh_inv"
    ]
   },
   {
@@ -1004,29 +1082,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "1887cbad-55ab-4c1b-993e-c1c1ee45aae6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "no_rt_rollup_routes = rollup_route_bridge.merge(\n",
-    "    no_rt[no_rt_keep_cols],\n",
-    "    left_on=\"analysis_name\",\n",
-    "    right_on=\"organization_name\",\n",
-    "    how=\"inner\",\n",
-    ")"
+    "# no_rt_rollup_routes = rollup_route_bridge.merge(\n",
+    "#     no_rt[no_rt_keep_cols],\n",
+    "#     left_on=\"analysis_name\",\n",
+    "#     right_on=\"organization_name\",\n",
+    "#     how=\"inner\",\n",
+    "# )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "05f4ec16-7444-4464-9fb8-01517c81bce5",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "display(no_rt_rollup_routes.info(), no_rt_rollup_routes)"
+    "# display(no_rt_rollup_routes.info(), no_rt_rollup_routes)"
    ]
   },
   {
@@ -1041,23 +1119,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68c357ff-d231-4a50-ac68-cac7ab202deb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "display(\n",
-    "    \"Total Revenue Vehicles, from NTD\",\n",
-    "    diff_voms_ref_veh.head(3),\n",
-    "    \"Total Routes, from GTFS\",\n",
-    "    rollup_route_bridge.head(3),\n",
-    "    \"List of agencies without GTFS-RT, CS team\",\n",
-    "    no_rt.head(3),\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "92b8fa18-99ce-472d-b326-14729172335c",
    "metadata": {},
@@ -1067,7 +1128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 23,
    "id": "53b6756c-d691-4494-9805-b3f404a85063",
    "metadata": {},
    "outputs": [
@@ -1076,28 +1137,29 @@
      "output_type": "stream",
      "text": [
       "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 154 entries, 0 to 153\n",
-      "Data columns (total 16 columns):\n",
+      "RangeIndex: 155 entries, 0 to 154\n",
+      "Data columns (total 17 columns):\n",
       " #   Column                                        Non-Null Count  Dtype  \n",
       "---  ------                                        --------------  -----  \n",
-      " 0   Unnamed: 0                                    154 non-null    int64  \n",
-      " 1   ntd_id                                        154 non-null    object \n",
-      " 2   agency_name                                   154 non-null    object \n",
-      " 3   total_fleet_vehicles                          154 non-null    int64  \n",
-      " 4   active_fleet_vehicles                         154 non-null    int64  \n",
-      " 5   modetos_vehicles_operated_in_maximum_service  154 non-null    float64\n",
-      " 6   ntd_id_mart                                   154 non-null    object \n",
-      " 7   agency_mart                                   154 non-null    object \n",
-      " 8   agency_voms_mart                              154 non-null    float64\n",
-      " 9   voms_diff                                     154 non-null    float64\n",
-      " 10  total_fleet_veh_voms_diff                     154 non-null    float64\n",
-      " 11  schedule_gtfs_dataset_name                    154 non-null    object \n",
-      " 12  analysis_name                                 154 non-null    object \n",
-      " 13  ntd_id_2022                                   154 non-null    object \n",
-      " 14  schedule_name                                 154 non-null    object \n",
-      " 15  n_routes                                      154 non-null    int64  \n",
-      "dtypes: float64(4), int64(4), object(8)\n",
-      "memory usage: 19.4+ KB\n"
+      " 0   Unnamed: 0                                    155 non-null    int64  \n",
+      " 1   ntd_id                                        155 non-null    object \n",
+      " 2   agency_name                                   155 non-null    object \n",
+      " 3   total_fleet_vehicles                          155 non-null    int64  \n",
+      " 4   active_fleet_vehicles                         155 non-null    int64  \n",
+      " 5   modetos_vehicles_operated_in_maximum_service  155 non-null    float64\n",
+      " 6   ntd_id_mart                                   155 non-null    object \n",
+      " 7   agency_mart                                   155 non-null    object \n",
+      " 8   agency_voms_mart                              155 non-null    float64\n",
+      " 9   report_year_mart                              155 non-null    int64  \n",
+      " 10  voms_diff                                     155 non-null    float64\n",
+      " 11  total_fleet_veh_voms_diff                     155 non-null    float64\n",
+      " 12  schedule_gtfs_dataset_name                    155 non-null    object \n",
+      " 13  analysis_name                                 155 non-null    object \n",
+      " 14  ntd_id_2022                                   155 non-null    object \n",
+      " 15  schedule_name                                 155 non-null    object \n",
+      " 16  n_routes                                      155 non-null    int64  \n",
+      "dtypes: float64(4), int64(5), object(8)\n",
+      "memory usage: 20.7+ KB\n"
      ]
     }
    ],
@@ -1109,13 +1171,152 @@
     "    how=\"inner\",\n",
     ")\n",
     "\n",
-    "rev_veh_route.info()  # there are some unmerged agenies (77). this makes sense, not everyone in the NTD can be cross-walked to a gtfs schedule."
+    "rev_veh_route.info()  \n",
+    "\n",
+    "# there are some unmerged agenies (77). this makes sense, not everyone in the NTD can be cross-walked to a gtfs schedule.\n",
+    "# also confirmed in meeting that some agencies are missing in the bridge table/air table "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a084c9c-2ae6-4cab-aa46-eca093bdbb33",
+   "metadata": {},
+   "source": [
+    "## merge rev_veh_route to no_rt list"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "85e57389-6a71-49f3-814f-3daf30323166",
+   "id": "7721ea1c-46c7-46d3-bf11-d299fa6afcf8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 51 entries, 0 to 50\n",
+      "Data columns (total 26 columns):\n",
+      " #   Column                                            Non-Null Count  Dtype   \n",
+      "---  ------                                            --------------  -----   \n",
+      " 0   Unnamed: 0                                        51 non-null     int64   \n",
+      " 1   ntd_id                                            51 non-null     object  \n",
+      " 2   agency_name                                       51 non-null     object  \n",
+      " 3   total_fleet_vehicles                              51 non-null     int64   \n",
+      " 4   active_fleet_vehicles                             51 non-null     int64   \n",
+      " 5   modetos_vehicles_operated_in_maximum_service      51 non-null     float64 \n",
+      " 6   ntd_id_mart                                       51 non-null     object  \n",
+      " 7   agency_mart                                       51 non-null     object  \n",
+      " 8   agency_voms_mart                                  51 non-null     float64 \n",
+      " 9   report_year_mart                                  51 non-null     int64   \n",
+      " 10  voms_diff                                         51 non-null     float64 \n",
+      " 11  total_fleet_veh_voms_diff                         51 non-null     float64 \n",
+      " 12  schedule_gtfs_dataset_name                        51 non-null     object  \n",
+      " 13  analysis_name                                     51 non-null     object  \n",
+      " 14  ntd_id_2022                                       51 non-null     object  \n",
+      " 15  schedule_name                                     51 non-null     object  \n",
+      " 16  n_routes                                          51 non-null     int64   \n",
+      " 17  organization_name                                 51 non-null     object  \n",
+      " 18  service_name                                      51 non-null     object  \n",
+      " 19  total_2023_voms                                   51 non-null     float64 \n",
+      " 20  is_the_agency_pursuing_rt_(via_the_msas_or_not)?  10 non-null     object  \n",
+      " 21  notes                                             10 non-null     object  \n",
+      " 22  passiogo                                          4 non-null      object  \n",
+      " 23  gtfs_rt                                           48 non-null     object  \n",
+      " 24  if_gtfs-rt_data_-_add_the_link                    1 non-null      object  \n",
+      " 25  _merge                                            51 non-null     category\n",
+      "dtypes: category(1), float64(5), int64(5), object(15)\n",
+      "memory usage: 10.3+ KB\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "None"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "_merge\n",
+       "both          51\n",
+       "left_only      0\n",
+       "right_only     0\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "_merge\n",
+       "left_only     104\n",
+       "both           51\n",
+       "right_only      7\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rev_veh_route_no_rt = rev_veh_route.merge(\n",
+    "    no_rt,\n",
+    "    left_on=\"ntd_id\",\n",
+    "    right_on=\"ntd_id\",\n",
+    "    how=\"inner\",\n",
+    "    indicator=True,\n",
+    ")\n",
+    "\n",
+    "rev_veh_route_no_rt_outer_merge = rev_veh_route.merge(\n",
+    "    no_rt,\n",
+    "    left_on=\"ntd_id\",\n",
+    "    right_on=\"ntd_id\",\n",
+    "    how=\"outer\",\n",
+    "    indicator=True,\n",
+    ")\n",
+    "\n",
+    "display(\n",
+    "    rev_veh_route_no_rt.info(),\n",
+    "    rev_veh_route_no_rt[\"_merge\"].value_counts(),\n",
+    "    rev_veh_route_no_rt_outer_merge[\"_merge\"].value_counts()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "222e7c35-e092-4cb3-8ab2-fcef6f28a7aa",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(162, 26)"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rev_veh_route_no_rt_outer_merge.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "b6e51a75-d74f-4d59-9234-76e4e1700d30",
    "metadata": {
     "scrolled": true
    },
@@ -1141,121 +1342,75 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Unnamed: 0</th>\n",
        "      <th>ntd_id</th>\n",
-       "      <th>agency_name</th>\n",
-       "      <th>total_fleet_vehicles</th>\n",
-       "      <th>active_fleet_vehicles</th>\n",
-       "      <th>modetos_vehicles_operated_in_maximum_service</th>\n",
-       "      <th>ntd_id_mart</th>\n",
-       "      <th>agency_mart</th>\n",
-       "      <th>agency_voms_mart</th>\n",
-       "      <th>voms_diff</th>\n",
-       "      <th>total_fleet_veh_voms_diff</th>\n",
-       "      <th>schedule_gtfs_dataset_name</th>\n",
-       "      <th>analysis_name</th>\n",
-       "      <th>ntd_id_2022</th>\n",
-       "      <th>schedule_name</th>\n",
-       "      <th>n_routes</th>\n",
+       "      <th>organization_name</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>89</th>\n",
+       "      <td>90251</td>\n",
+       "      <td>City of Baldwin Park</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>90260</td>\n",
+       "      <td>City of Compton</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>90261</td>\n",
+       "      <td>City of Covina</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>125</th>\n",
+       "      <td>91008</td>\n",
+       "      <td>Modoc Transportation Agency</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>155</th>\n",
+       "      <td>99316</td>\n",
+       "      <td>Chemehuevi Indian Tribe</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>159</th>\n",
+       "      <td>99449</td>\n",
+       "      <td>City of El Segundo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>160</th>\n",
+       "      <td>99451</td>\n",
+       "      <td>City of San Fernando</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: [Unnamed: 0, ntd_id, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, ntd_id_mart, agency_mart, agency_voms_mart, voms_diff, total_fleet_veh_voms_diff, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, schedule_name, n_routes]\n",
-       "Index: []"
+       "    ntd_id            organization_name\n",
+       "89   90251         City of Baldwin Park\n",
+       "98   90260              City of Compton\n",
+       "99   90261               City of Covina\n",
+       "125  91008  Modoc Transportation Agency\n",
+       "155  99316      Chemehuevi Indian Tribe\n",
+       "159  99449           City of El Segundo\n",
+       "160  99451         City of San Fernando"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "rev_veh_route[rev_veh_route[\"agency_name\"].str.contains(\"Yuma\")] # confirme Plumas made it"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0a084c9c-2ae6-4cab-aa46-eca093bdbb33",
-   "metadata": {},
-   "source": [
-    "## merge rev_veh_route to no_rt list"
+    "rev_veh_route_no_rt_outer_merge[rev_veh_route_no_rt_outer_merge[\"_merge\"]==\"right_only\"][[\"ntd_id\",\"organization_name\"]]\n",
+    "\n",
+    "# City of Compton, City of Covina, City of El Segundo, City of San Fernando didnt matchbecause they arent in the bridge table?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a1c3f10d-3830-4414-b11b-7383b7c6319a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "no_rt[\"organization_name\"].unique().tolist()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "7721ea1c-46c7-46d3-bf11-d299fa6afcf8",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 44 entries, 0 to 43\n",
-      "Data columns (total 25 columns):\n",
-      " #   Column                                            Non-Null Count  Dtype   \n",
-      "---  ------                                            --------------  -----   \n",
-      " 0   Unnamed: 0                                        44 non-null     int64   \n",
-      " 1   ntd_id                                            44 non-null     object  \n",
-      " 2   agency_name                                       44 non-null     object  \n",
-      " 3   total_fleet_vehicles                              44 non-null     int64   \n",
-      " 4   active_fleet_vehicles                             44 non-null     int64   \n",
-      " 5   modetos_vehicles_operated_in_maximum_service      44 non-null     float64 \n",
-      " 6   ntd_id_mart                                       44 non-null     object  \n",
-      " 7   agency_mart                                       44 non-null     object  \n",
-      " 8   agency_voms_mart                                  44 non-null     float64 \n",
-      " 9   voms_diff                                         44 non-null     float64 \n",
-      " 10  total_fleet_veh_voms_diff                         44 non-null     float64 \n",
-      " 11  schedule_gtfs_dataset_name                        44 non-null     object  \n",
-      " 12  analysis_name                                     44 non-null     object  \n",
-      " 13  ntd_id_2022                                       44 non-null     object  \n",
-      " 14  schedule_name                                     44 non-null     object  \n",
-      " 15  n_routes                                          44 non-null     int64   \n",
-      " 16  organization_name                                 44 non-null     object  \n",
-      " 17  service_name                                      44 non-null     object  \n",
-      " 18  total_2023_voms                                   44 non-null     float64 \n",
-      " 19  is_the_agency_pursuing_rt_(via_the_msas_or_not)?  10 non-null     object  \n",
-      " 20  notes                                             10 non-null     object  \n",
-      " 21  passiogo                                          0 non-null      object  \n",
-      " 22  gtfs_rt                                           44 non-null     object  \n",
-      " 23  if_gtfs-rt_data_-_add_the_link                    0 non-null      object  \n",
-      " 24  _merge                                            44 non-null     category\n",
-      "dtypes: category(1), float64(5), int64(4), object(15)\n",
-      "memory usage: 8.6+ KB\n"
-     ]
-    }
-   ],
-   "source": [
-    "rev_veh_route_no_rt = rev_veh_route.merge(\n",
-    "    no_rt,\n",
-    "    left_on=\"analysis_name\",\n",
-    "    right_on=\"organization_name\",\n",
-    "    how=\"inner\",\n",
-    "    indicator=True,\n",
-    ")\n",
-    "rev_veh_route_no_rt.info()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 26,
    "id": "8b5829de-97b0-47e4-885b-99212b8d2191",
    "metadata": {},
    "outputs": [],
@@ -1285,72 +1440,11 @@
     "    \"passiogo\",\n",
     "    \"gtfs_rt\",\n",
     "    \"if_gtfs-rt_data_-_add_the_link\",\n",
-    "    # \"_merge\",\n",
+    "    \"_merge\",\n",
     "]\n",
-    "clean_rev_veh_route_no_rt = rev_veh_route_no_rt[drop_cols]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "4f41357a-dacb-44a8-a537-19f01764bb91",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>agency_name</th>\n",
-       "      <th>total_fleet_vehicles</th>\n",
-       "      <th>active_fleet_vehicles</th>\n",
-       "      <th>modetos_vehicles_operated_in_maximum_service</th>\n",
-       "      <th>schedule_gtfs_dataset_name</th>\n",
-       "      <th>analysis_name</th>\n",
-       "      <th>ntd_id_2022</th>\n",
-       "      <th>n_routes</th>\n",
-       "      <th>service_name</th>\n",
-       "      <th>is_the_agency_pursuing_rt_(via_the_msas_or_not)?</th>\n",
-       "      <th>notes</th>\n",
-       "      <th>passiogo</th>\n",
-       "      <th>gtfs_rt</th>\n",
-       "      <th>if_gtfs-rt_data_-_add_the_link</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: [agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, n_routes, service_name, is_the_agency_pursuing_rt_(via_the_msas_or_not)?, notes, passiogo, gtfs_rt, if_gtfs-rt_data_-_add_the_link]\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "clean_rev_veh_route_no_rt[clean_rev_veh_route_no_rt[\"service_name\"].str.contains(\"Yuma\")]"
+    "clean_rev_veh_route_no_rt = rev_veh_route_no_rt[drop_cols]\n",
+    "\n",
+    "clean_rev_veh_route_no_rt_outer_merge = rev_veh_route_no_rt_outer_merge[drop_cols]"
    ]
   },
   {
@@ -1363,12 +1457,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "35b71c3f-926d-4dd4-9083-db46ef4c27d2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "clean_rev_veh_route_no_rt.to_csv(f\"{this_gcs_path}1943_total_revenue_vehicles_routes_no_rt.csv\")"
+    "clean_rev_veh_route_no_rt.to_csv(f\"{this_gcs_path}1943_total_revenue_vehicles_routes_no_rt.csv\")\n",
+    "clean_rev_veh_route_no_rt_outer_merge.to_csv(f\"{this_gcs_path}1943_total_revenue_vehicles_routes_no_rt_outer_merge.csv\")"
    ]
   },
   {
@@ -1381,7 +1476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "id": "6297516d-28cd-4291-b50f-6df85e79ee11",
    "metadata": {
     "scrolled": true
@@ -1423,12 +1518,32 @@
        "      <th>passiogo</th>\n",
        "      <th>gtfs_rt</th>\n",
        "      <th>if_gtfs-rt_data_-_add_the_link</th>\n",
+       "      <th>_merge</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0</td>\n",
+       "      <td>Sacramento Regional Transit District</td>\n",
+       "      <td>557</td>\n",
+       "      <td>508</td>\n",
+       "      <td>193.0</td>\n",
+       "      <td>Sacramento Schedule</td>\n",
+       "      <td>Sacramento Regional Transit District</td>\n",
+       "      <td>90019</td>\n",
+       "      <td>64</td>\n",
+       "      <td>South County Transit Link</td>\n",
+       "      <td>Maybe</td>\n",
+       "      <td>Might be onboarding using the MSAs, but progre...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>No</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
        "      <td>City of Corona</td>\n",
        "      <td>20</td>\n",
        "      <td>20</td>\n",
@@ -1443,10 +1558,11 @@
        "      <td>NaN</td>\n",
        "      <td>No</td>\n",
        "      <td>NaN</td>\n",
+       "      <td>both</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
        "      <td>City of Laguna Beach</td>\n",
        "      <td>32</td>\n",
        "      <td>32</td>\n",
@@ -1461,10 +1577,11 @@
        "      <td>NaN</td>\n",
        "      <td>No</td>\n",
        "      <td>NaN</td>\n",
+       "      <td>both</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
        "      <td>City of Lompoc</td>\n",
        "      <td>16</td>\n",
        "      <td>16</td>\n",
@@ -1479,99 +1596,90 @@
        "      <td>NaN</td>\n",
        "      <td>No</td>\n",
        "      <td>NaN</td>\n",
+       "      <td>both</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>City of Lodi</td>\n",
-       "      <td>25</td>\n",
-       "      <td>25</td>\n",
-       "      <td>8.0</td>\n",
-       "      <td>Grapeline Schedule</td>\n",
-       "      <td>City of Lodi</td>\n",
-       "      <td>90175</td>\n",
-       "      <td>11</td>\n",
-       "      <td>Grapeline</td>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>Los Angeles County Metropolitan Transportation...</td>\n",
+       "      <td>4415</td>\n",
+       "      <td>4231</td>\n",
+       "      <td>1476.0</td>\n",
+       "      <td>LA Metro Rail Schedule</td>\n",
+       "      <td>Los Angeles County Metropolitan Transportation...</td>\n",
+       "      <td>90154</td>\n",
+       "      <td>6</td>\n",
+       "      <td>Los Angeles County Transit Services</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>No</td>\n",
        "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>4</td>\n",
-       "      <td>Altamont Corridor Express</td>\n",
-       "      <td>40</td>\n",
-       "      <td>37</td>\n",
-       "      <td>28.0</td>\n",
-       "      <td>Bay Area 511 ACE Schedule</td>\n",
-       "      <td>San Joaquin Regional Rail Commission</td>\n",
-       "      <td>90182</td>\n",
-       "      <td>1</td>\n",
-       "      <td>Altamont Corridor Express</td>\n",
-       "      <td>Maybe</td>\n",
-       "      <td>Might be part of Amtrak work to get RT</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>No (ETA spot)</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>both</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   Unnamed: 0                agency_name  total_fleet_vehicles  \\\n",
-       "0           0             City of Corona                    20   \n",
-       "1           1       City of Laguna Beach                    32   \n",
-       "2           2             City of Lompoc                    16   \n",
-       "3           3               City of Lodi                    25   \n",
-       "4           4  Altamont Corridor Express                    40   \n",
+       "   Unnamed: 0                                        agency_name  \\\n",
+       "0           0               Sacramento Regional Transit District   \n",
+       "1           1                                     City of Corona   \n",
+       "2           2                               City of Laguna Beach   \n",
+       "3           3                                     City of Lompoc   \n",
+       "4           4  Los Angeles County Metropolitan Transportation...   \n",
        "\n",
-       "   active_fleet_vehicles  modetos_vehicles_operated_in_maximum_service  \\\n",
-       "0                     20                                           6.0   \n",
-       "1                     32                                          18.0   \n",
-       "2                     16                                           2.0   \n",
-       "3                     25                                           8.0   \n",
-       "4                     37                                          28.0   \n",
+       "   total_fleet_vehicles  active_fleet_vehicles  \\\n",
+       "0                   557                    508   \n",
+       "1                    20                     20   \n",
+       "2                    32                     32   \n",
+       "3                    16                     16   \n",
+       "4                  4415                   4231   \n",
        "\n",
-       "  schedule_gtfs_dataset_name                         analysis_name  \\\n",
-       "0            Corona Schedule                        City of Corona   \n",
-       "1      Laguna Beach Schedule                  City of Laguna Beach   \n",
-       "2            Lompoc Schedule                        City of Lompoc   \n",
-       "3         Grapeline Schedule                          City of Lodi   \n",
-       "4  Bay Area 511 ACE Schedule  San Joaquin Regional Rail Commission   \n",
+       "   modetos_vehicles_operated_in_maximum_service schedule_gtfs_dataset_name  \\\n",
+       "0                                         193.0        Sacramento Schedule   \n",
+       "1                                           6.0            Corona Schedule   \n",
+       "2                                          18.0      Laguna Beach Schedule   \n",
+       "3                                           2.0            Lompoc Schedule   \n",
+       "4                                        1476.0     LA Metro Rail Schedule   \n",
        "\n",
-       "   ntd_id_2022  n_routes               service_name  \\\n",
-       "0        90052         2             Corona Cruiser   \n",
-       "1        90119         3       Laguna Beach Trolley   \n",
-       "2        90149         6     City of Lompoc Transit   \n",
-       "3        90175        11                  Grapeline   \n",
-       "4        90182         1  Altamont Corridor Express   \n",
+       "                                       analysis_name  ntd_id_2022  n_routes  \\\n",
+       "0               Sacramento Regional Transit District        90019        64   \n",
+       "1                                     City of Corona        90052         2   \n",
+       "2                               City of Laguna Beach        90119         3   \n",
+       "3                                     City of Lompoc        90149         6   \n",
+       "4  Los Angeles County Metropolitan Transportation...        90154         6   \n",
+       "\n",
+       "                          service_name  \\\n",
+       "0            South County Transit Link   \n",
+       "1                       Corona Cruiser   \n",
+       "2                 Laguna Beach Trolley   \n",
+       "3               City of Lompoc Transit   \n",
+       "4  Los Angeles County Transit Services   \n",
        "\n",
        "  is_the_agency_pursuing_rt_(via_the_msas_or_not)?  \\\n",
        "0                                            Maybe   \n",
-       "1                                              NaN   \n",
+       "1                                            Maybe   \n",
        "2                                              NaN   \n",
        "3                                              NaN   \n",
-       "4                                            Maybe   \n",
+       "4                                              NaN   \n",
        "\n",
-       "                                    notes  passiogo        gtfs_rt  \\\n",
-       "0   Expressed interest in RT through MSAs       NaN            No    \n",
-       "1                                     NaN       NaN             No   \n",
-       "2                                     NaN       NaN             No   \n",
-       "3                                     NaN       NaN            No    \n",
-       "4  Might be part of Amtrak work to get RT       NaN  No (ETA spot)   \n",
+       "                                               notes passiogo gtfs_rt  \\\n",
+       "0  Might be onboarding using the MSAs, but progre...      NaN     No    \n",
+       "1              Expressed interest in RT through MSAs      NaN     No    \n",
+       "2                                                NaN      NaN      No   \n",
+       "3                                                NaN      NaN      No   \n",
+       "4                                                NaN      NaN     No    \n",
        "\n",
-       "   if_gtfs-rt_data_-_add_the_link  \n",
-       "0                             NaN  \n",
-       "1                             NaN  \n",
-       "2                             NaN  \n",
-       "3                             NaN  \n",
-       "4                             NaN  "
+       "  if_gtfs-rt_data_-_add_the_link _merge  \n",
+       "0                            NaN   both  \n",
+       "1                            NaN   both  \n",
+       "2                            NaN   both  \n",
+       "3                            NaN   both  \n",
+       "4                            NaN   both  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1579,6 +1687,9 @@
    "source": [
     "clean_check = gcs_pandas().read_csv(\n",
     "    f\"{this_gcs_path}1943_total_revenue_vehicles_routes_no_rt.csv\"\n",
+    ")\n",
+    "clean_check_outer_merge = gcs_pandas().read_csv(\n",
+    "    f\"{this_gcs_path}1943_total_revenue_vehicles_routes_no_rt_outer_merge.csv\"\n",
     ")\n",
     "\n",
     "clean_check.head()"
@@ -1600,22 +1711,22 @@
     "## Some agencies have missing numbers\n",
     "why?\n",
     "\n",
-    "- `Yuma County Intergovernmental Public Transportation Authority` -> ~~Yuma Arizona?! 90233? AZ are filtered out.~~ FIXED, i added them manually.\n",
-    "- `City of Alhambra` -> in rev vehicle and route list, but not part of the no_rt list, so was dropped in the final merge\n",
-    "- `City of Cerritos` -> in rev vehicle and route list, but not part of the no_rt list, so was dropped in the final merge\n",
-    "- `City of Baldwin Park` -> ~~in rev veh and routes list, but didnt merge because names were different.~~ FIXED, used `ntd_id_mart` in join\n",
-    "- `City of Calabasas` -> in rev vehicle and route list, but not part of the no_rt list\n",
-    "- `City of Compton` - > in rev veh and no rt list, but not part of the routes list (maybe i need a different date for gtfs?). Compton is not in the bridge table so its not making it through the merge with the rollup table. need to figure this out\n",
-    "- **`Plumas County`** -> is in the rev veh-to-routes merge and no_rt list, wasnt joining on the name. can fix this manually (plumas county vs plumas county transportation comission)\n",
-    "- `City of Covina` - > in rev veh and no_rt list, but not part of the routes list (maybe i need a different date for gtfs?). Cant find a \"City of Covina\" scheduled in rollup table or bridge table, \n",
-    "- `Modoc Transportation Agency` -> only in rev vehicle list, not in routes or no rt list\n",
-    "- `City of El Segundo` -> ntd id 99449 under LA Metro? not  in the rev vehicle or routes list, only in no_rt list. \n",
-    "- `City of San Fernando` -> under LA Metro as well? in routes and no_rt list, not in rev veh list\n"
+    "- `Yuma County Intergovernmental Public Transportation Authority` -> ~~Yuma Arizona?! 90233? AZ are filtered out.~~ FIXED, i added them manually. GTG\n",
+    "- `City of Alhambra` -> in rev vehicle and route list, but not part of the no_rt list, so was dropped in the final merge. GTG\n",
+    "- `City of Cerritos` -> in rev vehicle and route list, but not part of the no_rt list, so was dropped in the final merge. GTG\n",
+    "- `City of Baldwin Park` -> ~~in rev veh and routes list, but didnt merge because names were different.~~ Is in the no_rt list but is marked YES for having gtfs-RT. Not in bridge table so didnt make it to the routes list.\n",
+    "- `City of Calabasas` -> ~~in rev vehicle and route list, but not part of the no_rt list.~~ In the no_rt list, they have gtfs-rt. GTG\n",
+    "- `City of Compton` - > in rev veh and no_rt list. Not in bridge table so didnt make it to the routes list.\n",
+    "- `Plumas County` -> ~~is in the rev veh-to-routes merge and no_rt list, wasnt joining on the name. can fix this manually (plumas county vs plumas county transportation comission)~~ FIXED. \n",
+    "- `City of Covina` - > in rev veh and no_rt list, Not in bridge table so didnt make it to the routes list.\n",
+    "- `Modoc Transportation Agency` ->  in rev vehicle list and no rt list. Not in bridge table so didnt make it to the routes list.\n",
+    "- `City of El Segundo` -> ntd id 99449 under LA Metro? not  in the rev vehicle or routes list, only in no_rt list. Reduced Asset Reporter in NTD\n",
+    "- `City of San Fernando` -> under LA Metro as well? in routes and no_rt list, not in rev veh list. Reduced Asset Reporter in NTD\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 34,
    "id": "ef5bb51f-93bc-447f-bed3-77a7b2650f37",
    "metadata": {},
    "outputs": [
@@ -1658,19 +1769,43 @@
        "      <th>ntd_id_mart</th>\n",
        "      <th>agency_mart</th>\n",
        "      <th>agency_voms_mart</th>\n",
+       "      <th>report_year_mart</th>\n",
        "      <th>voms_diff</th>\n",
        "      <th>total_fleet_veh_voms_diff</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>200</th>\n",
+       "      <td>200</td>\n",
+       "      <td>99316</td>\n",
+       "      <td>Chemehuevi Indian Tribe</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>99316</td>\n",
+       "      <td>Chemehuevi Indian Tribe</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: [Unnamed: 0, ntd_id, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, ntd_id_mart, agency_mart, agency_voms_mart, voms_diff, total_fleet_veh_voms_diff]\n",
-       "Index: []"
+       "     Unnamed: 0 ntd_id              agency_name  total_fleet_vehicles  \\\n",
+       "200         200  99316  Chemehuevi Indian Tribe                     2   \n",
+       "\n",
+       "     active_fleet_vehicles  modetos_vehicles_operated_in_maximum_service  \\\n",
+       "200                      2                                           2.0   \n",
+       "\n",
+       "    ntd_id_mart              agency_mart  agency_voms_mart  report_year_mart  \\\n",
+       "200       99316  Chemehuevi Indian Tribe               2.0              2024   \n",
+       "\n",
+       "     voms_diff  total_fleet_veh_voms_diff  \n",
+       "200        0.0                        0.0  "
       ]
      },
      "metadata": {},
@@ -1688,7 +1823,7 @@
     {
      "data": {
       "text/plain": [
-       "'Total Routes, from GTFS'"
+       "'Total Routes, from GTFS roll up and bridge table'"
       ]
      },
      "metadata": {},
@@ -1723,27 +1858,14 @@
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>191</th>\n",
-       "      <td>Yuma Schedule</td>\n",
-       "      <td>Yuma County Intergovernmental Public Transport...</td>\n",
-       "      <td>90233</td>\n",
-       "      <td>Yuma Schedule</td>\n",
-       "      <td>9</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "    schedule_gtfs_dataset_name  \\\n",
-       "191              Yuma Schedule   \n",
-       "\n",
-       "                                         analysis_name ntd_id_2022  \\\n",
-       "191  Yuma County Intergovernmental Public Transport...       90233   \n",
-       "\n",
-       "     schedule_name  n_routes  \n",
-       "191  Yuma Schedule         9  "
+       "Empty DataFrame\n",
+       "Columns: [schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, schedule_name, n_routes]\n",
+       "Index: []"
       ]
      },
      "metadata": {},
@@ -1797,6 +1919,7 @@
        "      <th>ntd_id_mart</th>\n",
        "      <th>agency_mart</th>\n",
        "      <th>agency_voms_mart</th>\n",
+       "      <th>report_year_mart</th>\n",
        "      <th>voms_diff</th>\n",
        "      <th>total_fleet_veh_voms_diff</th>\n",
        "      <th>schedule_gtfs_dataset_name</th>\n",
@@ -1813,7 +1936,7 @@
       ],
       "text/plain": [
        "Empty DataFrame\n",
-       "Columns: [Unnamed: 0, ntd_id, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, ntd_id_mart, agency_mart, agency_voms_mart, voms_diff, total_fleet_veh_voms_diff, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, schedule_name, n_routes]\n",
+       "Columns: [Unnamed: 0, ntd_id, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, ntd_id_mart, agency_mart, agency_voms_mart, report_year_mart, voms_diff, total_fleet_veh_voms_diff, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, schedule_name, n_routes]\n",
        "Index: []"
       ]
      },
@@ -1860,6 +1983,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>organization_name</th>\n",
+       "      <th>ntd_id</th>\n",
        "      <th>service_name</th>\n",
        "      <th>total_2023_voms</th>\n",
        "      <th>is_the_agency_pursuing_rt_(via_the_msas_or_not)?</th>\n",
@@ -1871,14 +1995,15 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Yuma County Intergovernmental Public Transport...</td>\n",
-       "      <td>Yuma County Area Transit</td>\n",
-       "      <td>54.0</td>\n",
+       "      <th>50</th>\n",
+       "      <td>Chemehuevi Indian Tribe</td>\n",
+       "      <td>99316</td>\n",
+       "      <td>Havasu Landing Resort &amp; Casino Ferry</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>No</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1886,17 +2011,14 @@
        "</div>"
       ],
       "text/plain": [
-       "                                   organization_name  \\\n",
-       "1  Yuma County Intergovernmental Public Transport...   \n",
+       "          organization_name ntd_id                          service_name  \\\n",
+       "50  Chemehuevi Indian Tribe  99316  Havasu Landing Resort & Casino Ferry   \n",
        "\n",
-       "               service_name  total_2023_voms  \\\n",
-       "1  Yuma County Area Transit             54.0   \n",
+       "    total_2023_voms is_the_agency_pursuing_rt_(via_the_msas_or_not)? notes  \\\n",
+       "50              2.0                                              NaN   NaN   \n",
        "\n",
-       "  is_the_agency_pursuing_rt_(via_the_msas_or_not)? notes passiogo gtfs_rt  \\\n",
-       "1                                              NaN   NaN      NaN     No    \n",
-       "\n",
-       "  if_gtfs-rt_data_-_add_the_link  \n",
-       "1                            NaN  "
+       "   passiogo gtfs_rt if_gtfs-rt_data_-_add_the_link  \n",
+       "50      NaN     NaN                            NaN  "
       ]
      },
      "metadata": {},
@@ -1956,6 +2078,7 @@
        "      <th>passiogo</th>\n",
        "      <th>gtfs_rt</th>\n",
        "      <th>if_gtfs-rt_data_-_add_the_link</th>\n",
+       "      <th>_merge</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1965,7 +2088,78 @@
       ],
       "text/plain": [
        "Empty DataFrame\n",
-       "Columns: [Unnamed: 0, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, n_routes, service_name, is_the_agency_pursuing_rt_(via_the_msas_or_not)?, notes, passiogo, gtfs_rt, if_gtfs-rt_data_-_add_the_link]\n",
+       "Columns: [Unnamed: 0, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, n_routes, service_name, is_the_agency_pursuing_rt_(via_the_msas_or_not)?, notes, passiogo, gtfs_rt, if_gtfs-rt_data_-_add_the_link, _merge]\n",
+       "Index: []"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Merged data, outer join'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>agency_name</th>\n",
+       "      <th>total_fleet_vehicles</th>\n",
+       "      <th>active_fleet_vehicles</th>\n",
+       "      <th>modetos_vehicles_operated_in_maximum_service</th>\n",
+       "      <th>schedule_gtfs_dataset_name</th>\n",
+       "      <th>analysis_name</th>\n",
+       "      <th>ntd_id_2022</th>\n",
+       "      <th>n_routes</th>\n",
+       "      <th>service_name</th>\n",
+       "      <th>is_the_agency_pursuing_rt_(via_the_msas_or_not)?</th>\n",
+       "      <th>notes</th>\n",
+       "      <th>passiogo</th>\n",
+       "      <th>gtfs_rt</th>\n",
+       "      <th>if_gtfs-rt_data_-_add_the_link</th>\n",
+       "      <th>_merge</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [Unnamed: 0, agency_name, total_fleet_vehicles, active_fleet_vehicles, modetos_vehicles_operated_in_maximum_service, schedule_gtfs_dataset_name, analysis_name, ntd_id_2022, n_routes, service_name, is_the_agency_pursuing_rt_(via_the_msas_or_not)?, notes, passiogo, gtfs_rt, if_gtfs-rt_data_-_add_the_link, _merge]\n",
        "Index: []"
       ]
      },
@@ -1974,7 +2168,7 @@
     }
    ],
    "source": [
-    "agency = \"Yuma\"\n",
+    "agency = \"Chemehuevi\"\n",
     "\n",
     "display(\n",
     "    \"Total Revenue Vehicles, from NTD\",\n",
@@ -1983,7 +2177,7 @@
     "        | (diff_voms_ref_veh[\"agency_mart\"].str.contains(agency))\n",
     "    ],\n",
     "    \"\",\n",
-    "    \"Total Routes, from GTFS\",\n",
+    "    \"Total Routes, from GTFS roll up and bridge table\",\n",
     "    rollup_route_bridge[\n",
     "        (rollup_route_bridge[\"schedule_gtfs_dataset_name\"].str.contains(agency))\n",
     "        | (rollup_route_bridge[\"analysis_name\"].str.contains(agency))\n",
@@ -1994,7 +2188,10 @@
     "    rev_veh_route[rev_veh_route[\"agency_name\"].str.contains(agency)],\n",
     "    \"\",\n",
     "    \"List of agencies without GTFS-RT, CS team\",\n",
-    "    no_rt[no_rt[\"organization_name\"].str.contains(agency)],\n",
+    "    no_rt[\n",
+    "        (no_rt[\"organization_name\"].str.contains(agency))\n",
+    "        | (no_rt[\"service_name\"].str.contains(agency))\n",
+    "        ],\n",
     "    \"\",\n",
     "    \"merged data revenue vehicles x total routes to no gtfs_rt agencies\",\n",
     "    clean_check[\n",
@@ -2002,6 +2199,14 @@
     "        | (clean_check[\"schedule_gtfs_dataset_name\"].str.contains(agency))\n",
     "        | (clean_check[\"analysis_name\"].str.contains(agency))\n",
     "        | (clean_check[\"service_name\"].str.contains(agency))\n",
+    "    ],\n",
+    "    \"\",\n",
+    "    \"Merged data, outer join\",\n",
+    "    clean_check_outer_merge[\n",
+    "        (clean_check_outer_merge[\"agency_name\"].str.contains(agency))\n",
+    "        | (clean_check_outer_merge[\"schedule_gtfs_dataset_name\"].str.contains(agency))\n",
+    "        | (clean_check_outer_merge[\"analysis_name\"].str.contains(agency))\n",
+    "        | (clean_check_outer_merge[\"service_name\"].str.contains(agency))\n",
     "    ],\n",
     ")"
    ]


### PR DESCRIPTION
Issue:
- #1943

Changes to initial notebook:
- Received list of "missing agencies" to address. Added section to the bottom of the notebook explaining what happened to each of those agencies. ~7 agencies did not appear in the `bridge_gtfs_analysis_name_x_ntd` table so they never made it to the final merge.
- Added a 2nd attempt at merging per Henry's instructions: merge the revenue vehicle list to the routes list, then merge to the "no gtfs-rt" list
-  Added ntd id to the "no gtfs-rt" list for easier mergning

Also made a brief write up:
>My analysis consist of multiple tables each contiaining multiple components.
>1.	The Total Revenue Vehicles (rev vehicles) table
>2.	The Total Routes (routes table) table
>3.	The “organizations_without_gtfs_rt_data…” (no_rt list) table
>
>Regarding the rev vehicles table. The National Transit Database (NTD) provides a report of revenue vehicle inventory, see link: https://www.transit.dot.gov/ntd/data-product/2024-annual-database-revenue-vehicle-inventory. This dataset was filtered for California agencies, grouped by ntd_id and agency name and aggregated to sum the total fleet vehicles, active fleet vehicles and mode/TOS VOMS. The resulting rev vehicles table contains  total revenue vehicles and VOMS per agency
>
>The routes table is built using a SQL query that joins 2 tables from the DDS data warehouse;
>1.	mart_gtfs_rollup.fct_monthly_operator_summary (rollup table)
>2.	mart_transit_database.bridge_gtfs_analysis_name_x_ntd (bridge table)
>
>The rollup table contains the total count of routes per GTFS schedule dataset. This table was filtered for schedules after February 1, 2026. The bridge table provides a crosswalk between GTFS schedule dataset name to NTD IDs, effectively identifying the agency name for the schedule. However, it was discovered that not every schedule in the rollup table is include in the bridge table. Meaning some schedules were dropped during the final merge. The resulting routes table contains the total routes per schedule per agency.
>
>The “no_rt list” table contains a list of transit agencies that do not have GTFS-RT. However, some agencies were marked YES or have PassiGO. An NTD ID column was added to make joining to the other tables easier. 
>
>First, the rev vehicles and routes table were  inner joined on NTD ID, resulting in in 155 agencies with: total revenue vehicles, VOMS and total routes values. The resulting table was then joined to the no_rt table. Some agencies were dropped during the merges so 2 scenarios emerged.
>1.	Inner join: only NTD ID that matched both lists were kept. This list contained 51 agencies.
>2.	Outer join: Kept all NTD ID from both list, regardless if they matched. This contains 162 agencies but can be used for further filtering.
>
>The following agencies in the no_rt list were dropped from the final datatset because the agencies did not appear in the bridge table
>ntd_id   organization_name
>90251   City of Baldwin Park
>90260   City of Compton
>90261   City of Covina
>91008   Modoc Transportation Agency
>99316   Chemehuevi Indian Tribe
>99449   City of El Segundo
>99451   City of San Fernando
