### PR TITLE
Add Reusable Notebook for Event-Based GTFS TDQ Analysis

### DIFF
--- a/transit_event_analysis/README.md
+++ b/transit_event_analysis/README.md
@@ -33,7 +33,7 @@ Identifies **bus and rail transit stops** near any venue and displays interactiv
 
 ## Refreshing the Stops Data
 
-The notebook reads from `df_dim_stops_latest.parquet` in the root directory.  
+The notebook reads from `df_dim_stops_latest.parquet` in the root directory.
 This file contains the latest transit stops data fetched from BigQuery.
 
 If you need to refresh the data (e.g. new agencies or stops have been added):

--- a/transit_event_analysis/README.md
+++ b/transit_event_analysis/README.md
@@ -1,0 +1,65 @@
+# Transit Stop Analysis Tool
+
+Identifies **bus and rail transit stops** near any venue and displays interactive maps and summary tables.
+
+---
+
+## Repo Structure
+
+```
+├── analysis.ipynb                  # Main notebook — open and run this
+├── refresh_data.ipynb              # Run this to fetch fresh data from BigQuery
+├── query.sql                       # BigQuery SQL used to fetch stops data
+├── df_dim_stops_latest.parquet     # Pre-fetched stops data
+├── utils/
+│   └── geo_functions.py            # All analysis logic (do not edit unless updating logic)
+└── README.md
+```
+
+---
+
+## How to Use
+
+1. Open **`analysis.ipynb`** in JupyterHub
+2. From the top menu click **Run → Run All Cells**
+3. A form will appear with:
+   - **Venue name** text box — type any venue (e.g. `SoFi Stadium`, `Chase Center`)
+   - **Bus buffer** slider — radius in miles for bus stop search (default: 3 mi)
+   - **Rail buffer** slider — radius in miles for rail station search (default: 10 mi)
+4. Click **▶ Run Analysis**
+5. Maps and tables will appear below
+
+---
+
+## Refreshing the Stops Data
+
+The notebook reads from `df_dim_stops_latest.parquet` in the root directory.  
+This file contains the latest transit stops data fetched from BigQuery.
+
+If you need to refresh the data (e.g. new agencies or stops have been added):
+
+1. Open **`refresh_data.ipynb`**
+2. Click **Run → Run All Cells**
+3. Wait for the query to complete — this may take a few minutes
+4. The parquet file will be automatically overwritten with the latest data
+
+> ⚠️ The refresh query bills against BigQuery — only run when fresh data is actually needed.
+
+---
+
+## Requirements
+
+```
+pandas
+numpy
+folium
+geopy
+ipywidgets
+```
+
+---
+
+## Notes
+
+- The `query.sql` file contains the full BigQuery SQL used to generate the stops dataset
+- Buffer distances can be adjusted interactively via the sliders — no code editing needed

--- a/transit_event_analysis/analysis.ipynb
+++ b/transit_event_analysis/analysis.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f3496520",
+   "metadata": {},
+   "source": [
+    "# 📍 Transit Stop Analysis Tool\n",
+    "\n",
+    "This notebook identifies **bus and rail stops** near any venue/location and displays interactive maps and summary tables.\n",
+    "\n",
+    "### How to use:\n",
+    "1. From the top menu click **Run** → **Run All Cells**\n",
+    "2. A text box and a button will appear below\n",
+    "3. Optionally adjust the buffer distances\n",
+    "4. Click **▶ Run Analysis**\n",
+    "\n",
+    "> ⚠️ Please wait for the maps and tables to fully load before entering a new venue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "42553b6c",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "afb490522ac0433b87f835462d5b8c1f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Text(value='', description='📍 Venue/Location:', layout=Layout(width='420px'), placeholder=\"e.g. SoFi Stadium, …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24c905d296d34de9a61381fba34d7224",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=3.0, description='🚌 Bus buffer (mi):', layout=Layout(width='420px'), max=10.0, min=0.5, step…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a90b8e4aa3b40a394e3bb36abea2a48",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=10.0, description='🚆 Rail buffer (mi):', layout=Layout(width='420px'), max=30.0, min=1.0, st…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f75944ce72954953a9a94f5f98cd4142",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(button_style='success', description='▶ Run Analysis', layout=Layout(margin='10px 0 0 0', width='160px')…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "133a65975dd54841ac48679b548101c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, '.')\n",
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display, clear_output\n",
+    "from utils.geo_functions import run_analysis\n",
+    "\n",
+    "# --- Input widgets ---\n",
+    "venue_input = widgets.Text(\n",
+    "    value='',\n",
+    "    placeholder=\"e.g. SoFi Stadium, Levi's Stadium\",\n",
+    "    description='📍 Venue/Location:',\n",
+    "    layout=widgets.Layout(width='420px')\n",
+    ")\n",
+    "\n",
+    "bus_buffer_input = widgets.FloatSlider(\n",
+    "    value=3,\n",
+    "    min=0.5, max=10, step=0.5,\n",
+    "    description='🚌 Bus buffer (mi):',\n",
+    "    style={'description_width': 'initial'},\n",
+    "    layout=widgets.Layout(width='420px')\n",
+    ")\n",
+    "\n",
+    "rail_buffer_input = widgets.FloatSlider(\n",
+    "    value=10,\n",
+    "    min=1, max=30, step=1,\n",
+    "    description='🚆 Rail buffer (mi):',\n",
+    "    style={'description_width': 'initial'},\n",
+    "    layout=widgets.Layout(width='420px')\n",
+    ")\n",
+    "\n",
+    "run_button = widgets.Button(\n",
+    "    description='▶ Run Analysis',\n",
+    "    button_style='success',\n",
+    "    layout=widgets.Layout(width='160px', margin='10px 0 0 0')\n",
+    ")\n",
+    "\n",
+    "output_area = widgets.Output()\n",
+    "\n",
+    "# --- Button logic ---\n",
+    "def on_run_clicked(b):\n",
+    "    venue = venue_input.value.strip()\n",
+    "    with output_area:\n",
+    "        clear_output(wait=True)\n",
+    "        if not venue:\n",
+    "            print('⚠️  Please enter a venue name first.')\n",
+    "            return\n",
+    "        run_analysis(\n",
+    "            venue_name=venue,\n",
+    "            bus_buffer_miles=bus_buffer_input.value,\n",
+    "            rail_buffer_miles=rail_buffer_input.value\n",
+    "        )\n",
+    "\n",
+    "run_button.on_click(on_run_clicked)\n",
+    "\n",
+    "# --- Display ---\n",
+    "display(\n",
+    "    venue_input,\n",
+    "    bus_buffer_input,\n",
+    "    rail_buffer_input,\n",
+    "    run_button,\n",
+    "    output_area\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e58a1b9f-ed06-4783-af88-e062db53bdfc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/transit_event_analysis/query.sql
+++ b/transit_event_analysis/query.sql
@@ -1,0 +1,102 @@
+WITH stops AS (
+    SELECT
+        base64_url,
+        stop_id,
+        stop_name,
+        stop_lat,
+        stop_lon,
+        location_type,
+        wheelchair_boarding,
+        on_state_highway_network
+    FROM `cal-itp-data-infra.mart_gtfs_schedule_latest.dim_stops_latest`
+),
+
+stop_routes AS (
+    SELECT DISTINCT
+        st.base64_url,
+        st.stop_id,
+        r.route_type
+    FROM `cal-itp-data-infra.mart_gtfs_schedule_latest.dim_stop_times_latest` st
+
+    JOIN `cal-itp-data-infra.mart_gtfs_schedule_latest.dim_trips_latest` t
+        USING (base64_url, trip_id)
+
+    JOIN `cal-itp-data-infra.mart_gtfs_schedule_latest.dim_routes_latest` r
+        USING (base64_url, route_id)
+),
+
+stops_with_mode AS (
+    SELECT
+        s.*,
+        sr.route_type,
+
+        CASE
+            WHEN sr.route_type = '3'
+                THEN 'Bus'
+
+            WHEN sr.route_type IN (
+                '0',   -- Tram
+                '1',   -- Subway
+                '2',   -- Rail
+                '5',   -- Cable Tram
+                '6',   -- Gondola
+                '7',   -- Funicular
+                '11',  -- Trolleybus
+                '12'   -- Monorail
+            )
+                THEN 'Rail'
+
+            ELSE 'Other'
+
+        END AS mode_type
+
+    FROM stops s
+
+    LEFT JOIN stop_routes sr
+        USING(base64_url, stop_id)
+),
+
+datasets AS (
+    SELECT
+        dg.key AS gtfs_dataset_key,
+        swm.*
+
+    FROM stops_with_mode swm
+
+    JOIN
+    `cal-itp-data-infra.mart_transit_database.dim_gtfs_datasets` dg
+        USING(base64_url)
+
+    WHERE dg._is_current = TRUE
+),
+
+providers AS (
+    SELECT
+        d.*,
+        dp.organization_name
+
+    FROM datasets d
+
+    JOIN
+    `cal-itp-data-infra.mart_transit_database.dim_provider_gtfs_data` dp
+        ON d.gtfs_dataset_key =
+           dp.schedule_gtfs_dataset_key
+
+    WHERE
+        dp._is_current = TRUE
+        AND dp.public_customer_facing_or_regional_subfeed_fixed_route
+)
+
+SELECT DISTINCT
+    organization_name,
+    stop_id,
+    stop_name,
+    stop_lat,
+    stop_lon,
+    location_type,
+    wheelchair_boarding,
+    on_state_highway_network,
+    route_type,
+    mode_type
+
+FROM providers

--- a/transit_event_analysis/refresh_data.ipynb
+++ b/transit_event_analysis/refresh_data.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "93a0f643",
+   "metadata": {},
+   "source": [
+    "# 🔄 Refresh Stops Data\n",
+    "\n",
+    "Run this notebook **only when you need to fetch fresh transit stops data from BigQuery.**\n",
+    "\n",
+    "This will overwrite the existing `df_dim_stops_latest.parquet` file in the root directory.\n",
+    "\n",
+    "> ⚠️ This query bills against BigQuery — do not run unnecessarily.\n",
+    "\n",
+    "### How to use:\n",
+    "1. From the top menu click **Run** → **Run All Cells**\n",
+    "2. Wait for the query to complete — this may take a few minutes\n",
+    "3. Once done, the updated parquet file will be ready for use in `analysis.ipynb`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10ac1e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.cloud import bigquery\n",
+    "from calitp_data_analysis.sql import get_engine\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Load the SQL query from the query file\n",
+    "query = Path('query.sql').read_text()\n",
+    "\n",
+    "# Run the BigQuery query\n",
+    "print('⏳ Fetching data from BigQuery, please wait...')\n",
+    "job_config = bigquery.QueryJobConfig(maximum_bytes_billed=2_000_000_000_000)\n",
+    "engine = get_engine()\n",
+    "df_dim_stops_latest = pd.read_sql_query(\n",
+    "    query,\n",
+    "    engine.execution_options(job_config=job_config)\n",
+    ")\n",
+    "\n",
+    "# Save as parquet in the root directory\n",
+    "df_dim_stops_latest.to_parquet('df_dim_stops_latest.parquet', index=False)\n",
+    "print(f'✅ Done! {len(df_dim_stops_latest):,} rows saved to df_dim_stops_latest.parquet')\n",
+    "df_dim_stops_latest.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/transit_event_analysis/utils/geo_functions.py
+++ b/transit_event_analysis/utils/geo_functions.py
@@ -7,14 +7,13 @@ Called by analysis.ipynb — do not run this file directly.
 
 from pathlib import Path
 
+import folium
 import numpy as np
 import pandas as pd
-import folium
-from geopy.geocoders import Nominatim
-from geopy.extra.rate_limiter import RateLimiter
 from geopy.distance import geodesic
-from IPython.display import display, HTML
-
+from geopy.extra.rate_limiter import RateLimiter
+from geopy.geocoders import Nominatim
+from IPython.display import HTML, display
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -23,40 +22,34 @@ from IPython.display import display, HTML
 DATA_DIR = Path("data")
 
 COLORS = [
-    "blue", "green", "purple", "orange", "darkred",
-    "black", "beige", "darkblue", "darkgreen", "cadetblue",
-    "darkpurple", "pink", "lightblue", "lightgreen", "gray"
+    "blue",
+    "green",
+    "purple",
+    "orange",
+    "darkred",
+    "black",
+    "beige",
+    "darkblue",
+    "darkgreen",
+    "cadetblue",
+    "darkpurple",
+    "pink",
+    "lightblue",
+    "lightgreen",
+    "gray",
 ]
 
 TABLE_STYLES = [
-    {
-        "selector": "table",
-        "props": [
-            ("border", "2px solid black"),
-            ("border-collapse", "collapse")
-        ]
-    },
-    {
-        "selector": "th, td",
-        "props": [
-            ("border", "1px solid gray"),
-            ("padding", "6px")
-        ]
-    },
-    {
-        "selector": "caption",
-        "props": [
-            ("caption-side", "top"),
-            ("font-size", "16px"),
-            ("font-weight", "bold")
-        ]
-    }
+    {"selector": "table", "props": [("border", "2px solid black"), ("border-collapse", "collapse")]},
+    {"selector": "th, td", "props": [("border", "1px solid gray"), ("padding", "6px")]},
+    {"selector": "caption", "props": [("caption-side", "top"), ("font-size", "16px"), ("font-weight", "bold")]},
 ]
 
 
 # ---------------------------------------------------------------------------
 # Data loading
 # ---------------------------------------------------------------------------
+
 
 def load_stops_data() -> pd.DataFrame:
     """Load the pre-fetched stops pickle from the data directory."""
@@ -66,6 +59,7 @@ def load_stops_data() -> pd.DataFrame:
 # ---------------------------------------------------------------------------
 # Geocoding & filtering
 # ---------------------------------------------------------------------------
+
 
 def geocode_venue(venue_name: str) -> tuple[float | None, float | None, str | None]:
     """
@@ -112,22 +106,13 @@ def geocode_venue(venue_name: str) -> tuple[float | None, float | None, str | No
     return location.latitude, location.longitude, corrected_name
 
 
-def filter_nearby_stops(
-    df: pd.DataFrame,
-    venue_lat: float,
-    venue_lon: float,
-    max_miles: float
-) -> pd.DataFrame:
+def filter_nearby_stops(df: pd.DataFrame, venue_lat: float, venue_lon: float, max_miles: float) -> pd.DataFrame:
     """
     Add a distance_miles column and return only stops within max_miles.
     """
     df = df.copy()
     df["distance_miles"] = df.apply(
-        lambda row: geodesic(
-            (venue_lat, venue_lon),
-            (row["stop_lat"], row["stop_lon"])
-        ).miles,
-        axis=1
+        lambda row: geodesic((venue_lat, venue_lon), (row["stop_lat"], row["stop_lon"])).miles, axis=1
     )
     return df[df["distance_miles"] <= max_miles].copy()
 
@@ -136,41 +121,27 @@ def filter_nearby_stops(
 # Bus helpers
 # ---------------------------------------------------------------------------
 
-def get_bus_stops(
-    nearby_stops: pd.DataFrame,
-    bus_buffer_miles: float
-) -> pd.DataFrame:
+
+def get_bus_stops(nearby_stops: pd.DataFrame, bus_buffer_miles: float) -> pd.DataFrame:
     """Filter nearby stops to bus stops within bus_buffer_miles."""
     return nearby_stops[
-        (nearby_stops["mode_type"] == "Bus") &
-        (nearby_stops["distance_miles"] <= bus_buffer_miles)
+        (nearby_stops["mode_type"] == "Bus") & (nearby_stops["distance_miles"] <= bus_buffer_miles)
     ].copy()
 
 
-def display_bus_table(
-    bus_stops: pd.DataFrame,
-    bus_buffer_miles: float,
-    venue_name: str
-) -> None:
+def display_bus_table(bus_stops: pd.DataFrame, bus_buffer_miles: float, venue_name: str) -> None:
     """Display a styled summary table of bus stops by agency."""
     bus_summary = (
-        bus_stops
-        .groupby("organization_name")
+        bus_stops.groupby("organization_name")
         .size()
         .reset_index(name="bus_stop_count")
         .sort_values("bus_stop_count", ascending=False)
         .reset_index(drop=True)
-        .rename(columns={
-            "organization_name": "Transit Agency",
-            "bus_stop_count": "Bus Stop Count"
-        })
+        .rename(columns={"organization_name": "Transit Agency", "bus_stop_count": "Bus Stop Count"})
     )
 
     display(
-        bus_summary.style
-        .set_caption(
-            f"Number of Bus Stops Within {bus_buffer_miles} Miles of {venue_name}"
-        )
+        bus_summary.style.set_caption(f"Number of Bus Stops Within {bus_buffer_miles} Miles of {venue_name}")
         .hide(axis="index")
         .background_gradient(subset=["Bus Stop Count"], cmap="Blues")
         .set_table_styles(TABLE_STYLES)
@@ -178,42 +149,37 @@ def display_bus_table(
 
 
 def display_bus_map(
-    bus_stops: pd.DataFrame,
-    venue_lat: float,
-    venue_lon: float,
-    bus_buffer_miles: float,
-    venue_name: str
+    bus_stops: pd.DataFrame, venue_lat: float, venue_lon: float, bus_buffer_miles: float, venue_name: str
 ) -> folium.Map:
     """Build and return a Folium map of bus stops around the venue."""
     organizations = sorted(bus_stops["organization_name"].dropna().unique())
-    org_color_map = {
-        org: COLORS[i % len(COLORS)]
-        for i, org in enumerate(organizations)
-    }
+    org_color_map = {org: COLORS[i % len(COLORS)] for i, org in enumerate(organizations)}
 
     m = folium.Map(location=[venue_lat, venue_lon], zoom_start=13)
 
     # Title
-    m.get_root().html.add_child(folium.Element(f"""
+    m.get_root().html.add_child(
+        folium.Element(
+            f"""
         <h3 align="center" style="font-size:20px">
         <b>Bus Stations Within {bus_buffer_miles} Miles of {venue_name}</b>
         </h3>
-    """))
+    """
+        )
+    )
 
     # Venue marker
-    folium.Marker(
-        [venue_lat, venue_lon],
-        tooltip=venue_name,
-        icon=folium.Icon(color="red")
-    ).add_to(m)
+    folium.Marker([venue_lat, venue_lon], tooltip=venue_name, icon=folium.Icon(color="red")).add_to(m)
 
     # Buffer circle
     folium.Circle(
         location=[venue_lat, venue_lon],
         radius=bus_buffer_miles * 1609.344,
-        color="black", weight=2, fill=False,
+        color="black",
+        weight=2,
+        fill=False,
         dash_array="8, 8",
-        tooltip=f"{bus_buffer_miles}-mile bus buffer"
+        tooltip=f"{bus_buffer_miles}-mile bus buffer",
     ).add_to(m)
 
     # Stop markers
@@ -226,7 +192,7 @@ def display_bus_map(
             fill=True,
             fill_color=org_color_map.get(org, "gray"),
             fill_opacity=0.7,
-            tooltip=f"{row['stop_name']} | {org}"
+            tooltip=f"{row['stop_name']} | {org}",
         ).add_to(m)
 
     # Legend
@@ -253,26 +219,18 @@ def display_bus_map(
 # Rail helpers
 # ---------------------------------------------------------------------------
 
-def get_rail_stops(
-    nearby_stops: pd.DataFrame,
-    rail_buffer_miles: float
-) -> pd.DataFrame:
+
+def get_rail_stops(nearby_stops: pd.DataFrame, rail_buffer_miles: float) -> pd.DataFrame:
     """Filter nearby stops to rail stops within rail_buffer_miles."""
     return nearby_stops[
-        (nearby_stops["mode_type"] == "Rail") &
-        (nearby_stops["distance_miles"] <= rail_buffer_miles)
+        (nearby_stops["mode_type"] == "Rail") & (nearby_stops["distance_miles"] <= rail_buffer_miles)
     ].copy()
 
 
-def display_rail_table(
-    rail_stops: pd.DataFrame,
-    rail_buffer_miles: float,
-    venue_name: str
-) -> None:
+def display_rail_table(rail_stops: pd.DataFrame, rail_buffer_miles: float, venue_name: str) -> None:
     """Display a styled summary table of rail stops by agency."""
     rail_summary = (
-        rail_stops
-        .groupby("organization_name")
+        rail_stops.groupby("organization_name")
         .agg(
             rail_stop_count=("stop_id", "count"),
             nearest_station=(
@@ -281,36 +239,30 @@ def display_rail_table(
                     rail_stops.loc[x.index, ["stop_name", "distance_miles"]]
                     .sort_values("distance_miles")
                     .iloc[0]["stop_name"]
-                )
+                ),
             ),
-            approx_distance_to_stadium=("distance_miles", "min")
+            approx_distance_to_stadium=("distance_miles", "min"),
         )
         .reset_index()
     )
 
-    rail_summary["approx_distance_to_stadium"] = (
-        rail_summary["approx_distance_to_stadium"]
-        .round(1)
-        .astype(str) + " mi"
-    )
+    rail_summary["approx_distance_to_stadium"] = rail_summary["approx_distance_to_stadium"].round(1).astype(str) + " mi"
 
     rail_summary = (
-        rail_summary
-        .rename(columns={
-            "organization_name": "Transit Agency",
-            "rail_stop_count": "Rail Station Count",
-            "nearest_station": "Nearest Station(s)",
-            "approx_distance_to_stadium": "Approx. Distance to Stadium"
-        })
+        rail_summary.rename(
+            columns={
+                "organization_name": "Transit Agency",
+                "rail_stop_count": "Rail Station Count",
+                "nearest_station": "Nearest Station(s)",
+                "approx_distance_to_stadium": "Approx. Distance to Stadium",
+            }
+        )
         .sort_values("Rail Station Count", ascending=False)
         .reset_index(drop=True)
     )
 
     display(
-        rail_summary.style
-        .set_caption(
-            f"Number of Rail Stations Within {rail_buffer_miles} Miles of {venue_name}"
-        )
+        rail_summary.style.set_caption(f"Number of Rail Stations Within {rail_buffer_miles} Miles of {venue_name}")
         .hide(axis="index")
         .background_gradient(subset=["Rail Station Count"], cmap="Blues")
         .set_table_styles(TABLE_STYLES)
@@ -318,42 +270,37 @@ def display_rail_table(
 
 
 def display_rail_map(
-    rail_stops: pd.DataFrame,
-    venue_lat: float,
-    venue_lon: float,
-    rail_buffer_miles: float,
-    venue_name: str
+    rail_stops: pd.DataFrame, venue_lat: float, venue_lon: float, rail_buffer_miles: float, venue_name: str
 ) -> folium.Map:
     """Build and return a Folium map of rail stops around the venue."""
     organizations = sorted(rail_stops["organization_name"].dropna().unique())
-    org_color_map = {
-        org: COLORS[i % len(COLORS)]
-        for i, org in enumerate(organizations)
-    }
+    org_color_map = {org: COLORS[i % len(COLORS)] for i, org in enumerate(organizations)}
 
     m = folium.Map(location=[venue_lat, venue_lon], zoom_start=11.3)
 
     # Title
-    m.get_root().html.add_child(folium.Element(f"""
+    m.get_root().html.add_child(
+        folium.Element(
+            f"""
         <h3 align="center" style="font-size:20px">
         <b>Rail Stations Within {rail_buffer_miles} Miles of {venue_name}</b>
         </h3>
-    """))
+    """
+        )
+    )
 
     # Venue marker
-    folium.Marker(
-        [venue_lat, venue_lon],
-        tooltip=venue_name,
-        icon=folium.Icon(color="red")
-    ).add_to(m)
+    folium.Marker([venue_lat, venue_lon], tooltip=venue_name, icon=folium.Icon(color="red")).add_to(m)
 
     # Buffer circle
     folium.Circle(
         location=[venue_lat, venue_lon],
         radius=rail_buffer_miles * 1609.344,
-        color="black", weight=2, fill=False,
+        color="black",
+        weight=2,
+        fill=False,
         dash_array="8, 8",
-        tooltip=f"{rail_buffer_miles}-mile rail buffer"
+        tooltip=f"{rail_buffer_miles}-mile rail buffer",
     ).add_to(m)
 
     # Stop markers with jitter to separate overlapping points
@@ -363,20 +310,13 @@ def display_rail_map(
         lon_jitter = np.random.uniform(-0.003, 0.003)
 
         folium.CircleMarker(
-            location=[
-                row["stop_lat"] + lat_jitter,
-                row["stop_lon"] + lon_jitter
-            ],
+            location=[row["stop_lat"] + lat_jitter, row["stop_lon"] + lon_jitter],
             radius=4,
             color=org_color_map.get(org, "#999999"),
             fill=True,
             fill_color=org_color_map.get(org, "#999999"),
             fill_opacity=0.8,
-            tooltip=(
-                f"{row['stop_name']}<br>"
-                f"{org}<br>"
-                f"{row['distance_miles']:.1f} mi"
-            )
+            tooltip=(f"{row['stop_name']}<br>" f"{org}<br>" f"{row['distance_miles']:.1f} mi"),
         ).add_to(m)
 
     # Scrollable legend
@@ -408,11 +348,8 @@ def display_rail_map(
 # Top-level orchestration — called by the notebook
 # ---------------------------------------------------------------------------
 
-def run_analysis(
-    venue_name: str,
-    bus_buffer_miles: float = 3,
-    rail_buffer_miles: float = 10
-) -> None:
+
+def run_analysis(venue_name: str, bus_buffer_miles: float = 3, rail_buffer_miles: float = 10) -> None:
     """
     Full pipeline: geocode venue, filter stops, display tables and maps.
     This is the single entry point called from analysis.ipynb.
@@ -431,36 +368,26 @@ def run_analysis(
 
     print("🔍 Filtering nearby stops...")
     print("⏳ Please wait, generating maps and tables...")
-    nearby_stops = filter_nearby_stops(
-        df, venue_lat, venue_lon, max_miles=rail_buffer_miles
-    )
+    nearby_stops = filter_nearby_stops(df, venue_lat, venue_lon, max_miles=rail_buffer_miles)
 
     # --- Bus ---
-    display(HTML(
-        '<br><br><h2 style="text-align:center;">🚌 Bus Analysis</h2><hr/>'
-    ))
+    display(HTML('<br><br><h2 style="text-align:center;">🚌 Bus Analysis</h2><hr/>'))
     bus_stops = get_bus_stops(nearby_stops, bus_buffer_miles)
     if bus_stops.empty:
         print(f"   ℹ️  No bus stops found within {bus_buffer_miles} miles of '{corrected_name}'.")
     else:
         display_bus_table(bus_stops, bus_buffer_miles, corrected_name)
         display(HTML("<br>"))
-        bus_map = display_bus_map(
-            bus_stops, venue_lat, venue_lon, bus_buffer_miles, corrected_name
-        )
+        bus_map = display_bus_map(bus_stops, venue_lat, venue_lon, bus_buffer_miles, corrected_name)
         display(bus_map)
 
     # --- Rail ---
-    display(HTML(
-        '<br><br><h2 style="text-align:center;">🚆 Rail Analysis</h2><hr/>'
-    ))
+    display(HTML('<br><br><h2 style="text-align:center;">🚆 Rail Analysis</h2><hr/>'))
     rail_stops = get_rail_stops(nearby_stops, rail_buffer_miles)
     if rail_stops.empty:
         print(f"   ℹ️  No rail stations found within {rail_buffer_miles} miles of '{corrected_name}'.")
     else:
         display_rail_table(rail_stops, rail_buffer_miles, corrected_name)
         display(HTML("<br>"))
-        rail_map = display_rail_map(
-            rail_stops, venue_lat, venue_lon, rail_buffer_miles, corrected_name
-        )
+        rail_map = display_rail_map(rail_stops, venue_lat, venue_lon, rail_buffer_miles, corrected_name)
         display(rail_map)

--- a/transit_event_analysis/utils/geo_functions.py
+++ b/transit_event_analysis/utils/geo_functions.py
@@ -1,0 +1,466 @@
+"""
+geo_functions.py
+----------------
+All logic for transit stop analysis around a venue.
+Called by analysis.ipynb — do not run this file directly.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import folium
+from geopy.geocoders import Nominatim
+from geopy.extra.rate_limiter import RateLimiter
+from geopy.distance import geodesic
+from IPython.display import display, HTML
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DATA_DIR = Path("data")
+
+COLORS = [
+    "blue", "green", "purple", "orange", "darkred",
+    "black", "beige", "darkblue", "darkgreen", "cadetblue",
+    "darkpurple", "pink", "lightblue", "lightgreen", "gray"
+]
+
+TABLE_STYLES = [
+    {
+        "selector": "table",
+        "props": [
+            ("border", "2px solid black"),
+            ("border-collapse", "collapse")
+        ]
+    },
+    {
+        "selector": "th, td",
+        "props": [
+            ("border", "1px solid gray"),
+            ("padding", "6px")
+        ]
+    },
+    {
+        "selector": "caption",
+        "props": [
+            ("caption-side", "top"),
+            ("font-size", "16px"),
+            ("font-weight", "bold")
+        ]
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_stops_data() -> pd.DataFrame:
+    """Load the pre-fetched stops pickle from the data directory."""
+    return pd.read_parquet("df_dim_stops_latest.parquet")
+
+
+# ---------------------------------------------------------------------------
+# Geocoding & filtering
+# ---------------------------------------------------------------------------
+
+def geocode_venue(venue_name: str) -> tuple[float | None, float | None, str | None]:
+    """
+    Return (latitude, longitude, corrected_name) for a venue name.
+    - corrected_name is the first part of the address returned by Nominatim,
+      reflecting the canonical/corrected venue name.
+    - If the user typed a minor typo that Nominatim resolved, corrected_name
+      will reflect the real location name to use in table/map captions.
+    - Returns (None, None, None) with a friendly printed message if geocoding fails.
+    """
+    geolocator = Nominatim(user_agent="transit_event_analysis")
+    geocode = RateLimiter(geolocator.geocode, min_delay_seconds=1)
+
+    try:
+        location = geocode(venue_name)
+    except Exception as e:
+        print(f"⚠️  Geocoding service error: {e}")
+        print("    Please check your internet connection and try again.")
+        return None, None, None
+
+    if location is None:
+        print(f"❌  Could not find a location matching '{venue_name}'.")
+        print("💡  Tips:")
+        print("      • Check your spelling")
+        print("      • Add a city or state: e.g. 'SoFi Stadium, Los Angeles'")
+        print("      • Try a nearby landmark or the street address instead")
+        print("      → Please correct the venue name and click ▶ Run Analysis again.")
+        return None, None, None
+
+    # Decide what name to show in captions based on what the user typed:
+    # - If the input contained a comma → user entered a full/partial address
+    #   → show the full corrected address returned by Nominatim
+    # - If no comma → user entered a simple venue name (e.g. "SoFi Stadium")
+    #   → show just the first segment of the corrected address (the venue name)
+    if "," in venue_name:
+        corrected_name = location.address
+    else:
+        corrected_name = location.address.split(",")[0].strip()
+
+    # Notify the user if the name differs from what they typed
+    if corrected_name.lower() != venue_name.strip().lower():
+        print(f"   ℹ️  Interpreted as: '{corrected_name}'")
+
+    return location.latitude, location.longitude, corrected_name
+
+
+def filter_nearby_stops(
+    df: pd.DataFrame,
+    venue_lat: float,
+    venue_lon: float,
+    max_miles: float
+) -> pd.DataFrame:
+    """
+    Add a distance_miles column and return only stops within max_miles.
+    """
+    df = df.copy()
+    df["distance_miles"] = df.apply(
+        lambda row: geodesic(
+            (venue_lat, venue_lon),
+            (row["stop_lat"], row["stop_lon"])
+        ).miles,
+        axis=1
+    )
+    return df[df["distance_miles"] <= max_miles].copy()
+
+
+# ---------------------------------------------------------------------------
+# Bus helpers
+# ---------------------------------------------------------------------------
+
+def get_bus_stops(
+    nearby_stops: pd.DataFrame,
+    bus_buffer_miles: float
+) -> pd.DataFrame:
+    """Filter nearby stops to bus stops within bus_buffer_miles."""
+    return nearby_stops[
+        (nearby_stops["mode_type"] == "Bus") &
+        (nearby_stops["distance_miles"] <= bus_buffer_miles)
+    ].copy()
+
+
+def display_bus_table(
+    bus_stops: pd.DataFrame,
+    bus_buffer_miles: float,
+    venue_name: str
+) -> None:
+    """Display a styled summary table of bus stops by agency."""
+    bus_summary = (
+        bus_stops
+        .groupby("organization_name")
+        .size()
+        .reset_index(name="bus_stop_count")
+        .sort_values("bus_stop_count", ascending=False)
+        .reset_index(drop=True)
+        .rename(columns={
+            "organization_name": "Transit Agency",
+            "bus_stop_count": "Bus Stop Count"
+        })
+    )
+
+    display(
+        bus_summary.style
+        .set_caption(
+            f"Number of Bus Stops Within {bus_buffer_miles} Miles of {venue_name}"
+        )
+        .hide(axis="index")
+        .background_gradient(subset=["Bus Stop Count"], cmap="Blues")
+        .set_table_styles(TABLE_STYLES)
+    )
+
+
+def display_bus_map(
+    bus_stops: pd.DataFrame,
+    venue_lat: float,
+    venue_lon: float,
+    bus_buffer_miles: float,
+    venue_name: str
+) -> folium.Map:
+    """Build and return a Folium map of bus stops around the venue."""
+    organizations = sorted(bus_stops["organization_name"].dropna().unique())
+    org_color_map = {
+        org: COLORS[i % len(COLORS)]
+        for i, org in enumerate(organizations)
+    }
+
+    m = folium.Map(location=[venue_lat, venue_lon], zoom_start=13)
+
+    # Title
+    m.get_root().html.add_child(folium.Element(f"""
+        <h3 align="center" style="font-size:20px">
+        <b>Bus Stations Within {bus_buffer_miles} Miles of {venue_name}</b>
+        </h3>
+    """))
+
+    # Venue marker
+    folium.Marker(
+        [venue_lat, venue_lon],
+        tooltip=venue_name,
+        icon=folium.Icon(color="red")
+    ).add_to(m)
+
+    # Buffer circle
+    folium.Circle(
+        location=[venue_lat, venue_lon],
+        radius=bus_buffer_miles * 1609.344,
+        color="black", weight=2, fill=False,
+        dash_array="8, 8",
+        tooltip=f"{bus_buffer_miles}-mile bus buffer"
+    ).add_to(m)
+
+    # Stop markers
+    for _, row in bus_stops.iterrows():
+        org = row["organization_name"]
+        folium.CircleMarker(
+            location=[row["stop_lat"], row["stop_lon"]],
+            radius=3,
+            color=org_color_map.get(org, "gray"),
+            fill=True,
+            fill_color=org_color_map.get(org, "gray"),
+            fill_opacity=0.7,
+            tooltip=f"{row['stop_name']} | {org}"
+        ).add_to(m)
+
+    # Legend
+    legend_html = """
+    <div style="
+        position: fixed; bottom: 50px; left: 50px; z-index: 9999;
+        background-color: white; padding: 10px;
+        border: 2px solid grey; border-radius: 5px; font-size: 12px;
+    ">
+    <b>Organization</b><br>
+    """
+    for org, color in org_color_map.items():
+        legend_html += f"""
+        <i style="background:{color}; width:10px; height:10px;
+            display:inline-block; margin-right:5px;"></i>{org}<br>
+        """
+    legend_html += "</div>"
+    m.get_root().html.add_child(folium.Element(legend_html))
+
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Rail helpers
+# ---------------------------------------------------------------------------
+
+def get_rail_stops(
+    nearby_stops: pd.DataFrame,
+    rail_buffer_miles: float
+) -> pd.DataFrame:
+    """Filter nearby stops to rail stops within rail_buffer_miles."""
+    return nearby_stops[
+        (nearby_stops["mode_type"] == "Rail") &
+        (nearby_stops["distance_miles"] <= rail_buffer_miles)
+    ].copy()
+
+
+def display_rail_table(
+    rail_stops: pd.DataFrame,
+    rail_buffer_miles: float,
+    venue_name: str
+) -> None:
+    """Display a styled summary table of rail stops by agency."""
+    rail_summary = (
+        rail_stops
+        .groupby("organization_name")
+        .agg(
+            rail_stop_count=("stop_id", "count"),
+            nearest_station=(
+                "stop_name",
+                lambda x: (
+                    rail_stops.loc[x.index, ["stop_name", "distance_miles"]]
+                    .sort_values("distance_miles")
+                    .iloc[0]["stop_name"]
+                )
+            ),
+            approx_distance_to_stadium=("distance_miles", "min")
+        )
+        .reset_index()
+    )
+
+    rail_summary["approx_distance_to_stadium"] = (
+        rail_summary["approx_distance_to_stadium"]
+        .round(1)
+        .astype(str) + " mi"
+    )
+
+    rail_summary = (
+        rail_summary
+        .rename(columns={
+            "organization_name": "Transit Agency",
+            "rail_stop_count": "Rail Station Count",
+            "nearest_station": "Nearest Station(s)",
+            "approx_distance_to_stadium": "Approx. Distance to Stadium"
+        })
+        .sort_values("Rail Station Count", ascending=False)
+        .reset_index(drop=True)
+    )
+
+    display(
+        rail_summary.style
+        .set_caption(
+            f"Number of Rail Stations Within {rail_buffer_miles} Miles of {venue_name}"
+        )
+        .hide(axis="index")
+        .background_gradient(subset=["Rail Station Count"], cmap="Blues")
+        .set_table_styles(TABLE_STYLES)
+    )
+
+
+def display_rail_map(
+    rail_stops: pd.DataFrame,
+    venue_lat: float,
+    venue_lon: float,
+    rail_buffer_miles: float,
+    venue_name: str
+) -> folium.Map:
+    """Build and return a Folium map of rail stops around the venue."""
+    organizations = sorted(rail_stops["organization_name"].dropna().unique())
+    org_color_map = {
+        org: COLORS[i % len(COLORS)]
+        for i, org in enumerate(organizations)
+    }
+
+    m = folium.Map(location=[venue_lat, venue_lon], zoom_start=11.3)
+
+    # Title
+    m.get_root().html.add_child(folium.Element(f"""
+        <h3 align="center" style="font-size:20px">
+        <b>Rail Stations Within {rail_buffer_miles} Miles of {venue_name}</b>
+        </h3>
+    """))
+
+    # Venue marker
+    folium.Marker(
+        [venue_lat, venue_lon],
+        tooltip=venue_name,
+        icon=folium.Icon(color="red")
+    ).add_to(m)
+
+    # Buffer circle
+    folium.Circle(
+        location=[venue_lat, venue_lon],
+        radius=rail_buffer_miles * 1609.344,
+        color="black", weight=2, fill=False,
+        dash_array="8, 8",
+        tooltip=f"{rail_buffer_miles}-mile rail buffer"
+    ).add_to(m)
+
+    # Stop markers with jitter to separate overlapping points
+    for _, row in rail_stops.iterrows():
+        org = row["organization_name"]
+        lat_jitter = np.random.uniform(-0.003, 0.003)
+        lon_jitter = np.random.uniform(-0.003, 0.003)
+
+        folium.CircleMarker(
+            location=[
+                row["stop_lat"] + lat_jitter,
+                row["stop_lon"] + lon_jitter
+            ],
+            radius=4,
+            color=org_color_map.get(org, "#999999"),
+            fill=True,
+            fill_color=org_color_map.get(org, "#999999"),
+            fill_opacity=0.8,
+            tooltip=(
+                f"{row['stop_name']}<br>"
+                f"{org}<br>"
+                f"{row['distance_miles']:.1f} mi"
+            )
+        ).add_to(m)
+
+    # Scrollable legend
+    legend_html = """
+    <div style="
+        position: fixed; bottom: 50px; left: 50px;
+        width: 280px; max-height: 300px; overflow-y: scroll;
+        background-color: white; border: 2px solid gray;
+        padding: 10px; z-index: 9999; font-size: 12px;
+    ">
+    <b>Organizations</b><br>
+    """
+    for org, color in org_color_map.items():
+        legend_html += f"""
+        <div>
+        <span style="display:inline-block; width:12px; height:12px;
+            background:{color}; margin-right:6px;
+            border:1px solid black;"></span>
+        {org}
+        </div>
+        """
+    legend_html += "</div>"
+    m.get_root().html.add_child(folium.Element(legend_html))
+
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration — called by the notebook
+# ---------------------------------------------------------------------------
+
+def run_analysis(
+    venue_name: str,
+    bus_buffer_miles: float = 3,
+    rail_buffer_miles: float = 10
+) -> None:
+    """
+    Full pipeline: geocode venue, filter stops, display tables and maps.
+    This is the single entry point called from analysis.ipynb.
+    """
+    print(f"📍 Geocoding '{venue_name}'...")
+    venue_lat, venue_lon, corrected_name = geocode_venue(venue_name)
+
+    # Geocoding failed — message already printed inside geocode_venue
+    if venue_lat is None:
+        return
+
+    print(f"   → {venue_lat:.4f}, {venue_lon:.4f}")
+
+    print("📦 Loading stops data...")
+    df = load_stops_data()
+
+    print("🔍 Filtering nearby stops...")
+    print("⏳ Please wait, generating maps and tables...")
+    nearby_stops = filter_nearby_stops(
+        df, venue_lat, venue_lon, max_miles=rail_buffer_miles
+    )
+
+    # --- Bus ---
+    display(HTML(
+        '<br><br><h2 style="text-align:center;">🚌 Bus Analysis</h2><hr/>'
+    ))
+    bus_stops = get_bus_stops(nearby_stops, bus_buffer_miles)
+    if bus_stops.empty:
+        print(f"   ℹ️  No bus stops found within {bus_buffer_miles} miles of '{corrected_name}'.")
+    else:
+        display_bus_table(bus_stops, bus_buffer_miles, corrected_name)
+        display(HTML("<br>"))
+        bus_map = display_bus_map(
+            bus_stops, venue_lat, venue_lon, bus_buffer_miles, corrected_name
+        )
+        display(bus_map)
+
+    # --- Rail ---
+    display(HTML(
+        '<br><br><h2 style="text-align:center;">🚆 Rail Analysis</h2><hr/>'
+    ))
+    rail_stops = get_rail_stops(nearby_stops, rail_buffer_miles)
+    if rail_stops.empty:
+        print(f"   ℹ️  No rail stations found within {rail_buffer_miles} miles of '{corrected_name}'.")
+    else:
+        display_rail_table(rail_stops, rail_buffer_miles, corrected_name)
+        display(HTML("<br>"))
+        rail_map = display_rail_map(
+            rail_stops, venue_lat, venue_lon, rail_buffer_miles, corrected_name
+        )
+        display(rail_map)


### PR DESCRIPTION
## Summary
This PR adds a reusable analysis tool that identifies bus and rail 
transit stops near any venue and displays interactive maps and 
summary tables.

ref: #2058


## Structure
transit_event_analysis/
├── analysis.ipynb                  # Main notebook — open and run this
├── refresh_data.ipynb              # Run this to fetch fresh data from BigQuery
├── query.sql                       # BigQuery SQL used to fetch stops data
├── df_dim_stops_latest.parquet     # Pre-fetched stops data
├── utils/
│   └── geo_functions.py            # All analysis logic
└── README.md

## How to Use
1. Open analysis.ipynb in JupyterHub
2. Click Run → Run All Cells
3. Type a venue name and click ▶ Run Analysis
4. Interactive maps and summary tables will appear below

## Notes
- To refresh the data in the future, run refresh_data.ipynb
- All heavy logic lives in utils/geo_functions.py — the notebook 
  itself is minimal and user-friendly