### PR TITLE
remove `rt_predictions` from pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,87 +5,6 @@
 # If you are using `Prototype Image - 2026.3.18, Python 3.11` in JupyterHub, you need to add `uv run ` to the beginning of the commands in order to work.
 # For example: Instead of `python portfolio/portfolio.py clean $(site)`, run `uv run python portfolio/portfolio.py clean $(site)`.
 
-# Build and Deploy Production Portfolio Site with:
-# make build_production_portfolio_site site='MY_SITE_IDENTIFIER'
-build_production_portfolio_site:
-	uv sync --all-groups
-	uv run python portfolio/portfolio.py clean $(site)
-	uv run python portfolio/portfolio.py build $(site)
-	gcloud auth login --login-config=iac/login.json && gcloud config set project cal-itp-data-infra
-	uv run python portfolio/portfolio.py build $(site) --no-execute-papermill --deploy --target production
-	git add portfolio/sites/$(site).yml
-	#make build_production_portfolio_index
-
-# Build and Deploy Staging Portfolio Site with:
-# make build_staging_portfolio_site site='MY_SITE_IDENTIFIER'
-build_staging_portfolio_site:
-	uv sync --all-groups
-	uv run python portfolio/portfolio.py clean $(site)
-	gcloud auth login --login-config=iac/login.json
-	uv run python portfolio/portfolio.py build $(site)
-	uv run python portfolio/portfolio.py build $(site) --no-execute-papermill --deploy --target staging
-	#make build_staging_portfolio_index
-
-# Build and Deploy Production Portfolio Index page with:
-build_production_portfolio_index:
-	uv run python portfolio/portfolio.py index --deploy --prod
-
-# Build and Deploy Staging Portfolio Index page (including test portfolios) with:
-build_staging_portfolio_index:
-	uv run python portfolio/portfolio.py index --deploy --no-prod
-
-# Build locally the Portfolio Site without deploying with:
-# make test_build_portfolio_site site='MY_SITE_IDENTIFIER'
-test_build_portfolio_site:
-	uv run python portfolio/portfolio.py clean $(site)
-	#gcloud auth login --login-config=iac/login.json
-	uv run python portfolio/portfolio.py build $(site)
-
-# Delete Local Site folder with:
-# make clean_portfolio_site site='MY_SITE_IDENTIFIER'
-clean_portfolio_site:
-	uv run python portfolio/portfolio.py clean $(site)
-
-# Delete Local Site folder and Remove Portfolio site with:
-# make remove_portfolio_site site='MY_SITE_IDENTIFIER'
-remove_portfolio_site:
-	uv run python portfolio/portfolio.py clean $(site)
-	git rm portfolio/sites/$(site).yml
-
-build_ntd_report:
-	$(eval export site = ntd_monthly_ridership)
-	cd ntd/monthly_ridership_report/ && python deploy_portfolio_yaml.py && cd ..
-	make build_production_portfolio_site
-
-build_ntd_annual_report:
-	$(eval export site = ntd_annual_ridership_report)
-	cd ntd/annual_ridership_report/ && python deploy_portfolio_yaml.py && cd ..
-	make build_production_portfolio_site
-
-build_new_transit_metrics_report:
-	$(eval export site = new_transit_metrics)
-	cd ntd/new_transit_metrics/ && python deploy_portfolio_yaml.py && cd ..
-	make build_production_portfolio_site
-
-build_gtfs_digest:
-	$(eval export site = gtfs_digest)
-	cd gtfs_digest/ && make digest_report && cd ..
-	make build_production_portfolio_site
-
-build_district_digest:
-	$(eval export site = district_digest)
-	cd gtfs_digest/ && uv run python deploy_district_yaml.py district && cd ..
-	make build_production_portfolio_site
-
-build_legislative_district_digest:
-	$(eval export site = legislative_district_digest)
-	cd gtfs_digest/ && uv run python deploy_district_yaml.py legislative_district && cd ..
-	make build_production_portfolio_site
-
-build_fund_split:
-	$(eval export site = sb125_fund_split_analysis)
-	make build_production_portfolio_site
-
 add_precommit:
 	uv run pre-commit install
 	#pre-commit run --all-files
@@ -97,6 +16,3 @@ install_env:
 	# "_shared_utils", "rt_segment_speeds", and "rt_delay" are already installed when `uv sync` runs.
 	uv sync --all-groups
 	make add_precommit
-
-install_portfolio:
-	uv sync --group portfolio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ members = [
     "portfolio",
     "rt_segment_speeds",
     "rt_delay",
-    "rt_predictions",
     "thruway_intercity_bus",
     "sb125_analyses",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,6 @@ members = [
     "calitp-portfolio",
     "portfolio",
     "rt-analysis",
-    "rt-predictions",
     "sb125-analyses",
     "segment-speed-utils",
     "shared-utils",
@@ -3396,25 +3395,6 @@ wheels = [
 name = "rt-analysis"
 version = "0.4.2"
 source = { editable = "rt_delay" }
-
-[[package]]
-name = "rt-predictions"
-version = "0.1.0"
-source = { virtual = "rt_predictions" }
-dependencies = [
-    { name = "calitp-data-analysis" },
-    { name = "shared-utils" },
-    { name = "vegafusion" },
-    { name = "vl-convert-python" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "calitp-data-analysis", editable = "calitp-data-analysis" },
-    { name = "shared-utils", editable = "_shared_utils" },
-    { name = "vegafusion", extras = ["embed"], specifier = ">=1.5.0" },
-    { name = "vl-convert-python", specifier = ">=1.6.0" },
-]
 
 [[package]]
 name = "rtree"


### PR DESCRIPTION
* Remove `rt_predictions` from `pypyproject.toml` and rerun `uv sync --all-groups` to check in `uv.lock`
* Clean up `Makefile` and remove outdated commands for portfolio -> refer to `calitp-portfolio/README.md` for new commands
* Follow-up to #2141