### PR TITLE
Move Title to extras to display iframe map correctly

### DIFF
--- a/_shared_utils/shared_utils/webmap_utils.py
+++ b/_shared_utils/shared_utils/webmap_utils.py
@@ -152,7 +152,7 @@ def display_spa_map(spa_map_url: str, width: int = 1000, height: int = 650, titl
     Width/height defaults are current best option for JupyterBook, don't change for portfolio use
     width, height: int (pixels)
     """
-    i = IFrame(spa_map_url, width=width, height=height, title=title)
+    i = IFrame(spa_map_url, width=width, height=height, extras=[f'title="{title}"'])
     display(i)
     return
 


### PR DESCRIPTION
This PR fixes the `Bug: Webapp maps not rendering in iframe, same link works in new tab`
https://github.com/cal-itp/data-analyses/issues/2013.

We added a title required for accessibility, but it was creating a param on the map link instead or a Title property. I moved into `extras` and I was able to visualize the map.

<img width="1257" height="790" alt="image" src="https://github.com/user-attachments/assets/b86fd6b9-36af-433c-a7a1-0bd4ade37297" />
