### PR TITLE
Update `arcgis_query` to use simpler function to read in ArcGIS datasets

### DIFF
--- a/_shared_utils/shared_utils/arcgis_query.py
+++ b/_shared_utils/shared_utils/arcgis_query.py
@@ -1,164 +1,143 @@
 """
-Query beyond the 2,000 rows ESRI gives.
+Import ESRI feature layers from open data portal sources.
+Export into shared GCS folder to use across projects.
 
-https://gis.stackexchange.com/questions/266897/how-to-get-around-the-1000-objectids-limit-on-arcgis-server
+https://github.com/cagov/caldata-mdsa-caltrans-pems/blob/main/jobs/utils/geo.py
 """
 
-import urllib.parse
-from functools import cache
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import geopandas as gpd
-import numpy as np
 import pandas as pd
-import requests
-from calitp_data_analysis.gcs_geopandas import GCSGeoPandas
+from calitp_data_analysis.sql import to_snakecase
+from shared_utils import utils
 
 
-@cache
-def gcs_geopandas():
-    return GCSGeoPandas()
-
-
-def query_arcgis_feature_server(url_feature_server=""):
+def gdf_from_esri_feature_service(url):
     """
-    This function downloads all of the features available on a given ArcGIS
-    feature server. The function is written to bypass the limitations imposed
-    by the online service, such as only returning up to 1,000 or 2,000 featues
-    at a time.
+    Load an Esri Feature Service to a GeoDataFrame.
 
-    Parameters
-    ----------
-    url_feature_server : string
-        Sting containing the URL of the service API you want to query. It should
-        end in a forward slash and look something like this:
-        'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Counties/FeatureServer/0/'
-
-    Returns
-    -------
-    geodata_final : gpd.GeoDataFrame
-        This is a GeoDataFrame that contains all of the features from the
-        Feature Server. After calling this function, the `geodata_final` object
-        can be used to store the data on disk in several different formats
-        including, but not limited to, Shapefile (.shp), GeoJSON (.geojson),
-        GeoPackage (.gpkg), or PostGIS.
-        See https://geopandas.org/en/stable/docs/user_guide/io.html#writing-spatial-data
-        for more details.
-
+    Given a URL to an Esri Feature Service, download the features
+    as GeoJSON, and put them into a GeoDataFrame.
     """
-    if url_feature_server == "":
-        geodata_final = gpd.GeoDataFrame()
-        return geodata_final
+    parsed = urlparse(url)
 
-    # Fixing last character in case the URL provided didn't end in a
-    # forward slash
-    if url_feature_server[-1] != "/":
-        url_feature_server = url_feature_server + "/"
+    # Ensure we are using the query endpoint of the feature service
+    if not parsed.path.endswith("/query"):
+        parsed = parsed._replace(path=parsed.path + "/query")
 
-    # Getting the layer definitions. This contains important info such as the
-    # name of the column used as feature_ids/object_ids, among other things.
-    layer_def = requests.get(url_feature_server + "?f=pjson").json()
-
-    # The `objectIdField` is the column name used for the
-    # feature_ids/object_ids
-    fid_colname = layer_def["objectIdField"]
-
-    # The `maxRecordCount` tells us the maximum number of records this REST
-    # API service can return at once. The code below is written such that we
-    # perform multiple calls to the API, each one being short enough never to
-    # go beyond this limit.
-    record_count_max = layer_def["maxRecordCount"]
-
-    # Part of the URL that specifically requests only the object IDs
-    url_query_get_ids = f"query?f=geojson&returnIdsOnly=true" f"&where={fid_colname}+is+not+null"
-
-    url_comb = url_feature_server + url_query_get_ids
-
-    # Getting all the object IDs
-    service_request = requests.get(url_comb)
-    all_objectids = np.sort(service_request.json()["properties"]["objectIds"])
-
-    # This variable will store all the parts of the multiple queries. These
-    # parts will, at the end, be concatenated into one large GeoDataFrame.
-    geodata_parts = []
-
-    # This part of the query is fixed and never actually changes
-    url_query_fixed = "query?f=geojson&outFields=*&where="
-
-    # Identifying the largest query size allowed per request. This will dictate
-    # how many queries will need to be made. We start the search at
-    # the max record count, but that generates errors sometimes - the query
-    # might time out because it's too big. If the test query times out, we try
-    # shrink the query size until the test query goes through without
-    # generating a time-out error.
-    block_size = min(record_count_max, len(all_objectids))
-    worked = False
-    while not worked:
-        # Moving the "cursors" to their appropriate locations
-        id_start = all_objectids[0]
-        id_end = all_objectids[block_size - 1]
-
-        readable_query_string = f"{fid_colname}>={id_start} " f"and {fid_colname}<={id_end}"
-
-        url_query_variable = urllib.parse.quote(readable_query_string)
-
-        url_comb = url_feature_server + url_query_fixed + url_query_variable
-
-        url_get = requests.get(url_comb)
-
-        if "error" in url_get.json():
-            block_size = int(block_size / 2) + 1
-        else:
-            geodata_part = gcs_geopandas().read_file(url_get.text)
-
-            geodata_parts.append(geodata_part.copy())
-            worked = True
-
-    # Performing the actual query to the API multiple times. This skips the
-    # first few rows/features in the data because those rows were already
-    # captured in the query performed in the code chunk above.
-    for i in range(block_size, len(all_objectids), block_size):
-        # Moving the "cursors" to their appropriate locations and finding the
-        # limits of each block
-        sub_list = all_objectids[i : i + block_size]
-        id_start = sub_list[0]
-        id_end = sub_list[-1]
-
-        readable_query_string = f"{fid_colname}>={id_start} " f"and {fid_colname}<={id_end}"
-
-        # Encoding from readable text to URL
-        url_query_variable = urllib.parse.quote(readable_query_string)
-
-        # Constructing the full request URL
-        url_comb = url_feature_server + url_query_fixed + url_query_variable
-
-        # Actually performing the query and storing its results in a
-        # GeoDataFrame
-        geodata_part = gcs_geopandas().read_file(url_comb, driver="GeoJSON")
-
-        # Appending the result to `geodata_parts`
-        if geodata_part.shape[0] > 0:
-            geodata_parts.append(geodata_part)
-
-    # Concatenating all of the query parts into one large GeoDataFrame
-    geodata_final = pd.concat(geodata_parts, ignore_index=True).sort_values(by=fid_colname).reset_index(drop=True)
-
-    # Checking if any object ID is missing
-    ids_queried = set(geodata_final[fid_colname])
-    for i, this_id in enumerate(all_objectids):
-        if this_id not in ids_queried:
-            print("WARNING! The following ObjectID is missing from the final " f"GeoDataFrame: ObjectID={this_id}")
-            pass
-
-    # Checking if any object ID is included twice
-    geodata_temp = geodata_final[[fid_colname]].copy()
-    geodata_temp["temp"] = 1
-    geodata_temp = geodata_temp.groupby(fid_colname).agg({"temp": "sum"}).reset_index()
-    geodata_temp = geodata_temp.loc[geodata_temp["temp"] > 1].copy()
-    for i, this_id in enumerate(geodata_temp[fid_colname].values):
-        n_times = geodata_temp["temp"].values[i]
-        print(
-            "WARNING! The following ObjectID is included multiple times in"
-            f"the final GeoDataFrame: ObjectID={this_id}\tOccurrences={n_times}"
+    # Keep grabbing data using the resultOffset until there is no more left
+    offset = 0
+    gdfs = []
+    while True:
+        queries = dict(parse_qsl(parsed.query))
+        queries.update(
+            {
+                "where": "1=1",  # Ensure all rows
+                "f": "geojson",  # Ensure GeoJSON
+                "outFields": "*",  # Ensure all columns
+                "resultOffset": str(offset),  # offset the start
+                "returnGeometry": "true",  # Yes we want geometries
+            }
         )
+        offset_url = urlunparse(parsed._replace(query=urlencode(queries)))
 
-    return geodata_final
+        gdf = gpd.read_file(offset_url, driver="GeoJSON")
+        if len(gdf) == 0:
+            break
+
+        gdfs.append(gdf)
+        offset += len(gdf)
+    return pd.concat(gdfs).reset_index(drop=True)
+
+
+SHARED_GCS = "gs://calitp-analytics-data/data-analyses/shared_data/"
+
+COUNTY_POLYGONS_URL = (
+    "https://services1.arcgis.com/jUJYIo9tSA7EHvfZ/"
+    "arcgis/rest/services/California_County_Boundaries/FeatureServer/0/query"
+)
+
+LEGISLATIVE_BASE = "https://services3.arcgis.com/fdvHcZVgB2QSRNkL/" "arcgis/rest/services/Legislative/FeatureServer/"
+
+LEGISLATIVE_DICT = {
+    "ca_assembly_districts": f"{LEGISLATIVE_BASE}0/query/",
+    "ca_senate_districts": f"{LEGISLATIVE_BASE}1/query/",
+    "ca_congressional_districts": f"{LEGISLATIVE_BASE}2/query/",
+}
+
+CALTRANS_BASE = "https://caltrans-gis.dot.ca.gov/arcgis/rest/services/CHhighway/"
+SHN_LINES_URL = f"{CALTRANS_BASE}SHN_Lines/FeatureServer/0/query/"
+SHN_POSTMILES_URL = f"{CALTRANS_BASE}SHN_Postmiles_Tenth/FeatureServer/0/query/"
+CRS_FUNCTIONAL_CLASSICIATION_URL = f"{CALTRANS_BASE}CRS_Functional_Classification/FeatureServer/0/query/"
+CALTRANS_DISTRICTS_URL = (
+    "https://caltrans-gis.dot.ca.gov/arcgis/rest/services/" "CHboundary/District_Tiger_Lines/FeatureServer/0/query/"
+)
+
+ROADS_DICT = {
+    "state_highway_network_raw": SHN_LINES_URL,
+    "state_highway_network_postmiles": SHN_POSTMILES_URL,
+}
+
+
+# legislative district combines senate and assembly
+def combine_legislative_districts(assembly_districts_url: str, senate_districts_url: str) -> gpd.GeoDataFrame:
+    """
+    Create a combined assembly district and senate districts
+    gdf.
+    """
+    assembly_districts = gdf_from_esri_feature_service(assembly_districts_url)
+    senate_districts = gdf_from_esri_feature_service(senate_districts_url)
+
+    gdf = pd.concat(
+        [
+            assembly_districts[["AssemblyDistrictLabel", "geometry"]].rename(
+                columns={"AssemblyDistrictLabel": "legislative_district"}
+            ),
+            senate_districts[["SenateDistrictLabel", "geometry"]].rename(
+                columns={"SenateDistrictLabel": "legislative_district"}
+            ),
+        ],
+        axis=0,
+        ignore_index=True,
+    )
+
+    return gdf
+
+
+def exclude_columns(gdf: gpd.GeoDataFrame, list_of_cols: list = ["Shape__Length", "Shape__Area"]) -> gpd.GeoDataFrame:
+    """
+    Drop a couple of columns that tend to show up for ESRI.
+    """
+    for c in list_of_cols:
+        if c in gdf.columns:
+            gdf = gdf.drop(columns=c)
+
+    return gdf
+
+
+if __name__ == "__main__":
+
+    esri_datasets = {
+        "ca_county": COUNTY_POLYGONS_URL,
+        "caltrans_district": CALTRANS_DISTRICTS_URL,
+        "ca_congressional_districts": LEGISLATIVE_DICT["ca_congressional_districts"],
+        **ROADS_DICT,
+    }
+
+    for dataset_name, url in esri_datasets.items():
+        print(dataset_name)
+        gdf = gdf_from_esri_feature_service(url)
+        gdf = gdf.pipe(to_snakecase).pipe(exclude_columns)
+
+        print(gdf.crs)
+        print(gdf.shape)
+        utils.geoparquet_gcs_export(gdf, SHARED_GCS, dataset_name)
+        del gdf
+
+    legislative_districts_gdf = combine_legislative_districts(
+        LEGISLATIVE_DICT["ca_assembly_districts"],
+        LEGISLATIVE_DICT["ca_senate_districts"],
+    )
+
+    utils.geoparquet_gcs_export(legislative_districts_gdf, SHARED_GCS, "legislative_districts")

--- a/_shared_utils/shared_utils/arcgis_query.py
+++ b/_shared_utils/shared_utils/arcgis_query.py
@@ -123,8 +123,8 @@ if __name__ == "__main__":
         "caltrans_district": CALTRANS_DISTRICTS_URL,
         "ca_congressional_districts": LEGISLATIVE_DICT["ca_congressional_districts"],
         **ROADS_DICT,
+        "public_road_functional_classification": CRS_FUNCTIONAL_CLASSICIATION_URL,
     }
-
     for dataset_name, url in esri_datasets.items():
         print(dataset_name)
         gdf = gdf_from_esri_feature_service(url)

--- a/_shared_utils/shared_utils/arcgis_query.py
+++ b/_shared_utils/shared_utils/arcgis_query.py
@@ -9,8 +9,8 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import geopandas as gpd
 import pandas as pd
+from calitp_data_analysis import utils
 from calitp_data_analysis.sql import to_snakecase
-from shared_utils import utils
 
 
 def gdf_from_esri_feature_service(url):

--- a/_shared_utils/shared_utils/shared_data.py
+++ b/_shared_utils/shared_utils/shared_data.py
@@ -12,7 +12,7 @@ from calitp_data_analysis import geography_utils, utils
 from calitp_data_analysis.gcs_geopandas import GCSGeoPandas
 from calitp_data_analysis.gcs_pandas import GCSPandas
 from calitp_data_analysis.sql import to_snakecase
-from shared_utils import arcgis_query, catalog_utils
+from shared_utils import catalog_utils
 
 
 @cache
@@ -27,53 +27,6 @@ def gcs_geopandas():
 
 GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/shared_data/"
 COMPILED_CACHED_GCS = "gs://calitp-analytics-data/data-analyses/rt_delay/compiled_cached_views/"
-
-
-def make_county_centroids():
-    """
-    Find a county's centroids from county polygons.
-    """
-    URL = "https://opendata.arcgis.com/datasets/" "8713ced9b78a4abb97dc130a691a8695_0.geojson"
-
-    gdf = gcs_geopandas().read_file(URL).to_crs(geography_utils.CA_NAD83Albers_ft)
-    gdf.columns = gdf.columns.str.lower()
-
-    gdf = (
-        gdf.assign(area=gdf.geometry.area)
-        # Sort in descending order
-        # Ex: LA County, where there are separate polygons for Channel Islands
-        # centroid should be based on where the biggest polygon is
-        .sort_values(["county_name", "area"], ascending=[True, False])
-        .drop_duplicates(subset="county_name")
-        .reset_index()
-        .to_crs(geography_utils.WGS84)
-    )
-
-    # Grab the centroid
-    gdf = gdf.assign(
-        longitude=(gdf.geometry.centroid.x).round(2),
-        latitude=(gdf.geometry.centroid.y).round(2),
-    )
-
-    # Make the centroid into a list with [latitude, longitude] format
-    gdf = gdf.assign(
-        centroid=gdf.apply(lambda x: list([x.latitude, x.longitude]), axis=1),
-        zoom=11,
-    )[["county_name", "centroid", "zoom"]]
-
-    # Create statewide zoom parameters
-    ca_row = {"county_name": "CA", "centroid": [35.8, -119.4], "zoom": 6}
-
-    # Do transpose to get it to display match how columns are displayed
-    ca_row2 = pd.DataFrame.from_dict(ca_row, orient="index").T
-    gdf2 = gdf.append(ca_row2).reset_index(drop=True)
-
-    # Save as parquet, because lat/lon held in list, not point geometry anymore
-    gcs_geopandas().geo_data_frame_to_parquet(gdf2, f"{GCS_FILE_PATH}ca_county_centroids.parquet")
-
-    print("County centroids exported to GCS")
-
-    return
 
 
 def make_clean_state_highway_network():
@@ -103,22 +56,6 @@ def make_clean_state_highway_network():
 
     # Export to GCS
     utils.geoparquet_gcs_export(gdf2, GCS_FILE_PATH, "state_highway_network")
-
-
-def export_shn_postmiles():
-    """
-    Create State Highway Network postmiles dataset.
-    These are points....maybe we can somehow create line segments?
-    """
-    URL = "https://caltrans-gis.dot.ca.gov/arcgis/rest/services/" "CHhighway/SHN_Postmiles_Tenth/" "FeatureServer/0/"
-
-    gdf = arcgis_query.query_arcgis_feature_server(URL)
-
-    gdf2 = to_snakecase(gdf).drop(columns="objectid")
-
-    utils.geoparquet_gcs_export(gdf2, GCS_FILE_PATH, "state_highway_network_postmiles")
-
-    return
 
 
 def scaled_proportion(x: float, odometer_min: float, odometer_max: float) -> float:
@@ -281,33 +218,6 @@ def create_postmile_segments(
     return
 
 
-def export_combined_legislative_districts() -> gpd.GeoDataFrame:
-    """
-    Create a combined assembly district and senate districts
-    gdf.
-    """
-    BASE_URL = "https://services3.arcgis.com/fdvHcZVgB2QSRNkL/" "arcgis/rest/services/Legislative/FeatureServer/"
-    SUFFIX = "query?outFields=*&where=1%3D1&f=geojson"
-
-    ASSEMBLY_DISTRICTS = f"{BASE_URL}0/{SUFFIX}"
-    SENATE_DISTRICTS = f"{BASE_URL}1/{SUFFIX}"
-
-    ad = gcs_geopandas().read_file(ASSEMBLY_DISTRICTS)
-    sd = gcs_geopandas().read_file(SENATE_DISTRICTS)
-
-    gdf = pd.concat(
-        [
-            ad[["AssemblyDistrictLabel", "geometry"]].rename(columns={"AssemblyDistrictLabel": "legislative_district"}),
-            sd[["SenateDistrictLabel", "geometry"]].rename(columns={"SenateDistrictLabel": "legislative_district"}),
-        ],
-        axis=0,
-        ignore_index=True,
-    )
-
-    utils.geoparquet_gcs_export(gdf, GCS_FILE_PATH, "legislative_districts")
-    return
-
-
 def sjoin_shapes_legislative_districts(analysis_date: str) -> pd.DataFrame:
     """
     Grab shapes for a single day and do a spatial join
@@ -424,12 +334,8 @@ if __name__ == "__main__":
     SHN_HWY_BUFFER_FEET = 50
     PARALLEL_HWY_BUFFER_FEET = geography_utils.FEET_PER_MI * 0.5
 
-    # CA counties
-    make_county_centroids()
-
     # State Highway Network
     make_clean_state_highway_network()
-    export_shn_postmiles()
     dissolve_shn_district()
     buffer_shn(SHN_HWY_BUFFER_FEET, "shn_dissolved_by_ct_district_route")
 
@@ -437,6 +343,4 @@ if __name__ == "__main__":
     create_postmile_segments(["district", "county", "routetype", "route", "direction", "routes", "pmrouteid"])
 
     # Legislative Districts
-    export_combined_legislative_districts()
-
     make_transit_operators_to_legislative_district_crosswalk(rt_dates.y2024_dates + rt_dates.y2023_dates)


### PR DESCRIPTION
* Use CalData function that is much simpler for converting the ArcGIS url into a gdf
* Add `public_road_functional_classification` dataset here using that function
* Go through and make sure all existing Geoportal type sites work (assembly districts/senate districts, state highway network lines and postmiles)
   * some slight changes in rows for SHN, but this is because we're updating from Aug 2024 datasets (in GCS) to Jul 2025 (AGOL metadata notes about latest date the data reflects)
* Leave the dissolving and other transformations, joins with other data sources in `shared_data.py` 
* Remove `ca_county_centroids`