### PR TITLE
Remove tzset from shared_utils.rt_utils (#2029)

### DIFF
--- a/_shared_utils/pyproject.toml
+++ b/_shared_utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shared-utils"
-version = "5.0.0"
+version = "5.0.1"
 requires-python = ">=3.11.0, <3.12.0"
 dependencies = [
     "calitp-data-analysis",

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -20,10 +20,6 @@ fs = get_fs()
 gcsgp = GCSGeoPandas()
 
 
-# set system time
-os.environ["TZ"] = "America/Los_Angeles"
-time.tzset()
-
 GCS_PROJECT = "cal-itp-data-infra"
 BUCKET_NAME = "calitp-analytics-data"
 BUCKET_DIR = "data-analyses/rt_delay"

--- a/_shared_utils/shared_utils/rt_utils.py
+++ b/_shared_utils/shared_utils/rt_utils.py
@@ -1,6 +1,4 @@
 import datetime as dt
-import os
-import time
 from pathlib import Path
 
 import branca

--- a/uv.lock
+++ b/uv.lock
@@ -3209,7 +3209,7 @@ wheels = [
 
 [[package]]
 name = "shared-utils"
-version = "5.0.0"
+version = "5.0.1"
 source = { editable = "_shared_utils" }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
### Summary
`shared_utils.rt_utils` sets a timezone environment variable and uses `time.tzset`. This function is not defined on Windows, preventing local development with shared_utils, but does not seem to be necessary and could lead to unexpected behavior if users are not aware that the import is changing their timezone. 

### Changes
- Removed `time.tzset` from `shared_utils.rt_utils`
- Bumped version

### Testing
- On Windows ran `uv run --group test pytest` from the shared_utils directory and confirmed all tests pass
- Ran some cells in `gtfs_digest/report_caltrans_district`, received expected output