### PR TITLE
Small change to trigger GH action

### DIFF
--- a/portfolio/sites/rt_operator_metrics.yml
+++ b/portfolio/sites/rt_operator_metrics.yml
@@ -1,4 +1,6 @@
 directory: ./rt_predictions/
+readme: ./rt_predictions/README.md
+title: GTFS Real-Time Operator Summary Metrics
 notebook: ./rt_predictions/operator_report.ipynb
 parts:
 - chapters:
@@ -206,5 +208,3 @@ parts:
       name: WeHo Trip Updates
   - params:
       name: Yolobus TripUpdates
-readme: ./rt_predictions/README.md
-title: GTFS Real-Time Operator Summary Metrics


### PR DESCRIPTION
swap order in yaml, otherwise `portfolio/` doesn't have any changes, the contents in GCS have changed and are updated. can see it in the charts themselves, but somehow the `index.html` is weird and wiped all the sites, even though the GCS bucket's `index.html` and local `index.html` both show the full list of sites.

Running the `deploy_index` command doesn't seem to be taking, even with the login step right before.

The PR action itself was able to trigger action, so index was refreshed before merging. When sites are run for each month, some sites will change `.yml`, but not necessarily (NTD RTPA list is pretty set, HQTA explorer is set, but GTFS ones can vary month to month).

Follow-up to #2041 