### PR TITLE
Fix build portfolio for JupyterBook V2 and Myst

### DIFF
--- a/.github/workflows/update-portfolio-index.yml
+++ b/.github/workflows/update-portfolio-index.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Deploy index
         run: |
-          python portfolio/portfolio.py index --deploy
+          python portfolio/portfolio.py index --deploy --prod

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,56 @@
 # Run this in data-analyses
 # To specify different Makefile: make build_parallel_corridors -f Makefile
 
+# Build and Deploy Production Portfolio Site with:
+# make build_portfolio_site site='MY_SITE_IDENTIFIER'
 build_portfolio_site:
 	cd portfolio/ && pip install -r requirements.txt && cd ../
-	python portfolio/portfolio.py clean $(site)
+	#python portfolio/portfolio.py clean $(site)
 	python portfolio/portfolio.py build $(site)
 	gcloud auth login --login-config=iac/login.json && gcloud config set project cal-itp-data-infra
-	python portfolio/portfolio.py build $(site) --no-execute-papermill --deploy
+	python portfolio/portfolio.py build $(site) --no-execute-papermill --deploy --target production
 	git add portfolio/sites/$(site).yml
-	#make production_portfolio
+	#make build_portfolio_index
 
+# Build and Deploy Staging Portfolio Site with:
+# make build_staging_portfolio_site site='MY_SITE_IDENTIFIER'
+build_staging_portfolio_site:
+	cd portfolio/ && pip install -r requirements.txt && cd ../
+	#python portfolio/portfolio.py clean $(site)
+	gcloud auth login --login-config=iac/login.json
+	python portfolio/portfolio.py build $(site)
+	python portfolio/portfolio.py build $(site) --no-execute-papermill --deploy --target staging
+	#make build_staging_portfolio_index
+
+# Build and Deploy Production Portfolio Index page with:
+build_portfolio_index:
+	python portfolio/portfolio.py index --deploy --prod
+
+# Build and Deploy Staging Portfolio Index page (including test portfolios) with:
+build_staging_portfolio_index:
+	python portfolio/portfolio.py index --deploy --no-prod
+
+# Build locally the Portfolio Site without deploying with:
+# make test_build_portfolio_site site='MY_SITE_IDENTIFIER'
+test_build_portfolio_site:
+	#python portfolio/portfolio.py clean $(site)
+	#gcloud auth login --login-config=iac/login.json
+	python portfolio/portfolio.py build $(site)
+
+# Build locally the Portfolio Site without deploying with:
+# make test_build_portfolio_site site='MY_SITE_IDENTIFIER'
+test_build_portfolio_site:
+	#python portfolio/portfolio.py clean $(site)
+	#gcloud auth login --login-config=iac/login.json
+	python portfolio/portfolio.py build $(site)
+
+# Delete Local Site folder with:
+# make build_portfolio_site site='MY_SITE_IDENTIFIER'
+clean_portfolio_site:
+	python portfolio/portfolio.py clean $(site)
+
+# Delete Local Site folder and Remove Portfolio site with:
+# make build_staging_portfolio_site site='MY_SITE_IDENTIFIER'
 remove_portfolio_site:
 	python portfolio/portfolio.py clean $(site)
 	git rm portfolio/sites/$(site).yml
@@ -68,15 +109,8 @@ install_env:
 	cd rt_segment_speeds && pip install -r requirements.txt && cd ..
 	make add_precommit
 
-production_portfolio:
-	python portfolio/portfolio.py index --deploy
-
-# deploy site with:
-# make staging_portfolio site='MY_SITE_IDENTIFIER'
-staging_portfolio:
-	gcloud auth login --login-config=iac/login.json
-	python portfolio/portfolio.py deploy-index --target staging
-	python portfolio/portfolio.py deploy-site $(site) --target staging
+install_portfolio:
+	cd portfolio/ && pip install -r requirements.txt && cd ../
 
 # Create .egg to upload to dask cloud cluster
 egg_modules:

--- a/_shared_utils/shared_utils/portfolio_utils.py
+++ b/_shared_utils/shared_utils/portfolio_utils.py
@@ -21,7 +21,9 @@ def gcs_pandas():
     return GCSPandas()
 
 
-def create_portfolio_yaml_chapters_no_sections(portfolio_site_yaml: Path, chapter_name: str, chapter_values: list):
+def create_portfolio_yaml_chapters_no_sections(
+    portfolio_site_yaml: Path, chapter_name: str, chapter_values: list, group_caption: str = None
+):
     """
     Overwrite a portfolio site yaml by filling in all the parameters.
     Chapters no sections refer to analyses parameterized by 1 value.
@@ -40,8 +42,11 @@ def create_portfolio_yaml_chapters_no_sections(portfolio_site_yaml: Path, chapte
     chapters_list = [{**{"params": {chapter_name: str(one_chapter_value)}}} for one_chapter_value in chapter_values]
 
     # Make this into a list item
-    parts_list = [{"caption": "Introduction"}, {"chapters": chapters_list}]
-    site_yaml_dict["parts"] = parts_list
+    part = {"chapters": chapters_list}
+    if group_caption:
+        part["caption"] = group_caption
+
+    site_yaml_dict["parts"] = [part]
 
     # dump this dict into the yaml and overwrite existing file
     output = yaml.dump(site_yaml_dict)

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -20,30 +20,43 @@ See instructions here for authoring a notebook for paramaterization [pointers fo
      * by Caltrans district (chapter) and each district is its own page (no section).
    * [various parameterization examples](https://docs.calitp.org/data-infra/publishing/sections/5_analytics_portfolio_site.html)
 
-1. Build and deploy your parameterized notebook as a JupyterBook
+2. Build and deploy your parameterized notebook as a JupyterBook
    * (Optionally) Remove the local folder containing the previously generate portfolio site
      ```
      python portfolio/portfolio.py clean MY_NEW_REPORT
      ```
    * Parameterize the notebook specified in `portfolio/sites/MY_NEW_REPORT.yml`
      ```
-     python portfolio/portfolio.py build MY_NEW_REPORT`
+     python portfolio/portfolio.py build MY_NEW_REPORT
+     ```
+
+     Add the option `--hide_title_block` if you want to build the site without the Title Block.
+
+     ```
+     python portfolio/portfolio.py build MY_NEW_REPORT --hide_title_block
      ```
       * local files are created in `portfolio/MY_NEW_REPORT/` (all files below are within this newly created `portfolio/MY_NEW_REPORT/` sub-directory)
-      * JupyterBook necessary accessories: `myst.yml` and `README.md`
+      * JupyterBook necessary accessories: `myst.yml` and a README file.
       * There will be additional files or directories holding the parameterized notebooks and site build files.
    * During build you will see any accessibility violations that are detected in the generated site.
 
-1. Deploy your portfolio site to the staging environment for review
+3. Deploy your portfolio site to the staging environment for review
+> [!NOTE]
+> The default target is staging, so `--target staging` can be supplied.
+
    ```
    python portfolio/portfolio.py deploy-site MY_NEW_REPORT --target staging
    ```
+
    This will deploy to `https://analysis-staging.dds.dot.ca.gov/MY_NEW_REPORT`. You can later deploy to production with `--target production`.
 
 ### Additional useful commands and info
+> [!NOTE]
+> The default target is staging, so `--target staging` can be supplied.
+
 * Combine __production__ build and deploy steps for a specific portfolio site
   ```
-  python portfolio/portfolio.py build MY_NEW_REPORT --deploy
+  python portfolio/portfolio.py build MY_NEW_REPORT --deploy --target staging
   ```
   This will deploy to `https://analysis.dds.dot.ca.gov/MY_NEW_REPORT`.
 * When we deploy, the HTML files in `portfolio/MY_NEW_REPORT/_build/html` are published either to the staging or production sites.
@@ -51,12 +64,16 @@ See instructions here for authoring a notebook for paramaterization [pointers fo
 * Portfolio sites are now gitignored, no longer checked into git.
 
 ### Deploy Portfolio Index
+> [!NOTE]
+> The default target is staging, so `--target staging` can be supplied.
 
-Deploying to the staging environment (https://analysis-staging.dds.dot.ca.gov/)
+To deploy the Index page to the staging environment (https://analysis-staging.dds.dot.ca.gov/), run:
 ```
 python portfolio/portfolio.py deploy-index --target staging
 ```
 You can deploy to production with `--target production`.
+
+There is only one difference between staging and production Index page. In the Staging Index page you will see a list of `Test Projects` that you can use as examples or experiment building new ones.
 
 ## Accessibility Testing
 You will see accessibility violations at the end of building your site. If you have already built your site and wish to run only accessibilty checks, you can run `python portfolio/portfolio.py check-accessibility MY_NEW_REPORT`

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -25,7 +25,6 @@ from papermill.engines import NBClientEngine, papermill_engines
 from pydantic import BaseModel, field_validator
 from selenium import webdriver
 from slugify import slugify
-from typing_extensions import Annotated
 
 assert os.getcwd().endswith("data-analyses"), "this script must be run from the root of the data-analyses repo!"
 
@@ -64,6 +63,12 @@ def parameterize_filename(i: int, old_path: Path, params: Dict) -> Path:
     assert old_path.suffix == ".ipynb"
 
     return Path(str(i).zfill(2) + "__" + old_path.stem + "__" + slugify_params(params) + old_path.suffix)
+
+
+class YamlPartialDumper(yaml.Dumper):
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super(YamlPartialDumper, self).increase_indent(flow, False)
 
 
 class TyperLoggerHandler(logging.Handler):
@@ -223,19 +228,35 @@ class Chapter(BaseModel):
     @property
     def toc(self):
         if self.sections:
-            return {
-                "file": f"{self.slug}.md",
-                "children": [
-                    {
-                        "glob": f"{self.slug}/*",
-                    }
-                ],
-            }
+            if self.caption:
+                return {
+                    "title": f"{self.caption}",
+                    "file": f"{self.slug}.md",
+                    "children": [
+                        {
+                            "pattern": f"{self.slug}/*",
+                        }
+                    ],
+                }
+            else:
+                return {
+                    "file": f"{self.slug}.md",
+                    "children": [
+                        {
+                            "glob": f"{self.slug}/*",
+                        }
+                    ],
+                }
 
         folder = f"{self.slug}/" if self.slug else ""
-        return {
-            "file": f"{folder}{parameterize_filename('00', self.resolved_notebook, self.resolved_params)}",
-        }
+
+        if self.caption:
+            return {
+                "title": f"{self.caption}",
+                "file": f"{folder}{parameterize_filename('00', self.resolved_notebook, self.resolved_params)}",
+            }
+        else:
+            return {"file": f"{folder}{parameterize_filename('00', self.resolved_notebook, self.resolved_params)}"}
 
 
 class Part(BaseModel):
@@ -257,13 +278,7 @@ class Part(BaseModel):
 
     @property
     def to_toc(self):
-        return {"title": self.caption, "children": [chapter.toc for chapter in self.chapters]}
-
-
-class YamlPartialDumper(yaml.Dumper):
-
-    def increase_indent(self, flow=False, indentless=False):
-        return super(YamlPartialDumper, self).increase_indent(flow, False)
+        return {"title": self.caption} if self.caption else {}
 
 
 class Site(BaseModel):
@@ -274,15 +289,13 @@ class Site(BaseModel):
     readme: Optional[Path] = "README.md"
     notebook: Optional[Path] = None
     parts: List[Part] = []
-    chapters: List[Chapter] = []
     prepare_only: bool = False
 
     def __init__(self, **data):
         super().__init__(**data)
 
-        content = [*self.chapters, *self.parts]
-        for child in content:
-            child.site = self
+        for part in self.parts:
+            part.site = self
 
     @field_validator("readme", mode="before", check_fields=False)
     @classmethod
@@ -291,7 +304,7 @@ class Site(BaseModel):
             return Path(v)
         else:
             directory = info.data["directory"]
-            return (directory / Path("README.md")) or (directory / Path(v))
+            return directory / Path(v)
 
     @property
     def slug(self) -> str:
@@ -299,11 +312,18 @@ class Site(BaseModel):
 
     @property
     def toc_yaml(self) -> str:
-        chapters = [chapter.toc for chapter in self.chapters]
-        parts = [part.to_toc for part in self.parts if part.chapters]
-        children = [*chapters, *parts]
+        toc = [{"file": self.readme.name}]
+        for part in self.parts:
+            if part.chapters:
+                if part.to_toc:
+                    children = {"children": [chapter.toc for chapter in part.chapters]}
+                    toc.append(part.to_toc | children)
+                else:
+                    for chapter in part.chapters:
+                        toc.append(chapter.toc)
+
         return yaml.dump(
-            {"toc": [{"file": "README.md"}, *children]},
+            {"toc": toc},
             indent=4,
             Dumper=YamlPartialDumper,
         )
@@ -381,7 +401,7 @@ def index(
             f.write(env.get_template(template).render(sites=sites, google_analytics_id=GOOGLE_ANALYTICS_TAG_ID))
 
     if deploy:
-        deploy_index("production")
+        deploy_index("production" if prod else "staging")
 
 
 @app.command()
@@ -405,18 +425,23 @@ def build(
     ),
     no_stderr: bool = typer.Option(
         True,
-        help="If true, will clear stderr stream for cell outputs",
+        help="If true, will clear stderr stream for cell outputs.",
     ),
     prepare_only: bool = typer.Option(
         False,
         help="Pass-through flag to papermill; if true, papermill will not actually execute cells.",
     ),
-    verbose_logging: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging, DEBUG"),
+    verbose_logging: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging, DEBUG."),
+    target: str = typer.Option("staging", help="Where to deploy the site: staging or production."),
+    hide_title_block: bool = typer.Option(False, help="If true, will hide the title block for all pages."),
 ) -> None:
     """
     Builds a static site from parameterized notebooks as defined in a site YAML file.
     """
+    assert target in ["staging", "production"]
+
     configure_logging(verbose_logging)
+
     site_yml_name = site.value
     site_output_dir = PORTFOLIO_DIR / Path(site_yml_name)
     site_output_dir.mkdir(parents=True, exist_ok=True)
@@ -424,31 +449,24 @@ def build(
     with open(SITES_DIR / Path(f"{site_yml_name}.yml")) as f:
         portfolio_site = Site(output_dir=site_output_dir, name=site_yml_name, **yaml.safe_load(f))
 
-    typer.echo(f"copying readme from {portfolio_site.directory} to {site_output_dir}")
+    typer.echo(f"copying {portfolio_site.readme.name} from {portfolio_site.directory} to {site_output_dir}")
     shutil.copy(portfolio_site.readme, site_output_dir / portfolio_site.readme.name)
 
     fname = site_output_dir / Path("myst.yml")
     with open(fname, "w") as f:
         typer.secho(f"writing config and toc to {fname}", fg=typer.colors.GREEN)
         toc = portfolio_site.toc_yaml
+        typer.echo(toc)
         f.write(
             env.get_template("myst.yml").render(
-                site=portfolio_site, toc=toc, google_analytics_id=GOOGLE_ANALYTICS_TAG_ID
+                site=portfolio_site,
+                toc=toc,
+                hide_title_block=hide_title_block,
+                google_analytics_id=GOOGLE_ANALYTICS_TAG_ID,
             )
         )
 
     errors = []
-
-    for chapter in portfolio_site.chapters:
-        errors.extend(
-            chapter.generate(
-                execute_papermill=execute_papermill,
-                continue_on_error=continue_on_error,
-                prepare_only=prepare_only,
-                no_stderr=no_stderr,
-            )
-        )
-
     for part in portfolio_site.parts:
         for chapter in part.chapters:
             errors.extend(
@@ -485,7 +503,7 @@ def build(
             if ans != "ignore":
                 return
 
-        deploy_site(site, "production")
+        deploy_site(site, target)
 
     if errors:
         typer.secho(f"{len(errors)} errors encountered during papermill execution", fg=typer.colors.RED)
@@ -493,7 +511,7 @@ def build(
 
 
 @app.command()
-def deploy_index(target: Annotated[str, typer.Option(help="Where to deploy the site [staging|production]")]):
+def deploy_index(target: str = typer.Option("staging", help="Where to deploy the site: staging or production.")):
     """
     Deploys index page for analysis portfolio.
     """
@@ -507,7 +525,7 @@ def deploy_index(target: Annotated[str, typer.Option(help="Where to deploy the s
 
 @app.command()
 def deploy_site(
-    site: SiteChoices, target: Annotated[str, typer.Option(help="Where to deploy the site [staging|production]")]
+    site: SiteChoices, target: str = typer.Option("staging", help="Where to deploy the site: staging or production.")
 ):
     """
     Deploys site.

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -387,18 +387,33 @@ def index(
     prod: bool = False,
 ) -> None:
     sites = []
+    test_sites = []
+
     for site in os.listdir("./portfolio/sites/"):
+        if prod and site.lower().endswith("_test.yml"):
+            continue
+
         with open(f"./portfolio/sites/{site}") as f:
             name = site.replace(".yml", "")
             site_output_dir = PORTFOLIO_DIR / Path(name)
-            sites.append(Site(output_dir=site_output_dir, name=name, **yaml.safe_load(f)))
+            if site.lower().endswith("_test.yml"):
+                test_sites.append(Site(output_dir=site_output_dir, name=name, **yaml.safe_load(f)))
+            else:
+                sites.append(Site(output_dir=site_output_dir, name=name, **yaml.safe_load(f)))
+
+    sites.sort(key=lambda s: s.title)
+    test_sites.sort(key=lambda s: s.title)
 
     Path("./portfolio/index").mkdir(parents=True, exist_ok=True)
     for template in ["index.html"]:
         fname = f"./portfolio/index/{template}"
         with open(fname, "w") as f:
             typer.echo(f"writing out to {fname}")
-            f.write(env.get_template(template).render(sites=sites, google_analytics_id=GOOGLE_ANALYTICS_TAG_ID))
+            f.write(
+                env.get_template(template).render(
+                    sites=sites, test_sites=test_sites, google_analytics_id=GOOGLE_ANALYTICS_TAG_ID
+                )
+            )
 
     if deploy:
         deploy_index("production" if prod else "staging")

--- a/portfolio/sites/_basic_analyses_test.yml
+++ b/portfolio/sites/_basic_analyses_test.yml
@@ -1,0 +1,7 @@
+title: Basic Analyses Test
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README.md
+parts:
+  - chapters:
+      - notebook: ./tests/fixtures/portfolio/notebook_1.ipynb
+      - notebook: ./tests/fixtures/portfolio/notebook_2.ipynb

--- a/portfolio/sites/_different_readme_analyses_test.yml
+++ b/portfolio/sites/_different_readme_analyses_test.yml
@@ -1,0 +1,6 @@
+title: Different Readme Analyses Test
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README_SIMPLE.md
+parts:
+  - chapters:
+    - notebook: ./tests/fixtures/portfolio/notebook_new_readme_1.ipynb

--- a/portfolio/sites/_group_analyses_test.yml
+++ b/portfolio/sites/_group_analyses_test.yml
@@ -1,0 +1,8 @@
+title: Group Analyses Test
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README.md
+parts:
+  - caption: Introduction
+    chapters:
+      - notebook: ./tests/fixtures/portfolio/notebook_1.ipynb
+      - notebook: ./tests/fixtures/portfolio/notebook_2.ipynb

--- a/portfolio/sites/_group_and_params_analyses_test.yml
+++ b/portfolio/sites/_group_and_params_analyses_test.yml
@@ -1,0 +1,21 @@
+title: Group and Params Analyses Test
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README_BR.md
+notebook: ./tests/fixtures/portfolio/notebook_with_params_1.ipynb
+parts:
+    - caption: District 01 Eureka
+      chapters:
+        - params:
+            greetings: Humboldt Transit Authority
+        - params:
+            greetings: Lake Transit Authority
+        - params:
+            greetings: Mendocino Transit Authority
+        - params:
+            greetings: Redwood Coast Transit Authority
+    - caption: District 02 Redding
+      chapters:
+        - params:
+            greetings: Redding Area Bus Authority
+        - params:
+            greetings: Tehama County

--- a/portfolio/sites/_param_analyses_test.yml
+++ b/portfolio/sites/_param_analyses_test.yml
@@ -1,0 +1,10 @@
+title: Greetings Analyses Test with Params
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README.md
+notebook: ./tests/fixtures/portfolio/notebook_with_params_1.ipynb
+parts:
+  - chapters:
+    - params:
+        greetings: Hi! So happy to see you here!!
+    - params:
+        greetings: Bye! See you soon!!

--- a/portfolio/sites/_param_manual_title_analyses_test.yml
+++ b/portfolio/sites/_param_manual_title_analyses_test.yml
@@ -1,0 +1,12 @@
+title: Greetings Analyses Test with Params (Hiding Title Block)
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README.md
+notebook: ./tests/fixtures/portfolio/notebook_with_params_1.ipynb
+parts:
+  - chapters:
+    - caption: Hi!
+      params:
+        greetings: Hi! So happy to see you here!!
+    - caption: Bye!
+      params:
+        greetings: Bye! See you soon!!

--- a/portfolio/sites/_param_manual_title_br_analyses_test.yml
+++ b/portfolio/sites/_param_manual_title_br_analyses_test.yml
@@ -1,0 +1,12 @@
+title: Greetings Analyses Test with Params (Hiding Title Block and Blank Lines)
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README_BR.md
+notebook: ./tests/fixtures/portfolio/notebook_with_params_2.ipynb
+parts:
+  - chapters:
+    - caption: Hi!
+      params:
+        greetings: Hi! So happy to see you here!!
+    - caption: Bye!
+      params:
+        greetings: Bye! See you soon!!

--- a/portfolio/sites/_readme_only_analyses_test.yml
+++ b/portfolio/sites/_readme_only_analyses_test.yml
@@ -1,0 +1,3 @@
+title: Readme Only Analyses Test
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README.md

--- a/portfolio/sites/_section_analyses_test.yml
+++ b/portfolio/sites/_section_analyses_test.yml
@@ -1,0 +1,17 @@
+title: Section Analyses Test
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README_BR.md
+notebook: ./tests/fixtures/portfolio/notebook_with_params_2.ipynb
+parts:
+  - chapters:
+    - caption: Daily Greetings
+      params:
+        day_or_night: 01 - Day
+      sections:
+        - greetings: Good Morning!
+        - greetings: Good Afternoon!
+    - caption: Night Greetings
+      params:
+        day_or_night: 02 - Night
+      sections:
+        - greetings: Sleep well!

--- a/portfolio/sites/_section_as_group_analyses_test.yml
+++ b/portfolio/sites/_section_as_group_analyses_test.yml
@@ -1,0 +1,15 @@
+title: Section Analyses Test (as Group)
+directory: ./tests/fixtures/portfolio/
+readme: ./tests/fixtures/portfolio/README_BR.md
+notebook: ./tests/fixtures/portfolio/notebook_with_params_2.ipynb
+parts:
+    - caption: Daily Greetings
+      chapters:
+        - params:
+            greetings: Good Morning!
+        - params:
+            greetings: Good Afternoon!
+    - caption: Night Greetings
+      chapters:
+        - params:
+            greetings: Sleep well!

--- a/portfolio/sites/ntd_monthly_ridership.yml
+++ b/portfolio/sites/ntd_monthly_ridership.yml
@@ -1,79 +1,56 @@
-title: NTD Monthly Ridership by RTPA
 directory: ./ntd/monthly_ridership_report
-readme: ./ntd/monthly_ridership_report/README.md
-chapters:
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
+parts:
+- chapters:
+  - params:
       rtpa: Butte County Association of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: El Dorado County Transportation Commission
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Fresno Council of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Imperial County Transportation Commission
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Kern Council of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Kings County Association of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Los Angeles County Metropolitan Transportation Authority
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Merced County Association of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Metropolitan Transportation Commission
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Orange County Transportation Authority
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Placer County Transportation Planning Agency
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Riverside County Transportation Commission
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Sacramento Area Council of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: San Bernardino County Transportation Authority
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: San Diego Association of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: San Joaquin Council of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: San Luis Obispo Council of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Santa Barbara County Association of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Santa Cruz County Regional Transportation Commission
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Shasta Regional Transportation Agency
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Stanislaus Council of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Tahoe Regional Planning Agency
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Transportation Agency for Monterey County
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Tulare County Association of Governments
-  - notebook: ./ntd/monthly_ridership_report/monthly_ridership_report.ipynb
-    params:
+  - params:
       rtpa: Ventura County Transportation Commission
+readme: ./ntd/monthly_ridership_report/README.md
+title: NTD Monthly Ridership by RTPA

--- a/portfolio/templates/index.html
+++ b/portfolio/templates/index.html
@@ -65,6 +65,14 @@
         <p><a href="/{{ site.name }}/">{{ site.title }}</a></p>
         {% endfor %}
         <p><p>
+        {% if test_sites %}
+            <h3>Test Projects</h3>
+            <p>Examples of projects to build sites. Source code can be found <a href="https://github.com/cal-itp/data-analyses/tree/mov/1956-fix-build-portfolio/tests/fixtures/portfolio/">on GitHub.</a></p>
+            {% for test_site in test_sites -%}
+            <p><a href="/{{ test_site.name }}/">{{ test_site.title }}</a></p>
+            {% endfor %}
+            <p><p>
+        {% endif %}
         <h2>Reports</h2>
 <p>Accurate and timely GTFS data is a critical part of a providing a good transit experience. Our reports measure the quality of the GTFS data produced by an individual transit operator each month.</p>
 <a href="https://reports.dds.dot.ca.gov/">California GTFS Quality Dashboard</a><p>

--- a/portfolio/templates/index.html
+++ b/portfolio/templates/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Cal-ITP Data Analyses Portfolio</title>
+    <link rel="icon" href="https://raw.githubusercontent.com/cal-itp/data-analyses/refs/heads/main/portfolio/templates/assets/favicon.ico" type="image/x-icon">
     <!-- Shamelessly stolen -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&amp;family=Raleway:wght@700&amp;display=swap">
      <style type="text/css">

--- a/portfolio/templates/myst.yml
+++ b/portfolio/templates/myst.yml
@@ -24,4 +24,5 @@ site:
     logo_alt: Caltrans Data and Digital Services Logos
     style: ../templates/custom.css
     hide_title_block: {{ hide_title_block }}
+    hide_authors: true
   template: book-theme

--- a/portfolio/templates/myst.yml
+++ b/portfolio/templates/myst.yml
@@ -23,4 +23,5 @@ site:
     logo_url: '/'
     logo_alt: Caltrans Data and Digital Services Logos
     style: ../templates/custom.css
+    hide_title_block: {{ hide_title_block }}
   template: book-theme

--- a/tests/fixtures/portfolio/README.md
+++ b/tests/fixtures/portfolio/README.md
@@ -1,0 +1,7 @@
+# My Readme
+
+This is my analyses READ-ME file.
+
+## Definitions
+
+Just to run some fun tests!

--- a/tests/fixtures/portfolio/README_BR.md
+++ b/tests/fixtures/portfolio/README_BR.md
@@ -1,0 +1,10 @@
+<br>
+<br>
+
+# My Simple Readme
+
+This is my simple analyses READ-ME file.
+
+## Definitions
+
+Just to run some fun tests!

--- a/tests/fixtures/portfolio/README_SIMPLE.md
+++ b/tests/fixtures/portfolio/README_SIMPLE.md
@@ -1,0 +1,7 @@
+# My Simple Readme
+
+This is my simple analyses READ-ME file.
+
+## Definitions
+
+Just to run some fun tests!

--- a/tests/fixtures/portfolio/notebook_1.ipynb
+++ b/tests/fixtures/portfolio/notebook_1.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b8821431-1c90-4035-bfe5-48ddd59a41d8",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# My Simple Analyses Test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "857aa720-811e-4677-ac9a-fea0842a9362",
+   "metadata": {},
+   "source": [
+    "Lets see if you can see my analyses!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/fixtures/portfolio/notebook_2.ipynb
+++ b/tests/fixtures/portfolio/notebook_2.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b8821431-1c90-4035-bfe5-48ddd59a41d8",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# My Simple Analyses Test 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "857aa720-811e-4677-ac9a-fea0842a9362",
+   "metadata": {},
+   "source": [
+    "Yay! You got it!!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/fixtures/portfolio/notebook_new_readme_1.ipynb
+++ b/tests/fixtures/portfolio/notebook_new_readme_1.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b8821431-1c90-4035-bfe5-48ddd59a41d8",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# My New Readme Analyses Test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "857aa720-811e-4677-ac9a-fea0842a9362",
+   "metadata": {},
+   "source": [
+    "Lets see if you can see my analyses with a NEW READ-ME!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "253fc752-8426-43d8-b70a-8f349ba78fc3",
+   "metadata": {},
+   "source": [
+    "It is very simple! You just need to inform the path and the file name of your read-me."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b5b532c-6915-493c-ba1b-91a37bd5753b",
+   "metadata": {},
+   "source": [
+    "See line 3 on the example bellow:"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "f26c159b-480d-4a83-809f-94c6e779f2f8",
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "title: My New Readme Analyses Test\n",
+    "directory: ./\n",
+    "readme: ./NEW_README.md\n",
+    "parts:\n",
+    "  - chapters:\n",
+    "    - notebook: ./notebook_new_readme_1.ipynb"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/fixtures/portfolio/notebook_with_params_1.ipynb
+++ b/tests/fixtures/portfolio/notebook_with_params_1.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba1fde1d-5775-48c0-b1e8-c09f30df1731",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# greetings = \"Happy Monday\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e8e98ae-83bc-4a21-9bba-b7a0f1753efa",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "import calitp_data_analysis.magics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c06d61d1-e991-45b7-9745-839cce6143a8",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture_parameters\n",
+    "greetings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "796a4c05-e3e0-4562-a45a-a4e90024e6bd",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# {greetings}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "286fa822-9f85-4671-9525-58937ad9daba",
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## ☀️ Every morning starts a new page in your story. Make it a great one today."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/fixtures/portfolio/notebook_with_params_2.ipynb
+++ b/tests/fixtures/portfolio/notebook_with_params_2.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba1fde1d-5775-48c0-b1e8-c09f30df1731",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# greetings = \"Happy Monday\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e8e98ae-83bc-4a21-9bba-b7a0f1753efa",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "import calitp_data_analysis.magics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c06d61d1-e991-45b7-9745-839cce6143a8",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture_parameters\n",
+    "greetings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53ed9826-20a7-477f-a048-4e1c3917b84b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<br>\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "796a4c05-e3e0-4562-a45a-a4e90024e6bd",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# {greetings}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "286fa822-9f85-4671-9525-58937ad9daba",
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## ☀️ Every morning starts a new page in your story. Make it a great one today."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR fixes the Portfolio build to generate sites correctly using JupyterBook V2 and Myst.

Also improved Index page by adding `favicon`:
<img width="379" height="74" alt="image" src="https://github.com/user-attachments/assets/54d604cd-563d-49c0-9a68-2fb4660608c4" />

This option with an Arrow on the menu, I am calling a `Group option`:
<img width="1434" height="569" alt="image" src="https://github.com/user-attachments/assets/cc6fd39c-667d-4af1-96e3-26deef8c73af" />

To use this `Group Option` you can pass a new param `group_caption="My Group Title"` when calling [create_portfolio_yaml_chapters_no_sections](https://github.com/cal-itp/data-analyses/blob/d254398c0147c1f7d8025e456c04e1d91013200c/ntd/monthly_ridership_report/deploy_portfolio_yaml.py#L44):

``` 
    portfolio_utils.create_portfolio_yaml_chapters_no_sections(
        PORTFOLIO_SITE_YAML, chapter_name="rtpa", chapter_values=list(df.rtpa_name), group_caption="My Group Title"
    )
```



I tested all the changes using new Test Project examples that can be visualized at: https://analysis-staging.dds.dot.ca.gov/


<img width="592" height="440" alt="image" src="https://github.com/user-attachments/assets/f217841f-0617-4a6e-8488-e2ea84b152eb" />

This Test list will show only on Staging. It is excluded from Production index page (https://analysis.dds.dot.ca.gov).