### PR TITLE
Update uv sources path to local folders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,5 @@ test = [
 [tool.uv.sources]
 shared-utils = { workspace = true }
 calitp-data-analysis = { workspace = true }
-segment-speed-utils = { path = "rt_segment_speeds", editable = true }
-rt-analysis = { path = "rt_delay", editable = true }
+segment-speed-utils = { path = "./rt_segment_speeds", editable = true }
+rt-analysis = { path = "./rt_delay", editable = true }


### PR DESCRIPTION
Dependabots actions are failing to run:
```
Error during file fetching; aborting: The following path based dependencies could not be retrieved: "segment-speed-utils" at /pyproject.toml, "rt-analysis" at /pyproject.toml
```
https://github.com/cal-itp/data-analyses/actions/runs/25136374029/job/73675657906#step:3:143

I am updating the path to see if fixes it.